### PR TITLE
Trim whitespace from templated source

### DIFF
--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -60,7 +60,7 @@ func (e *CompiledTemplate) CodeAtLine(pos *filepos.Position) *TemplateLine {
 func (e *CompiledTemplate) CodeAsString() string {
 	result := []string{}
 	for _, line := range e.code {
-		result = append(result, line.Instruction.AsString())
+		result = append(result, strings.TrimSpace(line.Instruction.AsString()))
 	}
 	// Do not add any unnecessary newlines to match code lines
 	return strings.Join(result, "\n")

--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -59,8 +59,14 @@ func (e *CompiledTemplate) CodeAtLine(pos *filepos.Position) *TemplateLine {
 
 func (e *CompiledTemplate) CodeAsString() string {
 	result := []string{}
+	cont := false
 	for _, line := range e.code {
-		result = append(result, strings.TrimSpace(line.Instruction.AsString()))
+		src := line.Instruction.AsString()
+		if !cont {
+			src = strings.TrimSpace(src)
+		}
+		cont = strings.HasSuffix(src, "\\")
+		result = append(result, src)
 	}
 	// Do not add any unnecessary newlines to match code lines
 	return strings.Join(result, "\n")

--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -2,13 +2,13 @@ package template
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/k14s/ytt/pkg/filepos"
 	tplcore "github.com/k14s/ytt/pkg/template/core"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
+	"strings"
+	"unicode"
 )
 
 type EvaluationCtxDialectName string
@@ -63,7 +63,7 @@ func (e *CompiledTemplate) CodeAsString() string {
 	for _, line := range e.code {
 		src := line.Instruction.AsString()
 		if !cont {
-			src = strings.TrimSpace(src)
+			src = strings.TrimLeftFunc(src, unicode.IsSpace)
 		}
 		cont = strings.HasSuffix(src, "\\")
 		result = append(result, src)

--- a/pkg/yamltemplate/filetests/code-whitespace.yml
+++ b/pkg/yamltemplate/filetests/code-whitespace.yml
@@ -1,3 +1,4 @@
+#! blocks are determined by `:` and `end`, not whitespace
 #@ if True:
 #@ a = 123
 #@ else:
@@ -12,15 +13,32 @@ test1: #@ a
 #@    end
 test2: #@ a
 
-#! preserves space within strings
+#@ for a in [3]:
+#@   for b in [20]:
+#@     for c in [300]:
+test3: #@ a+b+c
+#@     end
+#@   end
+#@ end
+
+#! trims space from multi-line strings
 #@ a = "line1\n\
 #@    line2"
-test3: #@ a
+test4: #@ a
+
+#! space preserved within line-continued strings
+#@ a = "line1\n" + \
+#@ "   line2"
+test5: #@ a
 
 +++
 
 test1: 123
 test2: 223
-test3: |-
+test3: 323
+test4: |-
+  line1
+  line2
+test5: |-
   line1
      line2

--- a/pkg/yamltemplate/filetests/code-whitespace.yml
+++ b/pkg/yamltemplate/filetests/code-whitespace.yml
@@ -21,15 +21,10 @@ test3: #@ a+b+c
 #@   end
 #@ end
 
-#! trims space from multi-line strings
+#! preserves space within strings
 #@ a = "line1\n\
 #@    line2"
 test4: #@ a
-
-#! space preserved within line-continued strings
-#@ a = "line1\n" + \
-#@ "   line2"
-test5: #@ a
 
 +++
 
@@ -37,8 +32,5 @@ test1: 123
 test2: 223
 test3: 323
 test4: |-
-  line1
-  line2
-test5: |-
   line1
      line2


### PR DESCRIPTION
Working example of whitespace-trimming source from YAML templates just before parsing.