### PR TITLE
Fix typo in helm-ytt-post-renderer example

### DIFF
--- a/examples/helm-ytt-post-renderer/README.md
+++ b/examples/helm-ytt-post-renderer/README.md
@@ -11,8 +11,7 @@ From within this directory:
 
 ```bash
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
-helm fetch stable/postgresql
-tar xzvf postgresql
+helm pull --untar stable/postgresql
 helm template postgresql postgresql/ --post-renderer ./ytt-post-renderer
                                      # ^ same flag goes for install/upgrade
 ```

--- a/examples/helm-ytt-post-renderer/ytt-post-renderer
+++ b/examples/helm-ytt-post-renderer/ytt-post-renderer
@@ -4,4 +4,4 @@ set -e
 
 ytt version || (echo "*** Missing ytt binary. Install from https://k14s.io ***" 1>&2; exit 1)
 
-ytt --ignore-unknown-comments -f - -f overlays/
+ytt --ignore-unknown-comments -f - -f config/


### PR DESCRIPTION
Since Helm 3, `fetch` have been replaced with `pull` (while still maintaining `fetch` as an alias), and there's a `--untar` flag so no need for the `tar` command (where I anyway think the author had mixed up tar and untar).