### PR TITLE
Switch Back to Original Example ID Condition Check

### DIFF
--- a/pkg/website/server.go
+++ b/pkg/website/server.go
@@ -98,7 +98,7 @@ func (s *Server) exampleSetsHandler(w http.ResponseWriter, r *http.Request) {
 func (s *Server) examplesHandler(w http.ResponseWriter, r *http.Request) {
 	for _, eg := range exampleSets {
 		for _, example := range eg.Examples {
-			if strings.Contains(r.URL.Path, example.ID) {
+			if example.ID == strings.TrimPrefix(r.URL.Path, "/examples/") {
 				exampleBytes, err := json.Marshal(example)
 				if err != nil {
 					s.logError(w, err)


### PR DESCRIPTION
Using strings.Contains() can cause examples that have names that are substrings of other example names to load wrong examples. An example of this is `example-load` and `examples-load-data-values`. Reverting back to old condition to check for example ID.