### PR TITLE
Surface intention of each Compiled Template test

### DIFF
--- a/pkg/template/compiled_template_test.go
+++ b/pkg/template/compiled_template_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/k14s/ytt/pkg/template"
 )
 
-func TestTemplatePlainStarlark(t *testing.T) {
+func TestEvalExecutesStarlarkAndReturnsGlobals(t *testing.T) {
 	data := `
 def hello():
   return "hello"
@@ -40,7 +40,30 @@ a = hello()
 	}
 }
 
-func TestTemplateIgnoreIndentationExceptContinuedLines(t *testing.T) {
+func TestEvalIgnoresIndentationInStarlark(t *testing.T) {
+	data := `
+		if True:
+a = "evaluated"
+		end
+`
+	instructions := template.NewInstructionSet()
+	compiledTemplate := template.NewCompiledTemplate(
+		"stdin", template.NewCodeFromBytes([]byte(data), instructions),
+		instructions, template.NewNodes(), template.EvaluationCtxDialects{})
+
+	loader := template.NewNoopCompiledTemplateLoader(compiledTemplate)
+	thread := &starlark.Thread{Name: "test", Load: loader.Load}
+
+	resultGlobals, _, err := compiledTemplate.Eval(thread, loader)
+	if err != nil {
+		t.Fatalf("Evaluating starlark template: %s", err)
+	}
+
+	if resultGlobals["a"] != starlark.String("evaluated") {
+		t.Fatalf("Expected variable 'a' to have been set, but was \"%#v\"", resultGlobals["a"])
+	}
+}
+func TestEvalPreservesIndentationOfContinuedLines(t *testing.T) {
 	data := `
 		if True:
 	multiline = "[\
@@ -65,7 +88,8 @@ func TestTemplateIgnoreIndentationExceptContinuedLines(t *testing.T) {
 	}
 }
 
-func TestLine1StarlarkError(t *testing.T) {
+// bug test: fixed by bc93b02
+func TestEvalReturnsErrorEvenWhenFailsToCompileOnFirstLine(t *testing.T) {
 	data := `badsyntax`
 	instructions := template.NewInstructionSet()
 	compiledTemplate := template.NewCompiledTemplate(


### PR DESCRIPTION
- output from a Tech Forum "mob"
- at the time given there are multiple exported functions, fingered
  `Eval()` explicitly to make more plain what part of the overall
  interface is being covered by these tests.
- split-out the test about preserving indentation of continued lines
  as the existing test was making multiple and seperable assertions.

Signed-off-by: Cari Dean <cdean@pivotal.io>
Signed-off-by: Aaron Hurley <ahurley@pivotal.io>
Signed-off-by: Dennis Leon <leonde@vmware.com>
Signed-off-by: Steven Locke <slocke@pivotal.io>
Signed-off-by: Joao Pereira <joaod@vmware.com>