### PR TITLE
Remove Broken Schema Definition Link

### DIFF
--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -145,7 +145,7 @@ func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui cmdcore.PlainUI) Tem
 		if o.SchemaEnabled {
 			return TemplateOutput{Err: fmt.Errorf(
 				// TODO: Include documentation on defining a schema with this error when
-				// docs are ready. 
+				// docs are ready.
 				"Schema experiment flag was enabled but no schema document was provided",
 			)}
 		}

--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -144,7 +144,9 @@ func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui cmdcore.PlainUI) Tem
 	} else {
 		if o.SchemaEnabled {
 			return TemplateOutput{Err: fmt.Errorf(
-				"Schema experiment flag was enabled but no schema document was provided. (See this propsal for details on how to include a schema document: https://github.com/k14s/design-docs/blob/develop/ytt/001-schemas/README.md#defining-a-schema-document)",
+				// TODO: Include documentation on defining a schema with this error when
+				// docs are ready. 
+				"Schema experiment flag was enabled but no schema document was provided",
 			)}
 		}
 	}

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -713,7 +713,7 @@ rendered: true`
 		t.Fatalf("Expected RunWithFiles to fail with message about schema enabled but no schema provided, but was a success")
 	}
 
-	if !strings.Contains(out.Err.Error(), "Schema experiment flag was enabled but no schema document was provided.") {
+	if !strings.Contains(out.Err.Error(), "Schema experiment flag was enabled but no schema document was provided") {
 		t.Fatalf("Expected an error about schema enabled but no schema provided, but got: %v", out.Err.Error())
 	}
 }


### PR DESCRIPTION
Until docs are in more mature state, we should not provide a link with this error. Currently docs live in the design docs repo (https://github.com/k14s/design-docs/blob/develop/ytt/), but they are not up to date with the implementation and may cause confusion. A link should be added back when schema docs are better defined/have a more permanent location.