### PR TITLE
Schema nullable refactoring

### DIFF
--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -9,6 +9,7 @@ import (
 
 	cmdcore "github.com/k14s/ytt/pkg/cmd/core"
 	"github.com/k14s/ytt/pkg/files"
+	"github.com/k14s/ytt/pkg/schema"
 	"github.com/k14s/ytt/pkg/workspace"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 	"github.com/spf13/cobra"
@@ -131,10 +132,10 @@ func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui cmdcore.PlainUI) Tem
 	if err != nil {
 		return TemplateOutput{Err: err}
 	}
-	var schema yamlmeta.Schema = &yamlmeta.AnySchema{}
+	var schemaVar workspace.Schema = &schema.AnySchema{}
 	if len(schemaDocs) > 0 {
 		if o.SchemaEnabled {
-			schema, err = yamlmeta.NewDocumentSchema(schemaDocs[0])
+			schemaVar, err = schema.NewDocumentSchema(schemaDocs[0])
 			if err != nil {
 				return TemplateOutput{Err: err}
 			}
@@ -151,7 +152,7 @@ func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui cmdcore.PlainUI) Tem
 		}
 	}
 
-	values, libraryValues, err := libraryLoader.Values(valuesOverlays, schema)
+	values, libraryValues, err := libraryLoader.Values(valuesOverlays, schemaVar)
 	if err != nil {
 		return TemplateOutput{Err: err}
 	}

--- a/pkg/cmd/template/cmd_overlays_test.go
+++ b/pkg/cmd/template/cmd_overlays_test.go
@@ -237,3 +237,102 @@ overlayed: true
 		t.Fatalf("Expected error to match '%s' but was '%s'", expectedErr, out.Err.Error())
 	}
 }
+
+func TestMultipleDataValuesOneEmptyAndOneNonEmpty(t *testing.T) {
+	yamlTplData := []byte(`#@ load("@ytt:data", "data")
+key: #@ data.values.key
+`)
+
+	emptyYamlDataValue := []byte(`
+#@data/values
+---
+`)
+
+	nonEmptyYamlDataValue := []byte(`#@ load("@ytt:overlay", "overlay")
+#@data/values
+#@overlay/replace
+---
+key: value_from_data_value_overlay
+`)
+
+	expectedYAMLTplData := `key: value_from_data_value_overlay
+`
+
+	filesToProcess := files.NewSortedFiles([]*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+		files.MustNewFileFromSource(files.NewBytesSource("datavalue_empty.yml", emptyYamlDataValue)),
+		files.MustNewFileFromSource(files.NewBytesSource("datavalue_non_empty.yml", nonEmptyYamlDataValue)),
+	})
+
+	ui := cmdcore.NewPlainUI(false)
+	opts := cmdtpl.NewOptions()
+
+	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	if out.Err != nil {
+		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
+	}
+
+	if len(out.Files) != 1 {
+		t.Fatalf("Expected number of output files to be 1, but was %d", len(out.Files))
+	}
+
+	file := out.Files[0]
+
+	if file.RelativePath() != "tpl.yml" {
+		t.Fatalf("Expected output file to be tpl.yml, but was %#v", file.RelativePath())
+	}
+
+	if string(file.Bytes()) != expectedYAMLTplData {
+		t.Fatalf("Expected output file to have specific data, but was: >>>%s<<<", file.Bytes())
+	}
+}
+
+func TestEmptyOverlayAndEmptyDataValues(t *testing.T) {
+	yamlTplData := []byte(`
+array:
+- name: item1
+  subarray:
+  - item1
+`)
+
+	yamlDataValue := []byte(`
+#@data/values
+---
+`)
+
+	yamlOverlayTplData1 := []byte(`
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.all
+---
+`)
+
+	expectedYAMLTplData := ``
+
+	filesToProcess := files.NewSortedFiles([]*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+		files.MustNewFileFromSource(files.NewBytesSource("overlay2.yml", yamlOverlayTplData1)),
+		files.MustNewFileFromSource(files.NewBytesSource("datavalue.yml", yamlDataValue)),
+	})
+
+	ui := cmdcore.NewPlainUI(false)
+	opts := cmdtpl.NewOptions()
+
+	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	if out.Err != nil {
+		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
+	}
+
+	if len(out.Files) != 1 {
+		t.Fatalf("Expected number of output files to be 1, but was %d", len(out.Files))
+	}
+
+	file := out.Files[0]
+
+	if file.RelativePath() != "tpl.yml" {
+		t.Fatalf("Expected output file to be tpl.yml, but was %#v", file.RelativePath())
+	}
+
+	if string(file.Bytes()) != expectedYAMLTplData {
+		t.Fatalf("Expected output file to have specific data, but was: >>>%s<<<", file.Bytes())
+	}
+}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,12 +1,14 @@
 // Copyright 2020 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package yamlmeta_test
+package schema_test
 
 import (
 	"fmt"
-	"github.com/k14s/ytt/pkg/yamlmeta"
 	"testing"
+
+	"github.com/k14s/ytt/pkg/schema"
+	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
 func TestValueNotInSchemaErr(t *testing.T) {
@@ -26,7 +28,7 @@ not_in_schema: "this must fail validation."
 	if err != nil {
 		t.Fatalf("Unable to parse schema file: %s", err)
 	}
-	schema, err := yamlmeta.NewDocumentSchema(schemaDocSet.GetValues()[1].(*yamlmeta.Document))
+	schemaVar, err := schema.NewDocumentSchema(schemaDocSet.GetValues()[1].(*yamlmeta.Document))
 	if err != nil {
 		t.Fatalf("Unable to create schema from file %v: %s", schemaDocSet.GetValues()[1].(*yamlmeta.Document).Position, err)
 	}
@@ -35,7 +37,7 @@ not_in_schema: "this must fail validation."
 		t.Fatalf("Unable to parse data values file: %s", err)
 	}
 	dataValueDoc := dataValuesDocSet.GetValues()[1].(*yamlmeta.Document)
-	schema.AssignType(dataValueDoc)
+	schemaVar.AssignType(dataValueDoc)
 	typeCheck := dataValueDoc.Check()
 
 	const expectedErrorMessage = "{[Map item 'not_in_schema' at dataValues.yml:5 is not defined in schema]}"

--- a/pkg/schema/type.go
+++ b/pkg/schema/type.go
@@ -1,0 +1,311 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/k14s/ytt/pkg/filepos"
+	"github.com/k14s/ytt/pkg/structmeta"
+	"github.com/k14s/ytt/pkg/yamlmeta"
+)
+
+const (
+	AnnotationSchemaNullable structmeta.AnnotationName = "schema/nullable"
+)
+
+var _ yamlmeta.Type = (*DocumentType)(nil)
+var _ yamlmeta.Type = (*MapType)(nil)
+var _ yamlmeta.Type = (*MapItemType)(nil)
+var _ yamlmeta.Type = (*ArrayType)(nil)
+var _ yamlmeta.Type = (*ArrayItemType)(nil)
+
+type DocumentType struct {
+	Source    *yamlmeta.Document
+	ValueType yamlmeta.Type // typically one of: MapType, ArrayType, ScalarType
+}
+type MapType struct {
+	Items []*MapItemType
+}
+type MapItemType struct {
+	Key          interface{} // usually a string
+	ValueType    yamlmeta.Type
+	DefaultValue interface{}
+	Position     *filepos.Position
+	Annotations  TypeAnnotations
+}
+type ArrayType struct {
+	ItemsType yamlmeta.Type
+}
+type ArrayItemType struct {
+	ValueType yamlmeta.Type
+}
+type ScalarType struct {
+	Type interface{}
+}
+
+type TypeAnnotations map[structmeta.AnnotationName]interface{}
+
+func (t *DocumentType) GetValueType() yamlmeta.Type {
+	panic("Not implemented because it is unreachable")
+}
+func (m MapType) GetValueType() yamlmeta.Type {
+	panic("Not implemented because it is unreachable")
+}
+func (m MapItemType) GetValueType() yamlmeta.Type {
+	return m.ValueType
+}
+func (a ArrayType) GetValueType() yamlmeta.Type {
+	panic("Not implemented because it is unreachable")
+}
+func (a ArrayItemType) GetValueType() yamlmeta.Type {
+	return a.ValueType
+}
+func (m ScalarType) GetValueType() yamlmeta.Type {
+	panic("Not implemented because it is unreachable")
+}
+
+func (t *DocumentType) CheckType(_ yamlmeta.TypeWithValues, _ string) (chk yamlmeta.TypeCheck) {
+	return
+}
+func (m *MapType) CheckType(node yamlmeta.TypeWithValues, prependErrorMessage string) (chk yamlmeta.TypeCheck) {
+	violationErrorMessage := prependErrorMessage + " was type %T when %T was expected"
+
+	_, ok := node.(*yamlmeta.Map)
+	if !ok {
+		chk.Violations = append(chk.Violations, fmt.Sprintf(violationErrorMessage, node.GetValues()[0], &yamlmeta.Map{}))
+		return
+	}
+	return
+}
+func (m MapItemType) CheckType(node yamlmeta.TypeWithValues, prependErrorMessage string) (chk yamlmeta.TypeCheck) {
+	violationErrorMessage := prependErrorMessage + " was type %T when %T was expected"
+
+	mapItem, ok := node.(*yamlmeta.MapItem)
+	if !ok {
+		chk.Violations = append(chk.Violations, fmt.Sprintf(violationErrorMessage, node.GetValues()[0], node))
+		return
+	}
+	if mapItem.Value == nil && !m.IsNullable() {
+		chk.Violations = append(chk.Violations, fmt.Sprintf(violationErrorMessage, node.GetValues()[0], m.ValueType))
+	}
+
+	return
+}
+func (a ArrayType) CheckType(node yamlmeta.TypeWithValues, prependErrorMessage string) (chk yamlmeta.TypeCheck) {
+	violationErrorMessage := prependErrorMessage + " was type %T when %T was expected"
+
+	_, ok := node.(*yamlmeta.Array)
+	if !ok {
+		chk.Violations = append(chk.Violations, fmt.Sprintf(violationErrorMessage, node.GetValues()[0], &yamlmeta.Array{}))
+		return
+	}
+	return
+}
+func (a ArrayItemType) CheckType(node yamlmeta.TypeWithValues, prependErrorMessage string) (chk yamlmeta.TypeCheck) {
+	violationErrorMessage := prependErrorMessage + " was type %T when %T was expected"
+
+	_, ok := node.(*yamlmeta.ArrayItem)
+	if !ok {
+		chk.Violations = append(chk.Violations, fmt.Sprintf(violationErrorMessage, node.GetValues()[0], node))
+		return
+	}
+	return
+}
+func (m ScalarType) CheckType(node yamlmeta.TypeWithValues, prependErrorMessage string) (chk yamlmeta.TypeCheck) {
+	violationErrorMessage := prependErrorMessage + " was type %T when %T was expected"
+
+	value := node.GetValues()[0]
+	switch itemValueType := value.(type) {
+	case string:
+		if _, ok := m.Type.(string); !ok {
+			violation := fmt.Sprintf(violationErrorMessage, itemValueType, m.Type)
+			chk.Violations = append(chk.Violations, violation)
+		}
+	case int:
+		if _, ok := m.Type.(int); !ok {
+			violation := fmt.Sprintf(violationErrorMessage, itemValueType, m.Type)
+			chk.Violations = append(chk.Violations, violation)
+		}
+	case bool:
+		if _, ok := m.Type.(bool); !ok {
+			violation := fmt.Sprintf(violationErrorMessage, itemValueType, m.Type)
+			chk.Violations = append(chk.Violations, violation)
+		}
+	default:
+		violation := fmt.Sprintf(violationErrorMessage, itemValueType, m.Type)
+		chk.Violations = append(chk.Violations, violation)
+	}
+	return
+}
+
+func (t *DocumentType) CheckAllows(item *yamlmeta.MapItem) yamlmeta.TypeCheck {
+	panic("Attempt to check if a MapItem is allowed as a value of a Document.")
+}
+func (m MapItemType) CheckAllows(item *yamlmeta.MapItem) yamlmeta.TypeCheck {
+	panic("Attempt to check if a MapItem is allowed as a value of a MapItem.")
+}
+func (a ArrayType) CheckAllows(item *yamlmeta.MapItem) yamlmeta.TypeCheck {
+	panic("Attempt to check if a MapItem is allowed as a value of an Array.")
+}
+func (a ArrayItemType) CheckAllows(item *yamlmeta.MapItem) yamlmeta.TypeCheck {
+	panic("Attempt to check if a MapItem is allowed as a value of an ArrayItemType.")
+}
+func (m ScalarType) CheckAllows(item *yamlmeta.MapItem) yamlmeta.TypeCheck {
+	panic("Attempt to check if a MapItem is allowed as a value of a ScalarType.")
+}
+
+func (t *DocumentType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
+	doc, ok := typeable.(*yamlmeta.Document)
+	if !ok {
+		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &yamlmeta.Document{}, typeable)}
+		return
+	}
+	typeable.SetType(t)
+	typeableChild, ok := doc.Value.(yamlmeta.Typeable)
+	if ok || doc.Value == nil {
+		if t.ValueType != nil {
+			tChild := typeableChild
+			if doc.Value == nil {
+				switch t.ValueType.(type) {
+				case *MapType:
+					tChild = &yamlmeta.Map{}
+				default:
+					chk.Violations = append(chk.Violations, fmt.Sprintf("Expected node at %s to be %s, but was a %T", typeableChild.GetPosition().AsCompactString(), "Map", t.ValueType))
+				}
+				doc.Value = tChild
+			}
+			childCheck := t.ValueType.AssignTypeTo(tChild)
+			chk.Violations = append(chk.Violations, childCheck.Violations...)
+		} else {
+			chk.Violations = []string{fmt.Sprintf("Expected node at %s to be %s, but was a %T", typeableChild.GetPosition().AsCompactString(), "nil", typeableChild)}
+		}
+	} else {
+
+	} // else, at a leaf
+	return
+}
+func (t *MapType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
+	mapNode, ok := typeable.(*yamlmeta.Map)
+	if !ok {
+		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &yamlmeta.Map{}, typeable)}
+		return
+	}
+	var foundKeys []interface{}
+	typeable.SetType(t)
+	for _, mapItem := range mapNode.Items {
+		for _, itemType := range t.Items {
+			if mapItem.Key == itemType.Key {
+				foundKeys = append(foundKeys, itemType.Key)
+				childCheck := itemType.AssignTypeTo(mapItem)
+				chk.Violations = append(chk.Violations, childCheck.Violations...)
+				break
+			}
+		}
+	}
+
+	t.applySchemaDefaults(foundKeys, chk, mapNode)
+	return
+}
+
+func (t *MapType) applySchemaDefaults(foundKeys []interface{}, chk yamlmeta.TypeCheck, mapNode *yamlmeta.Map) {
+	for _, item := range t.Items {
+		if contains(foundKeys, item.Key) {
+			continue
+		}
+
+		val := &yamlmeta.MapItem{
+			Key:      item.Key,
+			Value:    item.DefaultValue,
+			Position: item.Position,
+		}
+		childCheck := item.AssignTypeTo(val)
+		chk.Violations = append(chk.Violations, childCheck.Violations...)
+		err := mapNode.AddValue(val)
+		if err != nil {
+			panic(fmt.Sprintf("Internal inconsistency: adding map item: %s", err))
+		}
+	}
+}
+
+func contains(haystack []interface{}, needle interface{}) bool {
+	for _, key := range haystack {
+		if key == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *MapItemType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
+	mapItem, ok := typeable.(*yamlmeta.MapItem)
+	if !ok {
+		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &yamlmeta.MapItem{}, typeable)}
+		return
+	}
+	typeable.SetType(t)
+	typeableValue, ok := mapItem.Value.(yamlmeta.Typeable)
+	if ok {
+		childCheck := t.ValueType.AssignTypeTo(typeableValue)
+		chk.Violations = append(chk.Violations, childCheck.Violations...)
+	} // else, at a leaf
+	return
+}
+func (t *ArrayType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
+	arrayNode, ok := typeable.(*yamlmeta.Array)
+	if !ok {
+		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &yamlmeta.Array{}, typeable)}
+		return
+	}
+	typeable.SetType(t)
+	for _, arrayItem := range arrayNode.Items {
+		childCheck := t.ItemsType.AssignTypeTo(arrayItem)
+		chk.Violations = append(chk.Violations, childCheck.Violations...)
+	}
+	return
+}
+func (t ArrayItemType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
+	arrayItem, ok := typeable.(*yamlmeta.ArrayItem)
+	if !ok {
+		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &yamlmeta.ArrayItem{}, typeable)}
+		return
+	}
+	typeable.SetType(t)
+	typeableValue, ok := arrayItem.Value.(yamlmeta.Typeable)
+	if ok {
+		childCheck := t.ValueType.AssignTypeTo(typeableValue)
+		chk.Violations = append(chk.Violations, childCheck.Violations...)
+	} // else, at a leaf
+	return
+}
+
+func (t *ScalarType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
+	switch t.Type.(type) {
+	case int:
+		typeable.SetType(t)
+	case string:
+		typeable.SetType(t)
+	default:
+		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &ScalarType{}, typeable)}
+	}
+	return
+}
+
+func (t *MapType) AllowsKey(key interface{}) bool {
+	for _, item := range t.Items {
+		if item.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *MapType) CheckAllows(item *yamlmeta.MapItem) (chk yamlmeta.TypeCheck) {
+	if !t.AllowsKey(item.Key) {
+		chk.Violations = append(chk.Violations, fmt.Sprintf("Map item '%s' at %s is not defined in schema", item.Key, item.Position.AsCompactString()))
+	}
+	return chk
+}
+
+func (t MapItemType) IsNullable() bool {
+	_, found := t.Annotations[AnnotationSchemaNullable]
+	return found
+}

--- a/pkg/template/annotations.go
+++ b/pkg/template/annotations.go
@@ -16,7 +16,6 @@ const (
 	AnnotationValue   structmeta.AnnotationName = "template/value"
 )
 
-// TODO change to struct
 type NodeAnnotations map[structmeta.AnnotationName]NodeAnnotation
 
 type NodeAnnotation struct {

--- a/pkg/workspace/data_values_pre_processing.go
+++ b/pkg/workspace/data_values_pre_processing.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/ytt/pkg/filepos"
+	"github.com/k14s/ytt/pkg/schema"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 	"github.com/k14s/ytt/pkg/yamltemplate"
 	yttoverlay "github.com/k14s/ytt/pkg/yttlibrary/overlay"
@@ -97,9 +98,11 @@ func (p DataValuesPreProcessing) templateFile(fileInLib *FileInLibrary) ([]*yaml
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := p.loader.schema.(*yamlmeta.AnySchema); !ok {
+	if _, ok := p.loader.schema.(*schema.AnySchema); !ok {
+
 		var outerTypeCheck yamlmeta.TypeCheck
-		for _, doc := range resultDocSet.Items {
+		// Skip first document because the parser inserts a new doc start at the beginning of every doc
+		for _, doc := range resultDocSet.Items[1:] {
 			outerTypeCheck = p.loader.schema.AssignType(doc)
 			if len(outerTypeCheck.Violations) > 0 {
 				return resultDocSet.Items, fmt.Errorf("Typechecking violations found: [%v]", strings.Join(outerTypeCheck.Violations, ", "))

--- a/pkg/workspace/library_loader.go
+++ b/pkg/workspace/library_loader.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/ytt/pkg/files"
+	"github.com/k14s/ytt/pkg/schema"
 	"github.com/k14s/ytt/pkg/structmeta"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 	"github.com/k14s/ytt/pkg/yamltemplate"
@@ -45,7 +46,7 @@ func NewLibraryLoader(libraryCtx LibraryExecutionContext,
 }
 
 func (ll *LibraryLoader) Schemas() ([]*yamlmeta.Document, error) {
-	loader := NewTemplateLoader(NewEmptyDataValues(), nil, ll.ui, ll.templateLoaderOpts, ll.libraryExecFactory, &yamlmeta.AnySchema{})
+	loader := NewTemplateLoader(NewEmptyDataValues(), nil, ll.ui, ll.templateLoaderOpts, ll.libraryExecFactory, &schema.AnySchema{})
 
 	schemaFiles, err := ll.schemaFiles(loader)
 	if err != nil {
@@ -72,7 +73,7 @@ func (ll *LibraryLoader) Schemas() ([]*yamlmeta.Document, error) {
 	return nil, nil
 }
 
-func (ll *LibraryLoader) Values(valuesOverlays []*DataValues, schema yamlmeta.Schema) (*DataValues, []*DataValues, error) {
+func (ll *LibraryLoader) Values(valuesOverlays []*DataValues, schema Schema) (*DataValues, []*DataValues, error) {
 	loader := NewTemplateLoader(NewEmptyDataValues(), nil, ll.ui, ll.templateLoaderOpts, ll.libraryExecFactory, schema)
 
 	valuesFiles, err := ll.valuesFiles(loader)
@@ -162,7 +163,7 @@ func (ll *LibraryLoader) Eval(values *DataValues, libraryValues []*DataValues) (
 func (ll *LibraryLoader) eval(values *DataValues, libraryValues []*DataValues) ([]EvalExport,
 	map[*FileInLibrary]*yamlmeta.DocumentSet, []files.OutputFile, error) {
 
-	loader := NewTemplateLoader(values, libraryValues, ll.ui, ll.templateLoaderOpts, ll.libraryExecFactory, &yamlmeta.AnySchema{})
+	loader := NewTemplateLoader(values, libraryValues, ll.ui, ll.templateLoaderOpts, ll.libraryExecFactory, &schema.AnySchema{})
 
 	exports := []EvalExport{}
 	docSets := map[*FileInLibrary]*yamlmeta.DocumentSet{}

--- a/pkg/workspace/library_module.go
+++ b/pkg/workspace/library_module.go
@@ -10,6 +10,7 @@ import (
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/starlark-go/starlarkstruct"
 	"github.com/k14s/ytt/pkg/filepos"
+	"github.com/k14s/ytt/pkg/schema"
 	"github.com/k14s/ytt/pkg/template/core"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 	"github.com/k14s/ytt/pkg/yamltemplate"
@@ -317,7 +318,7 @@ func (l *libraryValue) libraryValues(ll *LibraryLoader) (*DataValues, []*DataVal
 		}
 	}
 
-	dvs, foundChildDVss, err := ll.Values(append(dvss, afterLibModDVss...), &yamlmeta.AnySchema{})
+	dvs, foundChildDVss, err := ll.Values(append(dvss, afterLibModDVss...), &schema.AnySchema{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/workspace/schema.go
+++ b/pkg/workspace/schema.go
@@ -1,0 +1,15 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package workspace
+
+import (
+	"github.com/k14s/ytt/pkg/schema"
+	"github.com/k14s/ytt/pkg/yamlmeta"
+)
+
+type Schema interface {
+	AssignType(typeable yamlmeta.Typeable) yamlmeta.TypeCheck
+}
+
+var _ Schema = &schema.AnySchema{}
+var _ Schema = &schema.DocumentSchema{}

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -23,7 +23,7 @@ type TemplateLoader struct {
 	opts               TemplateLoaderOpts
 	compiledTemplates  map[string]*template.CompiledTemplate
 	libraryExecFactory *LibraryExecutionFactory
-	schema             yamlmeta.Schema
+	schema             Schema
 }
 
 type TemplateLoaderOpts struct {
@@ -38,7 +38,7 @@ type TemplateLoaderOptsOverrides struct {
 	StrictYAML              *bool
 }
 
-func NewTemplateLoader(values *DataValues, libraryValuess []*DataValues, ui files.UI, opts TemplateLoaderOpts, libraryExecFactory *LibraryExecutionFactory, schema yamlmeta.Schema) *TemplateLoader {
+func NewTemplateLoader(values *DataValues, libraryValuess []*DataValues, ui files.UI, opts TemplateLoaderOpts, libraryExecFactory *LibraryExecutionFactory, schema Schema) *TemplateLoader {
 
 	if values == nil {
 		panic("Expected values to be non-nil")

--- a/pkg/yamlmeta/ast.go
+++ b/pkg/yamlmeta/ast.go
@@ -90,6 +90,10 @@ type ArrayItem struct {
 	annotations interface{}
 }
 
+type Scalar struct {
+	Value interface{}
+}
+
 type Meta struct {
 	Data     string
 	Position *filepos.Position

--- a/pkg/yamlmeta/node.go
+++ b/pkg/yamlmeta/node.go
@@ -195,12 +195,13 @@ func (n *Document) Check() (chk TypeCheck) {
 	return
 }
 func (n *Map) Check() (chk TypeCheck) {
+	check := n.Type.CheckType(n, "")
+	if check.HasViolations() {
+		chk.Violations = append(chk.Violations, check.Violations...)
+		return
+	}
+
 	for _, item := range n.Items {
-		check := n.Type.CheckAllows(item)
-		if check.HasViolations() {
-			chk.Violations = append(chk.Violations, check.Violations...)
-			continue
-		}
 		check = item.Check()
 		if check.HasViolations() {
 			chk.Violations = append(chk.Violations, check.Violations...)

--- a/pkg/yamlmeta/type.go
+++ b/pkg/yamlmeta/type.go
@@ -4,7 +4,6 @@
 package yamlmeta
 
 import (
-	"fmt"
 	"github.com/k14s/ytt/pkg/filepos"
 )
 
@@ -12,18 +11,17 @@ type Type interface {
 	// Checks whether `value` is permitted within (applicable to map types only)
 	CheckAllows(item *MapItem) TypeCheck
 	AssignTypeTo(typeable Typeable) TypeCheck
+	GetValueType() Type
+	CheckType(node TypeWithValues, prependErrorMessage string) TypeCheck
 }
 
-var _ Type = (*DocumentType)(nil)
-var _ Type = (*MapType)(nil)
-var _ Type = (*MapItemType)(nil)
-var _ Type = (*ArrayType)(nil)
-var _ Type = (*ArrayItemType)(nil)
+type TypeWithValues interface {
+	GetValues() []interface{}
+}
 
 type Typeable interface {
 	// TODO: extract methods common to Node and Typeable to a shared interface?
 	GetPosition() *filepos.Position
-	GetValues() []interface{} // ie children
 
 	SetType(Type)
 }
@@ -39,184 +37,3 @@ func (n *Map) SetType(t Type)       { n.Type = t }
 func (n *MapItem) SetType(t Type)   { n.Type = t }
 func (n *Array) SetType(t Type)     { n.Type = t }
 func (n *ArrayItem) SetType(t Type) { n.Type = t }
-
-type DocumentType struct {
-	Source    *Document
-	ValueType Type // typically one of: MapType, ArrayType, ScalarType
-}
-type MapType struct {
-	Items []*MapItemType
-}
-type MapItemType struct {
-	Key          interface{} // usually a string
-	ValueType    Type
-	DefaultValue interface{}
-	Position     *filepos.Position
-}
-type ArrayType struct {
-	ItemsType Type
-}
-type ArrayItemType struct {
-	ValueType Type
-}
-type ScalarType struct {
-	Type interface{}
-}
-
-func (t *DocumentType) CheckAllows(item *MapItem) TypeCheck {
-	panic("Attempt to check if a MapItem is allowed as a value of a Document.")
-}
-func (m MapItemType) CheckAllows(item *MapItem) TypeCheck {
-	panic("Attempt to check if a MapItem is allowed as a value of a MapItem.")
-}
-func (a ArrayType) CheckAllows(item *MapItem) TypeCheck {
-	panic("Attempt to check if a MapItem is allowed as a value of an Array.")
-}
-func (a ArrayItemType) CheckAllows(item *MapItem) TypeCheck {
-	panic("Attempt to check if a MapItem is allowed as a value of an ArrayItemType.")
-}
-func (m ScalarType) CheckAllows(item *MapItem) TypeCheck {
-	panic("Attempt to check if a MapItem is allowed as a value of a ScalarType.")
-}
-
-func (t *DocumentType) AssignTypeTo(typeable Typeable) (chk TypeCheck) {
-	doc, ok := typeable.(*Document)
-	if !ok {
-		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &Document{}, typeable)}
-		return
-	}
-	typeable.SetType(t)
-	typeableChild, ok := doc.Value.(Typeable)
-	if ok {
-		if t.ValueType != nil {
-			childCheck := t.ValueType.AssignTypeTo(typeableChild)
-			chk.Violations = append(chk.Violations, childCheck.Violations...)
-		} else {
-			chk.Violations = []string{fmt.Sprintf("Expected node at %s to be %s, but was a %T", typeableChild.GetPosition().AsCompactString(), "nil", typeableChild)}
-		}
-	} else {
-
-	} // else, at a leaf
-	return
-}
-func (t *MapType) AssignTypeTo(typeable Typeable) (chk TypeCheck) {
-	mapNode, ok := typeable.(*Map)
-	if !ok {
-		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &Map{}, typeable)}
-		return
-	}
-	var foundKeys []interface{}
-	typeable.SetType(t)
-	for _, mapItem := range mapNode.Items {
-		for _, itemType := range t.Items {
-			if mapItem.Key == itemType.Key {
-				foundKeys = append(foundKeys, itemType.Key)
-				childCheck := itemType.AssignTypeTo(mapItem)
-				chk.Violations = append(chk.Violations, childCheck.Violations...)
-				break
-			}
-		}
-	}
-
-	t.applySchemaDefaults(foundKeys, chk, mapNode)
-	return
-}
-
-func (t *MapType) applySchemaDefaults(foundKeys []interface{}, chk TypeCheck, mapNode *Map) {
-	for _, item := range t.Items {
-		if contains(foundKeys, item.Key) {
-			continue
-		}
-
-		val := &MapItem{
-			Key:      item.Key,
-			Value:    item.DefaultValue,
-			Position: item.Position,
-		}
-		childCheck := item.AssignTypeTo(val)
-		chk.Violations = append(chk.Violations, childCheck.Violations...)
-		err := mapNode.AddValue(val)
-		if err != nil {
-			panic(fmt.Sprintf("Internal inconsistency: adding map item: %s", err))
-		}
-	}
-}
-
-func contains(haystack []interface{}, needle interface{}) bool {
-	for _, key := range haystack {
-		if key == needle {
-			return true
-		}
-	}
-	return false
-}
-
-func (t *MapItemType) AssignTypeTo(typeable Typeable) (chk TypeCheck) {
-	mapItem, ok := typeable.(*MapItem)
-	if !ok {
-		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &MapItem{}, typeable)}
-		return
-	}
-	typeable.SetType(t)
-	typeableValue, ok := mapItem.Value.(Typeable)
-	if ok {
-		childCheck := t.ValueType.AssignTypeTo(typeableValue)
-		chk.Violations = append(chk.Violations, childCheck.Violations...)
-	} // else, at a leaf
-	return
-}
-func (t *ArrayType) AssignTypeTo(typeable Typeable) (chk TypeCheck) {
-	arrayNode, ok := typeable.(*Array)
-	if !ok {
-		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &Array{}, typeable)}
-		return
-	}
-	typeable.SetType(t)
-	for _, arrayItem := range arrayNode.Items {
-		childCheck := t.ItemsType.AssignTypeTo(arrayItem)
-		chk.Violations = append(chk.Violations, childCheck.Violations...)
-	}
-	return
-}
-func (t ArrayItemType) AssignTypeTo(typeable Typeable) (chk TypeCheck) {
-	arrayItem, ok := typeable.(*ArrayItem)
-	if !ok {
-		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &ArrayItem{}, typeable)}
-		return
-	}
-	typeable.SetType(t)
-	typeableValue, ok := arrayItem.Value.(Typeable)
-	if ok {
-		childCheck := t.ValueType.AssignTypeTo(typeableValue)
-		chk.Violations = append(chk.Violations, childCheck.Violations...)
-	} // else, at a leaf
-	return
-}
-
-func (t *ScalarType) AssignTypeTo(typeable Typeable) (chk TypeCheck) {
-	switch t.Type.(type) {
-	case int:
-		typeable.SetType(t)
-	case string:
-		typeable.SetType(t)
-	default:
-		chk.Violations = []string{fmt.Sprintf("Expected node at %s to be a %T, but was a %T", typeable.GetPosition().AsCompactString(), &ScalarType{}, typeable)}
-	}
-	return
-}
-
-func (t *MapType) AllowsKey(key interface{}) bool {
-	for _, item := range t.Items {
-		if item.Key == key {
-			return true
-		}
-	}
-	return false
-}
-
-func (t *MapType) CheckAllows(item *MapItem) (chk TypeCheck) {
-	if !t.AllowsKey(item.Key) {
-		chk.Violations = append(chk.Violations, fmt.Sprintf("Map item '%s' at %s is not defined in schema", item.Key, item.Position.AsCompactString()))
-	}
-	return chk
-}

--- a/pkg/yamlmeta/type.go
+++ b/pkg/yamlmeta/type.go
@@ -8,8 +8,6 @@ import (
 )
 
 type Type interface {
-	// Checks whether `value` is permitted within (applicable to map types only)
-	CheckAllows(item *MapItem) TypeCheck
 	AssignTypeTo(typeable Typeable) TypeCheck
 	GetValueType() Type
 	CheckType(node TypeWithValues, prependErrorMessage string) TypeCheck


### PR DESCRIPTION
In this PR some refactoring was done to try to address comments on the commit original commit for the nullable schema annotation implementation.

https://github.com/vmware-tanzu/carvel-ytt/commit/66c26bad47cc0d30f4224c205f054a145793d6b0#r44427722
https://github.com/vmware-tanzu/carvel-ytt/commit/66c26bad47cc0d30f4224c205f054a145793d6b0#r44427606

In broad strokes, the annotation concept is now part of the schema types and instead of relying on magic strings we now use `structmeta.AnnotationName` and implemented a method that checks if a type can be nullable.