### PR TITLE
add --output-type yaml/json/pos to control combined output

### DIFF
--- a/pkg/filepos/position.go
+++ b/pkg/filepos/position.go
@@ -37,14 +37,18 @@ func (p *Position) Line() int {
 }
 
 func (p *Position) AsString() string {
+	return "line " + p.AsCompactString()
+}
+
+func (p *Position) AsCompactString() string {
 	filePrefix := p.file
 	if len(filePrefix) > 0 {
 		filePrefix += ":"
 	}
 	if p.IsKnown() {
-		return fmt.Sprintf("line %s%d", filePrefix, p.Line())
+		return fmt.Sprintf("%s%d", filePrefix, p.Line())
 	}
-	return fmt.Sprintf("line %s?", filePrefix)
+	return fmt.Sprintf("%s?", filePrefix)
 }
 
 func (p *Position) AsIntString() string {

--- a/pkg/yamlmeta/convert.go
+++ b/pkg/yamlmeta/convert.go
@@ -10,6 +10,7 @@ import (
 
 type InterfaceConvertOpts struct {
 	OrderedMap bool
+	Plain      bool
 }
 
 func NewASTFromInterface(val interface{}) interface{} {
@@ -77,6 +78,31 @@ func convertToLowYAML(val interface{}, opts InterfaceConvertOpts) interface{} {
 			return result
 		}
 		return val
+
+	default:
+		return val
+	}
+}
+
+func convertToLowGo(val interface{}) interface{} {
+	switch typedVal := val.(type) {
+	case yaml.MapSlice:
+		result := map[string]interface{}{}
+		for _, item := range typedVal {
+			if keyStr, ok := item.Key.(string); ok {
+				result[keyStr] = convertToLowGo(item.Value)
+			} else {
+				panic(fmt.Sprintf("Unsupport map key %T", item.Key))
+			}
+		}
+		return result
+
+	case []interface{}:
+		result := []interface{}{}
+		for _, item := range typedVal {
+			result = append(result, convertToLowGo(item))
+		}
+		return result
 
 	default:
 		return val

--- a/pkg/yamlmeta/document.go
+++ b/pkg/yamlmeta/document.go
@@ -15,5 +15,9 @@ func (d *Document) IsEmpty() bool {
 }
 
 func (d *Document) AsInterface(opts InterfaceConvertOpts) interface{} {
-	return convertToLowYAML(d.Value, opts)
+	result := convertToLowYAML(d.Value, opts)
+	if opts.Plain {
+		result = convertToLowGo(result)
+	}
+	return result
 }

--- a/pkg/yamlmeta/file_position_printer.go
+++ b/pkg/yamlmeta/file_position_printer.go
@@ -1,0 +1,124 @@
+package yamlmeta
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/k14s/ytt/pkg/filepos"
+	"github.com/k14s/ytt/pkg/yamlmeta/internal/yaml.v2"
+)
+
+type FilePositionPrinter struct {
+	writer   io.Writer
+	opts     FilePositionPrinterOpts
+	locWidth int
+}
+
+type FilePositionPrinterOpts struct{}
+
+func NewFilePositionPrinter(writer io.Writer) *FilePositionPrinter {
+	return &FilePositionPrinter{writer, FilePositionPrinterOpts{}, 0}
+}
+
+func NewFilePositionPrinterWithOpts(writer io.Writer, opts FilePositionPrinterOpts) *FilePositionPrinter {
+	return &FilePositionPrinter{writer, opts, 0}
+}
+
+func (p *FilePositionPrinter) Print(val interface{}) {
+	fmt.Fprintf(p.writer, "%s", p.PrintStr(val))
+}
+
+func (p *FilePositionPrinter) PrintStr(val interface{}) string {
+	buf := new(bytes.Buffer)
+	p.print(val, "", buf)
+	return buf.String()
+}
+
+func (p *FilePositionPrinter) print(val interface{}, indent string, writer io.Writer) {
+	const indentLvl = "  "
+
+	switch typedVal := val.(type) {
+	case *DocumentSet:
+		fmt.Fprintf(writer, "%s%s[docset]\n", p.lineStr(typedVal.Position), indent)
+
+		for _, item := range typedVal.Items {
+			p.print(item, indent+indentLvl, writer)
+		}
+
+	case *Document:
+		fmt.Fprintf(writer, "%s%s[doc]\n", p.lineStr(typedVal.Position), indent)
+		p.print(typedVal.Value, indent+indentLvl, writer)
+
+	case *Map:
+		// fmt.Fprintf(writer, "%s%smap\n", indent, p.lineStr(typedVal.Position))
+
+		for _, item := range typedVal.Items {
+			valStr, isLeaf := p.leafValue(item.Value)
+			if !isLeaf || strings.Contains(valStr, "\n") {
+				fmt.Fprintf(writer, "%s%s%s:\n", p.lineStr(item.Position), indent, item.Key)
+				p.print(item.Value, indent+indentLvl, writer)
+			} else {
+				fmt.Fprintf(writer, "%s%s%s: %s\n", p.lineStr(item.Position), indent, item.Key, valStr)
+			}
+		}
+
+	case *MapItem:
+		fmt.Fprintf(writer, "%s%s%s:\n", p.lineStr(typedVal.Position), indent, typedVal.Key)
+		p.print(typedVal.Value, indent+indentLvl, writer)
+
+	case *Array:
+		// fmt.Fprintf(writer, "%s%sarray\n", indent, p.lineStr(typedVal.Position))
+
+		for i, item := range typedVal.Items {
+			valStr, isLeaf := p.leafValue(item.Value)
+			if !isLeaf || strings.Contains(valStr, "\n") {
+				fmt.Fprintf(writer, "%s%s[%d]\n", p.lineStr(item.Position), indent, i)
+				p.print(item.Value, indent+indentLvl, writer)
+			} else {
+				fmt.Fprintf(writer, "%s%s[%d] %s\n", p.lineStr(item.Position), indent, i, valStr)
+			}
+		}
+
+	case *ArrayItem:
+		fmt.Fprintf(writer, "%s%s[?]\n", p.lineStr(typedVal.Position), indent)
+		p.print(typedVal.Value, indent+indentLvl, writer)
+
+	default:
+		valStr, isLeaf := p.leafValue(val)
+		if !isLeaf {
+			panic(fmt.Sprintf("Expected leaf, but was %T", typedVal))
+		}
+		fmt.Fprintf(writer, p.padLine("")+fmt.Sprintf("%s%s\n", indent, valStr))
+	}
+}
+
+func (p *FilePositionPrinter) leafValue(val interface{}) (string, bool) {
+	switch typedVal := val.(type) {
+	case *DocumentSet, *Document, *Map, *MapItem, *Array, *ArrayItem:
+		return "", false
+
+	default:
+		typedValBs, err := yaml.Marshal(typedVal)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to serialize %T", typedVal))
+		}
+		return string(typedValBs[:len(typedValBs)-1]), true // strip newline at the end
+	}
+}
+
+func (p *FilePositionPrinter) lineStr(pos *filepos.Position) string {
+	if pos.IsKnown() {
+		return p.padLine(pos.AsCompactString())
+	}
+	return ""
+}
+
+func (p *FilePositionPrinter) padLine(str string) string {
+	width := len(str)
+	if width > p.locWidth {
+		p.locWidth = width + 10
+	}
+	return fmt.Sprintf(fmt.Sprintf("%%%ds | ", p.locWidth), str)
+}

--- a/pkg/yamlmeta/printers.go
+++ b/pkg/yamlmeta/printers.go
@@ -1,0 +1,69 @@
+package yamlmeta
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/k14s/ytt/pkg/yamlmeta/internal/yaml.v2"
+)
+
+type DocumentPrinter interface {
+	Print(*Document) error
+}
+
+type YAMLPrinter struct {
+	buf         io.Writer
+	writtenOnce bool
+}
+
+var _ DocumentPrinter = &YAMLPrinter{}
+
+func NewYAMLPrinter(writer io.Writer) *YAMLPrinter {
+	return &YAMLPrinter{writer, false}
+}
+
+func (p *YAMLPrinter) Print(item *Document) error {
+	if p.writtenOnce {
+		p.buf.Write([]byte("---\n")) // TODO use encoder?
+	} else {
+		p.writtenOnce = true
+	}
+
+	bs, err := yaml.Marshal(item.AsInterface(InterfaceConvertOpts{OrderedMap: true}))
+	if err != nil {
+		return fmt.Errorf("marshaling doc: %s", err)
+	}
+	p.buf.Write(bs)
+	return nil
+}
+
+type JSONPrinter struct {
+	buf io.Writer
+}
+
+var _ DocumentPrinter = &JSONPrinter{}
+
+func NewJSONPrinter(writer io.Writer) JSONPrinter {
+	return JSONPrinter{writer}
+}
+
+func (p JSONPrinter) Print(item *Document) error {
+	bs, err := json.Marshal(item.AsInterface(InterfaceConvertOpts{OrderedMap: true, Plain: true}))
+	if err != nil {
+		return fmt.Errorf("marshaling doc: %s", err)
+	}
+	p.buf.Write(bs)
+	return nil
+}
+
+type WrappedFilePositionPrinter struct {
+	Printer *FilePositionPrinter
+}
+
+var _ DocumentPrinter = WrappedFilePositionPrinter{}
+
+func (p WrappedFilePositionPrinter) Print(item *Document) error {
+	p.Printer.Print(item)
+	return nil
+}


### PR DESCRIPTION
yaml - default
json - json objects are concatenated together without any separator
pos - print structure with file names and line numbers for map keys and array items

`json` output:

based on `ytt -f config-step-2-template/ -f config-step-2a-overlays/ -f config-step-2b-multiple-data-values/ --output-type json` (https://github.com/k14s/k8s-simple-app-example)

```
{
  "apiVersion": "v1",
  "kind": "Service",
  "metadata": {
    "name": "simple-app",
    "namespace": "default"
  },
  "spec": {
    "ports": [
      {
        "port": 80,
        "targetPort": 80
      }
    ],
    "selector": {
      "simple-app": ""
    }
  }
}
{
  "apiVersion": "apps/v1",
  "kind": "Deployment",
  "metadata": {
    "name": "simple-app",
    "namespace": "default"
  },
  "spec": {
    "replicas": 3,
    "selector": {
      "matchLabels": {
        "simple-app": ""
      }
    },
    "template": {
      "metadata": {
        "labels": {
          "simple-app": ""
        }
      },
      "spec": {
        "containers": [
          {
            "env": [
              {
                "name": "HELLO_MSG",
                "value": "another stranger"
              }
            ],
            "image": "docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0",
            "name": "simple-app"
          }
        ]
      }
    }
  }
}
```

`pos` output:

based on `ytt -f config-step-2-template/ -f config-step-2a-overlays/ -f config-step-2b-multiple-data-values/ --output-type pos` (https://github.com/k14s/k8s-simple-app-example)

```
          config.yml:7 | [doc]
          config.yml:8 |   apiVersion: v1
          config.yml:9 |   kind: Service
         config.yml:10 |   metadata:
         config.yml:11 |     namespace: default
         config.yml:12 |     name: simple-app
         config.yml:13 |   spec:
         config.yml:14 |     ports:
         config.yml:15 |       [0]
         config.yml:15 |         port: 80
         config.yml:16 |         targetPort: 80
         config.yml:17 |     selector:
          config.yml:4 |       simple-app: ""
         config.yml:18 | [doc]
         config.yml:19 |   apiVersion: apps/v1
         config.yml:20 |   kind: Deployment
         config.yml:21 |   metadata:
         config.yml:22 |     namespace: default
         config.yml:23 |     name: simple-app
         config.yml:24 |   spec:
         config.yml:25 |     selector:
         config.yml:26 |       matchLabels:
          config.yml:4 |         simple-app: ""
         config.yml:27 |     template:
         config.yml:28 |       metadata:
         config.yml:29 |         labels:
          config.yml:4 |           simple-app: ""
         config.yml:30 |       spec:
         config.yml:31 |         containers:
         config.yml:32 |           [0]
         config.yml:32 |             name: simple-app
         config.yml:33 |             image: docker.io/dkalinin/k8s-simple-app@sha256:4c8b96d4fffdfae29258d94a22ae4ad1fe36139d47288b8960d9958d1e63a9d0
         config.yml:34 |             env:
         config.yml:35 |               [0]
         config.yml:35 |                 name: HELLO_MSG
         config.yml:36 |                 value: another stranger
    custom-scale.yml:7 |     replicas: 3
```

future TODOs for `pos` type:

- support structures that are removed
- support stating which structures are overwritten
