### PR TITLE
Improve load example with diferent data types

### DIFF
--- a/examples/playground/example-function/def.yml
+++ b/examples/playground/example-function/def.yml
@@ -18,3 +18,35 @@ cities:
 #@ end
 
 yaml_key: #@ some_yaml()
+
+#! functions with scalar values must be written
+#! in Starlark
+
+#@ def some_scalar(): return "hello world"
+
+scalar_key: #@ some_scalar()
+
+---
+#! If the YAML fragment inside the function
+#! is not compatible with the surrounding context
+#! (here an array in a hash context), functions
+#! can be declared in separate document fragments
+#! to reset the context.
+
+#! To avoid splitting the current document,
+#! definitions can happen in a separate file or
+#! at the top of the document.
+
+#@ def some_yaml_array():
+- hello: world
+#@ end
+---
+
+yaml_array_key: #@ some_yaml_array()
+
+#! Function calls can define complete documents
+#! at the top level.
+
+--- #@ some_scalar()
+--- #@ some_yaml()
+--- #@ some_yaml_array()


### PR DESCRIPTION
Following issue #19, I improved the playground example to show various things:

- setting document values
- working with arrays as well as maps when defining functions using the document separator `---`
- working with scalars with starlark functions

I would have loved to demonstrate YAML indexing too but I couldn't, so I created issue #20