### PR TITLE
add docs site installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,44 @@
 
-* Install: Grab prebuilt binaries from the [Releases page](https://github.com/vmware-tanzu/carvel-ytt/releases)
+* Install: [See below](#installation), or grab prebuilt binaries from the [Releases page](https://github.com/vmware-tanzu/carvel-ytt/releases)
 * Play: Jump right in by trying out the [online playground](https://get-ytt.io/#playground)
 * For more information about annotations, data values, overlays and other features see [Docs](https://github.com/vmware-tanzu/carvel-ytt/tree/develop/docs) page
 * Slack: [#carvel in Kubernetes slack](https://slack.kubernetes.io/)
+
+## Installation
+
+### Via script (macOS or Linux)
+
+```terminal 
+$ wget -O- https://carvel.dev/install.sh | bash
+# or with curl...
+$ curl -L https://carvel.dev/install.sh | bash
+```
+
+### Via Homebrew (macOS or Linux)
+
+Based on <a href="https://github.com/vmware-tanzu/homebrew-carvel">github.com/vmware-tanzu/homebrew-carvel</a>
+
+```terminal
+$ brew tap vmware-tanzu/carvel
+$ brew install ytt kbld kapp imgpkg kwt vendir
+```
+
+### Specific version from a GitHub release
+    
+To download, click on one of the assets in a chosen [GitHub release](https://github.com/vmware-tanzu/carvel-ytt/releases), for example for 'ytt-darwin-amd64'.
+
+```terminal
+# Compare binary checksum against what's specified in the release notes
+# (if checksums do not match, binary was not successfully downloaded)
+$ shasum -a 256 ~/Downloads/ytt-darwin-amd64
+08b25d21675fdc77d4281c9bb74b5b36710cc091f30552830604459512f5744c   /Users/pivotal/Downloads/ytt-darwin-amd64
+# Move binary next to your other executables
+$ mv ~/Downloads/ytt-darwin-amd64 /usr/local/bin/ytt
+# Make binary executable
+$ chmod +x /usr/local/bin/ytt
+# Check its version
+$ ytt version
+```
 
 ## Overview
 


### PR DESCRIPTION
Hey folks, I didn't stumble across the docs site which mentions the homebrew tap until I'd done it the manual way. Hopefully this will make `ytt` marginally easier to install for those who don't find the full-form docs.