### PR TITLE
Use snake_case not camelcase for identifiers

### DIFF
--- a/examples/playground/getting-started/example-calc-in-functions/__readme.yaml
+++ b/examples/playground/getting-started/example-calc-in-functions/__readme.yaml
@@ -51,7 +51,7 @@ readme: |
     that name.
 
   For those seeking extra credit, consider
-  `labels(withVersion)`. Could the parameter name be made
+  `labels(with_version)`. Could the parameter name be made
   more intention revealing?
 
   ................

--- a/examples/playground/getting-started/example-calc-in-functions/config.yml
+++ b/examples/playground/getting-started/example-calc-in-functions/config.yml
@@ -24,10 +24,10 @@
 #@ end
 ---
 
-#@ def labels(withVersion=False):
+#@ def labels(with_version=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ app_name
-  #@ if withVersion:
+  #@ if with_version:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end
@@ -37,7 +37,7 @@ kind: Deployment
 metadata:
   annotations:
     comment: "This deployment was lifted from\nthe prometheus K8s configuration.\nYou might notice that this line\nis supplied as a single string\nin the source, but a multi-line\nstring in the output."
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ app_name
   namespace: default
 spec:
@@ -46,7 +46,7 @@ spec:
     matchLabels: #@ labels()
   template:
     metadata:
-      labels: #@ labels(withVersion=True)
+      labels: #@ labels(with_version=True)
     spec:
       containers:
         - name: prometheus-operator
@@ -65,7 +65,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ app_name + "-service"
 spec:
   type: ClusterIP

--- a/examples/playground/getting-started/example-collect-to-packages/config/common.lib.yml
+++ b/examples/playground/getting-started/example-collect-to-packages/config/common.lib.yml
@@ -23,10 +23,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(forSelecting=False):
+#@ def labels(for_selecting=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if not forSelecting:
+  #@ if not for_selecting:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end

--- a/examples/playground/getting-started/example-collect-to-packages/config/deployment.yml
+++ b/examples/playground/getting-started/example-collect-to-packages/config/deployment.yml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: #@ data.values.scaling_factor // 2
   selector:
-    matchLabels: #@ labels(forSelecting=True)
+    matchLabels: #@ labels(for_selecting=True)
   template:
     metadata:
       labels: #@ labels()

--- a/examples/playground/getting-started/example-collect-to-packages/config/service.yml
+++ b/examples/playground/getting-started/example-collect-to-packages/config/service.yml
@@ -14,4 +14,4 @@ spec:
       port: 38080
       protocol: TCP
       targetPort: 8080
-  selector: #@ labels(forSelecting=True)
+  selector: #@ labels(for_selecting=True)

--- a/examples/playground/getting-started/example-extend-data-values/config/deployment.yml
+++ b/examples/playground/getting-started/example-extend-data-values/config/deployment.yml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: #@ data.values.scaling_factor // 2
   selector:
-    matchLabels: #@ labels(forSelecting=True)
+    matchLabels: #@ labels(for_selecting=True)
   template:
     metadata:
       labels: #@ labels()

--- a/examples/playground/getting-started/example-extend-data-values/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-extend-data-values/config/lib/common.lib.yml
@@ -23,10 +23,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(forSelecting=False):
+#@ def labels(for_selecting=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if not forSelecting:
+  #@ if not for_selecting:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end

--- a/examples/playground/getting-started/example-extend-data-values/config/service.yml
+++ b/examples/playground/getting-started/example-extend-data-values/config/service.yml
@@ -14,4 +14,4 @@ spec:
       port: 38080
       protocol: TCP
       targetPort: 8080
-  selector: #@ labels(forSelecting=True)
+  selector: #@ labels(for_selecting=True)

--- a/examples/playground/getting-started/example-externalize-data-values/config.yml
+++ b/examples/playground/getting-started/example-externalize-data-values/config.yml
@@ -24,10 +24,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(withVersion=False):
+#@ def labels(with_version=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if withVersion:
+  #@ if with_version:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end
@@ -37,7 +37,7 @@ kind: Deployment
 metadata:
   annotations:
     comment: "This deployment was lifted from\nthe prometheus K8s configuration.\nYou might notice that this line\nis supplied as a single string\nin the source, but a multi-line\nstring in the output."
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ data.values.app_name
   namespace: default
 spec:
@@ -46,7 +46,7 @@ spec:
     matchLabels: #@ labels()
   template:
     metadata:
-      labels: #@ labels(withVersion=True)
+      labels: #@ labels(with_version=True)
     spec:
       containers:
         - name: prometheus-operator
@@ -65,7 +65,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ data.values.app_name + "-service"
 spec:
   type: ClusterIP

--- a/examples/playground/getting-started/example-extract-yaml-fragments/__readme.yaml
+++ b/examples/playground/getting-started/example-extract-yaml-fragments/__readme.yaml
@@ -14,10 +14,10 @@ readme: |
   We have done that in `config.yml`:
 
   1. `labels` is a function taking one parameter,
-     `withVersion` and implicitly returns the YAML fragment
+     `with_version` and implicitly returns the YAML fragment
      it contains.
   2. `app.kubernetes.io/version` is in the fragment only if
-      `withVersion` is `True`. (notice that the Starlark
+      `with_version` is `True`. (notice that the Starlark
       boolean literal for truthy is capital-T, `True`).
 
   ----------------------

--- a/examples/playground/getting-started/example-extract-yaml-fragments/config.yml
+++ b/examples/playground/getting-started/example-extract-yaml-fragments/config.yml
@@ -1,10 +1,10 @@
 #@ app_name = "prometheus-operator"
 #@ version = "v0.39.0"
 
-#@ def labels(withVersion=False):
+#@ def labels(with_version=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ app_name
-  #@ if withVersion:
+  #@ if with_version:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end
@@ -12,7 +12,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ app_name
   namespace: default
 spec:
@@ -46,7 +46,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ app_name + "-service"
 spec:
   type: ClusterIP

--- a/examples/playground/getting-started/example-factor-to-modules/common.lib.yml
+++ b/examples/playground/getting-started/example-factor-to-modules/common.lib.yml
@@ -23,10 +23,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(forSelecting=False):
+#@ def labels(for_selecting=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if not forSelecting:
+  #@ if not for_selecting:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end

--- a/examples/playground/getting-started/example-factor-to-modules/deployment.yml
+++ b/examples/playground/getting-started/example-factor-to-modules/deployment.yml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: #@ data.values.scaling_factor // 2
   selector:
-    matchLabels: #@ labels(forSelecting=True)
+    matchLabels: #@ labels(for_selecting=True)
   template:
     metadata:
       labels: #@ labels()

--- a/examples/playground/getting-started/example-factor-to-modules/service.yml
+++ b/examples/playground/getting-started/example-factor-to-modules/service.yml
@@ -14,4 +14,4 @@ spec:
       port: 38080
       protocol: TCP
       targetPort: 8080
-  selector: #@ labs(forSelecting=True)
+  selector: #@ labs(for_selecting=True)

--- a/examples/playground/getting-started/example-overlay-data-values/config/deployment.yml
+++ b/examples/playground/getting-started/example-overlay-data-values/config/deployment.yml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: #@ data.values.scaling_factor // 2
   selector:
-    matchLabels: #@ labels(forSelecting=True)
+    matchLabels: #@ labels(for_selecting=True)
   template:
     metadata:
       labels: #@ labels()

--- a/examples/playground/getting-started/example-overlay-data-values/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-overlay-data-values/config/lib/common.lib.yml
@@ -23,10 +23,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(forSelecting=False):
+#@ def labels(for_selecting=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if not forSelecting:
+  #@ if not for_selecting:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end

--- a/examples/playground/getting-started/example-overlay-data-values/config/service.yml
+++ b/examples/playground/getting-started/example-overlay-data-values/config/service.yml
@@ -14,4 +14,4 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: 80
-  selector: #@ labels(forSelecting=True)
+  selector: #@ labels(for_selecting=True)

--- a/examples/playground/getting-started/example-overlay-map-items/config/deployment.yml
+++ b/examples/playground/getting-started/example-overlay-map-items/config/deployment.yml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: #@ data.values.scaling_factor // 2
   selector:
-    matchLabels: #@ labels(forSelecting=True)
+    matchLabels: #@ labels(for_selecting=True)
   template:
     metadata:
       labels: #@ labels()

--- a/examples/playground/getting-started/example-overlay-map-items/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-overlay-map-items/config/lib/common.lib.yml
@@ -23,10 +23,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(forSelecting=False):
+#@ def labels(for_selecting=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if not forSelecting:
+  #@ if not for_selecting:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end

--- a/examples/playground/getting-started/example-overlay-map-items/config/service.yml
+++ b/examples/playground/getting-started/example-overlay-map-items/config/service.yml
@@ -14,4 +14,4 @@ spec:
       port: 38080
       protocol: TCP
       targetPort: 8080
-  selector: #@ labels(forSelecting=True)
+  selector: #@ labels(for_selecting=True)

--- a/examples/playground/getting-started/example-overlay-on-templates/config/deployment.yml
+++ b/examples/playground/getting-started/example-overlay-on-templates/config/deployment.yml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: #@ data.values.scaling_factor // 2
   selector:
-    matchLabels: #@ labels(forSelecting=True)
+    matchLabels: #@ labels(for_selecting=True)
   template:
     metadata:
       labels: #@ labels()

--- a/examples/playground/getting-started/example-overlay-on-templates/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-overlay-on-templates/config/lib/common.lib.yml
@@ -23,10 +23,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(forSelecting=False):
+#@ def labels(for_selecting=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if not forSelecting:
+  #@ if not for_selecting:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end

--- a/examples/playground/getting-started/example-overlay-on-templates/config/service.yml
+++ b/examples/playground/getting-started/example-overlay-on-templates/config/service.yml
@@ -14,4 +14,4 @@ spec:
       port: 38080
       protocol: TCP
       targetPort: 8080
-  selector: #@ labels(forSelecting=True)
+  selector: #@ labels(for_selecting=True)

--- a/examples/playground/getting-started/example-splitting-a-template/deployment.yml
+++ b/examples/playground/getting-started/example-splitting-a-template/deployment.yml
@@ -24,10 +24,10 @@ limits:
 #@ end
 ---
 
-#@ def labels(withVersion=False):
+#@ def labels(with_version=False):
   app.kubernetes.io/component: controller
   app.kubernetes.io/name: #@ data.values.app_name
-  #@ if withVersion:
+  #@ if with_version:
   app.kubernetes.io/version: #@ version
   #@ end
 #@ end
@@ -37,7 +37,7 @@ kind: Deployment
 metadata:
   annotations:
     comment: "This deployment was lifted from\nthe prometheus K8s configuration.\nYou might notice that this line\nis supplied as a single string\nin the source, but a multi-line\nstring in the output."
-  labels: #@ labels(withVersion=True)
+  labels: #@ labels(with_version=True)
   name: #@ data.values.app_name
   namespace: default
 spec:
@@ -46,7 +46,7 @@ spec:
     matchLabels: #@ labels()
   template:
     metadata:
-      labels: #@ labels(withVersion=True)
+      labels: #@ labels(with_version=True)
     spec:
       containers:
         - name: prometheus-operator


### PR DESCRIPTION
... in the examples.

We've see people copy and paste these examples into their projects,
highlighting the need for them to be exemplary.