### PR TITLE
Make overlay error order deterministic

### DIFF
--- a/pkg/yttlibrary/overlay/match_annotation_expects_kwarg.go
+++ b/pkg/yttlibrary/overlay/match_annotation_expects_kwarg.go
@@ -5,6 +5,7 @@ package overlay
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -189,5 +190,6 @@ func (MatchAnnotationExpectsKwarg) formatPositions(pos []*filepos.Position) stri
 	for _, p := range pos {
 		lines = append(lines, p.AsCompactString())
 	}
+	sort.Strings(lines)
 	return " (lines: " + strings.Join(lines, ", ") + ")"
 }


### PR DESCRIPTION
Currently when ytt overlay hit an error, the error line orders are not deterministic. However many CI systems could make assumptions on the order of the error messages in test cases. Now sort the lines in alphabetical order to make it deterministic.