### PR TITLE
(typo) correct reference to pkg/texttemplate

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -25,7 +25,7 @@ For those interested in extending and improving `ytt`, below is a quick referenc
   - `load(...)` directive goes through `TemplateLoader` to load files
 - [pkg/yamlmeta](https://github.com/k14s/ytt/tree/master/pkg/yamlmeta) parses YAML and tracks YAML node annotations (metas)
 - [pkg/yamltemplate](https://github.com/k14s/ytt/tree/master/pkg/yamltemplate) generates Starlark template based on yamlmeta package structures
-- [pkg/yamltemplate](https://github.com/k14s/ytt/tree/master/pkg/texttemplate) parses text templates and generates Starlark template
+- [pkg/texttemplate](https://github.com/k14s/ytt/tree/master/pkg/texttemplate) parses text templates and generates Starlark template
 - [pkg/template](https://github.com/k14s/ytt/tree/master/pkg/template)
   - `InstructionSet` provides generic template instruction set for building Starlark templates
   - `CompiledTemplate` uses [Starlark Go library](https://github.com/google/starlark-go) to evaluate Starlark code


### PR DESCRIPTION
@pivotal-issuemaster this is an obvious fix