### PR TITLE
Implement the ability to load own starlark modules.

### DIFF
--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -21,6 +21,7 @@ type TemplateOptions struct {
 	RegularFilesSourceOpts RegularFilesSourceOpts
 	FileMarksOpts          FileMarksOpts
 	DataValuesFlags        DataValuesFlags
+	Extender               func(load workspace.ModuleLoader) workspace.ModuleLoader
 }
 
 type TemplateInput struct {
@@ -116,6 +117,7 @@ func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui cmdcore.PlainUI) Tem
 	libraryExecutionFactory := workspace.NewLibraryExecutionFactory(ui, workspace.TemplateLoaderOpts{
 		IgnoreUnknownComments: o.IgnoreUnknownComments,
 		StrictYAML:            o.StrictYAML,
+		Extender:              o.Extender,
 	})
 
 	libraryCtx := workspace.LibraryExecutionContext{Current: rootLibrary, Root: rootLibrary}


### PR DESCRIPTION
I'm using ytt inside my application. I would like to provide own starlark modules that could be loaded inside templates.

I tried 2 variants:
1. Add a `Load` function to `TemplateOptions` of type `func(thread *starlark.Thread, module string) (starlark.StringDict, error)`
2. Add a `Extender` function of type `func(load ModuleLoader) ModuleLoader`

I took the second variant, because it
* requires less code changes
* allows to define a precedence  of own modules and ytt modules.
* allows nesting