### PR TITLE
Adding Check for if Issue Closed Timestamp != Comment Created Timestamp

### DIFF
--- a/.github/workflows/closed-issue-comment.yml
+++ b/.github/workflows/closed-issue-comment.yml
@@ -1,7 +1,5 @@
-name: Closed issue labeling
+name: Closed issue comment labeling
 on:
-  issues:
-    types: ['reopened']
   issue_comment:
     types: ['created']
 
@@ -10,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: docker://k8slt/closed-issue-label-action@sha256:84360552559e0de4dfaaeefcf1ea0a1070a6250621f98539caf3eaad9395feb7
-        if: github.event_name == 'issues' || ( github.event_name == 'issue_comment' && github.event.issue.state == 'closed') && (github.event.issue.closed_at != github.event.comment.created_at)
+        if: github.event.issue.state == 'closed' && github.event.issue.closed_at != github.event.comment.created_at
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ignore-comments: true

--- a/.github/workflows/closed-issue-label.yml
+++ b/.github/workflows/closed-issue-label.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: docker://k8slt/closed-issue-label-action@sha256:84360552559e0de4dfaaeefcf1ea0a1070a6250621f98539caf3eaad9395feb7
-        if: github.event_name == 'issues' || ( github.event_name == 'issue_comment' && github.event.issue.state == 'closed')
+        if: github.event_name == 'issues' || ( github.event_name == 'issue_comment' && github.event.issue.state == 'closed') && (github.event.issue.closed_at != github.event.comment.created_at)
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ignore-comments: true

--- a/.github/workflows/reopen-issue.yml
+++ b/.github/workflows/reopen-issue.yml
@@ -1,0 +1,14 @@
+name: Reopened issue labeling
+on:
+  issues:
+    types: ['reopened']
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://k8slt/closed-issue-label-action@sha256:84360552559e0de4dfaaeefcf1ea0a1070a6250621f98539caf3eaad9395feb7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: true
+          default-labels: '["carvel-triage"]'


### PR DESCRIPTION
Adding a check to prevent the `carvel-triage` label from being added when an issue is closed with a comment.

Issues being closed with a comment will have the same time stamp for both the issue closing/comment, so this check makes sure the time stamps are different (i.e. the comment happened after the issue was closed so the carvel-triage label should be reapplied).