### PR TITLE
Implement regexp.replace

### DIFF
--- a/docs/lang-ref-ytt.md
+++ b/docs/lang-ref-ytt.md
@@ -66,8 +66,13 @@ data.list("/data/data.txt") # read file
 load("@ytt:regexp", "regexp")
 
 regexp.match("[a-z]+[0-9]+", "__hello123__") # True
+
 regexp.replace("[a-z]+[0-9]+", "__hello123__", "foo") # __foo__
+regexp.replace("(?i)[a-z]+[0-9]+", "__hello123__HI456__") # __bye__bye__
+regexp.replace("[a-z]+[0-9]+", "__hello123__", lambda s: str(len(s))) # __8__
 ```
+
+See the [RE2 docs](https://github.com/google/re2/wiki/Syntax) for more on the regex syntax supported.
 
 ### url
 

--- a/docs/lang-ref-ytt.md
+++ b/docs/lang-ref-ytt.md
@@ -67,12 +67,15 @@ load("@ytt:regexp", "regexp")
 
 regexp.match("[a-z]+[0-9]+", "__hello123__") # True
 
-regexp.replace("[a-z]+[0-9]+", "__hello123__", "foo") # __foo__
-regexp.replace("(?i)[a-z]+[0-9]+", "__hello123__HI456__") # __bye__bye__
+regexp.replace("[a-z]+[0-9]+", "__hello123__", "foo")                 # __foo__
+regexp.replace("(?i)[a-z]+[0-9]+", "__hello123__HI456__")             # __bye__bye__
+regexp.replace("([a-z]+)[0-9]+", "__hello123__bye123__", "$1")        # __hello__bye__
 regexp.replace("[a-z]+[0-9]+", "__hello123__", lambda s: str(len(s))) # __8__
 ```
 
 See the [RE2 docs](https://github.com/google/re2/wiki/Syntax) for more on the regex syntax supported.
+
+Note that you can pass either a string or a lambda function as the third parameter. When given a string, `$` symbols are expanded, so that `$1` expands to the first submatch. When given a lambda function, the match is directly replaced by the result of the function.
 
 ### url
 

--- a/docs/lang-ref-ytt.md
+++ b/docs/lang-ref-ytt.md
@@ -66,6 +66,7 @@ data.list("/data/data.txt") # read file
 load("@ytt:regexp", "regexp")
 
 regexp.match("[a-z]+[0-9]+", "__hello123__") # True
+regexp.replace("[a-z]+[0-9]+", "__hello123__", "foo") # __foo__
 ```
 
 ### url

--- a/pkg/yamltemplate/filetests/ytt-library/regexp.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/regexp.yml
@@ -5,7 +5,7 @@ test2: #@ regexp.match("^[a-z]+[0-9]+$", "__hello123__")
 test3: #@ regexp.replace("[a-z]+[0-9]+", "__hello123__HI456__", "bye")
 test4: #@ regexp.replace("(?i)[a-z]+[0-9]+", "__hello123__HI456__", "bye")
 test5: #@ regexp.replace("(?i)([a-z]+)[0-9]+", "__hello123__HI456__", "$1")
-test6: #@ regexp.replace("[a-z]+[0-9]+", "__hello123__", lambda a: str(len(a)))
+test6: #@ regexp.replace("(?i)[a-z]+[0-9]+", "__hello123__HI456__", lambda a: str(len(a)))
 
 +++
 
@@ -14,4 +14,4 @@ test2: false
 test3: __bye__HI456__
 test4: __bye__bye__
 test5: __hello__HI__
-test6: __8__
+test6: __8__5__

--- a/pkg/yamltemplate/filetests/ytt-library/regexp.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/regexp.yml
@@ -2,8 +2,12 @@
 
 test1: #@ regexp.match("[a-z]+[0-9]+", "__hello123__")
 test2: #@ regexp.match("^[a-z]+[0-9]+$", "__hello123__")
+test3: #@ regexp.replace("[a-z]+[0-9]+", "__foo123__BAR456__", "baz")
+test4: #@ regexp.replace("(?i)[a-z]+[0-9]+", "__foo123__BAR456__", "baz")
 
 +++
 
 test1: true
 test2: false
+test3: __baz__BAR456__
+test4: __baz__baz__

--- a/pkg/yamltemplate/filetests/ytt-library/regexp.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/regexp.yml
@@ -2,12 +2,16 @@
 
 test1: #@ regexp.match("[a-z]+[0-9]+", "__hello123__")
 test2: #@ regexp.match("^[a-z]+[0-9]+$", "__hello123__")
-test3: #@ regexp.replace("[a-z]+[0-9]+", "__foo123__BAR456__", "baz")
-test4: #@ regexp.replace("(?i)[a-z]+[0-9]+", "__foo123__BAR456__", "baz")
+test3: #@ regexp.replace("[a-z]+[0-9]+", "__hello123__HI456__", "bye")
+test4: #@ regexp.replace("(?i)[a-z]+[0-9]+", "__hello123__HI456__", "bye")
+test5: #@ regexp.replace("(?i)([a-z]+)[0-9]+", "__hello123__HI456__", "$1")
+test6: #@ regexp.replace("[a-z]+[0-9]+", "__hello123__", lambda a: str(len(a)))
 
 +++
 
 test1: true
 test2: false
-test3: __baz__BAR456__
-test4: __baz__baz__
+test3: __bye__HI456__
+test4: __bye__bye__
+test5: __hello__HI__
+test6: __8__

--- a/pkg/yttlibrary/regexp.go
+++ b/pkg/yttlibrary/regexp.go
@@ -17,7 +17,8 @@ var (
 		"regexp": &starlarkstruct.Module{
 			Name: "regexp",
 			Members: starlark.StringDict{
-				"match": starlark.NewBuiltin("regexp.match", core.ErrWrapper(regexpModule{}.Match)),
+				"match":   starlark.NewBuiltin("regexp.match", core.ErrWrapper(regexpModule{}.Match)),
+				"replace": starlark.NewBuiltin("regexp.replace", core.ErrWrapper(regexpModule{}.Replace)),
 			},
 		},
 	}
@@ -46,4 +47,34 @@ func (b regexpModule) Match(thread *starlark.Thread, f *starlark.Builtin, args s
 	}
 
 	return starlark.Bool(matched), nil
+}
+
+func (b regexpModule) Replace(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if args.Len() != 3 {
+		return starlark.None, fmt.Errorf("expected exactly 3 arguments")
+	}
+
+	pattern, err := core.NewStarlarkValue(args.Index(0)).AsString()
+	if err != nil {
+		return starlark.None, err
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	source, err := core.NewStarlarkValue(args.Index(1)).AsString()
+	if err != nil {
+		return starlark.None, err
+	}
+
+	target, err := core.NewStarlarkValue(args.Index(2)).AsString()
+	if err != nil {
+		return starlark.None, err
+	}
+
+	newString := re.ReplaceAllLiteralString(source, target)
+
+	return starlark.String(newString), nil
 }

--- a/pkg/yttlibrary/regexp.go
+++ b/pkg/yttlibrary/regexp.go
@@ -69,12 +69,12 @@ func (b regexpModule) Replace(thread *starlark.Thread, f *starlark.Builtin, args
 		return starlark.None, err
 	}
 
-	target, err := core.NewStarlarkValue(args.Index(2)).AsString()
+	repl, err := core.NewStarlarkValue(args.Index(2)).AsString()
 	if err != nil {
 		return starlark.None, err
 	}
 
-	newString := re.ReplaceAllLiteralString(source, target)
+	newString := re.ReplaceAllString(source, repl)
 
 	return starlark.String(newString), nil
 }


### PR DESCRIPTION
Possible implementation for #169, subject to a few questions/notes about the API:

1. In the original issue, @cppforlife suggested implementing using [Regexp.ReplaceAllStringFunc](https://golang.org/pkg/regexp/#Regexp.ReplaceAllStringFunc), but [Regexp.ReplaceAllLiteralString](https://golang.org/pkg/regexp/#Regexp.ReplaceAllLiteralString) seems simpler for the use cases discussed in the issue and the referenced Slack discussion. Am I missing a use case that would require implementation with ReplaceAllStringFunc?

2. Depending on the answer to question 1 above, there's also a question about whether or not to implement this using [Regexp.ReplaceAllString](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString). This expands `$` signs to submatches (e.g. `$1` to the first submatch), but I wasn't sure how useful this would be, so applying YAGNI for now. (EDIT: As @cppforlife points out below, I mistakenly pushed an implementation using ReplaceAllString, but following subsequent discussion that has been kept.)

3. There was some discussion about whether or not to have separate `replace` and `replaceAll` functions. Given the suggested approach, I'm assuming we are happy to simply replace all (certainly, that tends to be what I most often need when I'm doing a replace), but just want to confirm.

4. There was also discussion about passing flags (e.g. for case-insensitive matches) as a separate param. However, Go uses [RE2 syntax](https://github.com/google/re2/wiki/Syntax) which embeds flags into the regex (example in the tests), so that may not be necessary. One use case for flags might be to select between different underlying implementations (e.g. to choose between ReplaceAllString and ReplaceAllLiteralString depending on whether or not the client wishes to expand submatches), but again, applying YAGNI for now.