### PR TITLE
Update Hardcoded Repo Name in Workflow

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -12,12 +12,12 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: src/github.com/k14s/ytt
+        path: src/github.com/${{ github.repository }}
     - name: Run Tests
       run: |
         set -e -x
         export GOPATH=$(pwd)
-        cd src/github.com/k14s/ytt
+        cd src/github.com/${{ github.repository }}
         ./hack/build.sh
         ./hack/test-all.sh
         ./hack/build-binaries.sh


### PR DESCRIPTION
Updating checkout step to use `${{ github.repository }}` for its path to help with transitioning to new org. Should be aliased, but might be nice to avoid confusion if someone is reviewing CI process.