### PR TITLE
Improve Non Yaml Warning Msg

### DIFF
--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -35,10 +35,9 @@ type TemplateInput struct {
 }
 
 type TemplateOutput struct {
-	Files     []files.OutputFile
-	DocSet    *yamlmeta.DocumentSet
-	Err       error
-	FileMarks []string
+	Files  []files.OutputFile
+	DocSet *yamlmeta.DocumentSet
+	Err    error
 }
 
 type FileSource interface {
@@ -96,8 +95,6 @@ func (o *TemplateOptions) Run() error {
 	}
 
 	out := o.RunWithFiles(in, ui)
-	out.FileMarks = o.FileMarksOpts.fileMarks
-
 	return o.pickSource(srcs, func(s FileSource) bool { return s.HasOutput() }).Output(out)
 }
 

--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -35,9 +35,10 @@ type TemplateInput struct {
 }
 
 type TemplateOutput struct {
-	Files  []files.OutputFile
-	DocSet *yamlmeta.DocumentSet
-	Err    error
+	Files     []files.OutputFile
+	DocSet    *yamlmeta.DocumentSet
+	Err       error
+	FileMarks []string
 }
 
 type FileSource interface {
@@ -69,8 +70,6 @@ func NewCmd(o *TemplateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&o.InspectFiles, "files-inspect", false, "Inspect files")
 	cmd.Flags().BoolVar(&o.SchemaEnabled, "enable-experiment-schema", false, "Enable experimental schema features")
 
-	o.RegularFilesSourceOpts.fileMarks = o.FileMarksOpts.fileMarks
-
 	o.BulkFilesSourceOpts.Set(cmd)
 	o.RegularFilesSourceOpts.Set(cmd)
 	o.FileMarksOpts.Set(cmd)
@@ -97,6 +96,7 @@ func (o *TemplateOptions) Run() error {
 	}
 
 	out := o.RunWithFiles(in, ui)
+	out.FileMarks = o.FileMarksOpts.fileMarks
 
 	return o.pickSource(srcs, func(s FileSource) bool { return s.HasOutput() }).Output(out)
 }

--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -69,6 +69,8 @@ func NewCmd(o *TemplateOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&o.InspectFiles, "files-inspect", false, "Inspect files")
 	cmd.Flags().BoolVar(&o.SchemaEnabled, "enable-experiment-schema", false, "Enable experimental schema features")
 
+	o.RegularFilesSourceOpts.fileMarks = o.FileMarksOpts.fileMarks
+
 	o.BulkFilesSourceOpts.Set(cmd)
 	o.RegularFilesSourceOpts.Set(cmd)
 	o.FileMarksOpts.Set(cmd)

--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -840,24 +840,23 @@ organization=Acme Widgets Inc.`)
 
 	testIniFile, err := createTempFileWithContent(iniData, "ini.txt")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testIniFile.Name())
 
-	expectedStdErr := fmt.Sprintf(`Warning: There are templates marked for output that are not included in this output.
-	Non-YAML templates are not rendered to standard output.
-	If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
-	Non-YAML files are: [%s]`, filepath.Base(testIniFile.Name()))
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+Non-YAML files are: [%s]`+"\n", filepath.Base(testIniFile.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdErr.Name())
 
 	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdOut.Name())
 
@@ -876,20 +875,23 @@ organization=Acme Widgets Inc.`)
 	cmd.SilenceUsage = true
 
 	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Unexpected error running command: %v", err)
+	}
 	resetStdOutAndErr()
 
 	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stderr to not fail")
+		t.Fatalf("Expected reading stderr to not fail: %v", err)
 	}
 
 	if string(stdErrContents) != expectedStdErr {
-		t.Fatalf("Expected std err to have specific warning message, but was: >>>%s<<<", stdErrContents)
+		t.Fatalf("Expected std err to be >>>%s<<<\nBut was: >>>%s<<<", expectedStdErr, stdErrContents)
 	}
 
 	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stdout to not fail")
+		t.Fatalf("Expected reading stdout to not fail: %v", err)
 	}
 
 	if string(stdOutContents) != "" {
@@ -897,26 +899,26 @@ organization=Acme Widgets Inc.`)
 	}
 }
 
-func TestFileMarkedAsAYamlFilesDoesNotSuggestsUsingOutputFlags(t *testing.T) {
+func TestFileMarkedAsAYamlFileDoesNotSuggestsUsingOutputFlags(t *testing.T) {
 	expectedStdErr := ""
 	expectedStdOut := `a: b
 `
 
 	testYamlFile, err := createTempFileWithContent([]byte(expectedStdOut), "txt")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testYamlFile.Name())
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdErr.Name())
 
 	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdOut.Name())
 
@@ -935,11 +937,14 @@ func TestFileMarkedAsAYamlFilesDoesNotSuggestsUsingOutputFlags(t *testing.T) {
 	cmd.SilenceUsage = true
 
 	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Unexpected error running command: %v", err)
+	}
 	resetStdOutAndErr()
 
 	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stderr to not fail")
+		t.Fatalf("Expected reading stderr to not fail: %v", err)
 	}
 
 	if string(stdErrContents) != expectedStdErr {
@@ -948,7 +953,7 @@ func TestFileMarkedAsAYamlFilesDoesNotSuggestsUsingOutputFlags(t *testing.T) {
 
 	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stdout to not fail")
+		t.Fatalf("Expected reading stdout to not fail: %v", err)
 	}
 
 	if string(stdOutContents) != expectedStdOut {
@@ -964,30 +969,29 @@ organization=Acme Widgets Inc.`)
 
 	testIniFile1, err := createTempFileWithContent(iniData, "ini.txt")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testIniFile1.Name())
 
 	testIniFile2, err := createTempFileWithContent(iniData, "ini.txt")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testIniFile2.Name())
 
-	expectedStdErr := fmt.Sprintf(`Warning: There are templates marked for output that are not included in this output.
-	Non-YAML templates are not rendered to standard output.
-	If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
-	Non-YAML files are: [%s, %s]`, filepath.Base(testIniFile1.Name()), filepath.Base(testIniFile2.Name()))
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+Non-YAML files are: [%s, %s]`+"\n", filepath.Base(testIniFile1.Name()), filepath.Base(testIniFile2.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdErr.Name())
 
 	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdOut.Name())
 
@@ -1006,20 +1010,23 @@ organization=Acme Widgets Inc.`)
 	cmd.SilenceUsage = true
 
 	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Unexpected error running command: %v", err)
+	}
 	resetStdOutAndErr()
 
 	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stderr to not fail")
+		t.Fatalf("Expected reading stderr to not fail: %v", err)
 	}
 
 	if string(stdErrContents) != expectedStdErr {
-		t.Fatalf("Expected std err to have specific warning message, but was: >>>%s<<<", stdErrContents)
+		t.Fatalf("Expected std err to be >>>%s<<<\nBut was: >>>%s<<<", expectedStdErr, stdErrContents)
 	}
 
 	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stdout to not fail")
+		t.Fatalf("Expected reading stdout to not fail: %v", err)
 	}
 
 	if string(stdOutContents) != "" {
@@ -1037,30 +1044,29 @@ organization=Acme Widgets Inc.`)
 `
 	testIniFile, err := createTempFileWithContent(iniData, "ini.txt")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testIniFile.Name())
 
 	testYamlFile, err := createTempFileWithContent(yamlData, "yml")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testYamlFile.Name())
 
-	expectedStdErr := fmt.Sprintf(`Warning: There are templates marked for output that are not included in this output.
-	Non-YAML templates are not rendered to standard output.
-	If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
-	Non-YAML files are: [%s]`, filepath.Base(testIniFile.Name()))
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+Non-YAML files are: [%s]`+"\n", filepath.Base(testIniFile.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdErr.Name())
 
 	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdOut.Name())
 
@@ -1079,20 +1085,23 @@ organization=Acme Widgets Inc.`)
 	cmd.SilenceUsage = true
 
 	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Unexpected error running command: %v", err)
+	}
 	resetStdOutAndErr()
 
 	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stderr to not fail")
+		t.Fatalf("Expected reading stderr to not fail: %v", err)
 	}
 
 	if string(stdErrContents) != expectedStdErr {
-		t.Fatalf("Expected std err to have specific warning message, but was: >>>%s<<<", stdErrContents)
+		t.Fatalf("Expected std err to be >>>%s<<<\nBut was: >>>%s<<<", expectedStdErr, stdErrContents)
 	}
 
 	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stdout to not fail")
+		t.Fatalf("Expected reading stdout to not fail: %v", err)
 	}
 
 	if string(stdOutContents) != expectedStdOut {
@@ -1109,13 +1118,13 @@ organization=Acme Widgets Inc.`)
 
 	testIniFile, err := createTempFileWithContent(iniData, "ini.txt")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testIniFile.Name())
 
 	testYamlFile, err := createTempFileWithContent(yamlData, "yml")
 	if err != nil {
-		t.Fatalf("Expected writing to test file not to fail")
+		t.Fatalf("Expected writing to test file not to fail: %v", err)
 	}
 	defer os.Remove(testYamlFile.Name())
 
@@ -1131,13 +1140,13 @@ organization=Acme Widgets Inc.`)
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdErr.Name())
 
 	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
 	if err != nil {
-		t.Fatalf("Expected creating a temp file to not fail")
+		t.Fatalf("Expected creating a temp file to not fail: %v", err)
 	}
 	defer os.Remove(fakeStdOut.Name())
 
@@ -1156,24 +1165,27 @@ organization=Acme Widgets Inc.`)
 	cmd.SilenceUsage = true
 
 	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Unexpected error running command: %v", err)
+	}
 	resetStdOutAndErr()
 
 	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stderr to not fail")
+		t.Fatalf("Expected reading stderr to not fail: %v", err)
 	}
 
 	if string(stdErrContents) != "" {
-		t.Fatalf("Expected std err to be empty, but was: >>>%s<<<", string(stdErrContents))
+		t.Fatalf("Expected std err to be empty, but was: >>>%s<<<", stdErrContents)
 	}
 
 	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
 	if err != nil {
-		t.Fatalf("Expected reading stdout to not fail")
+		t.Fatalf("Expected reading stdout to not fail: %v", err)
 	}
 
 	if string(stdOutContents) != expectedStdOut {
-		t.Fatalf("Expected std out to be >>>>%s<<<<\nbut was: >>>%s<<<", expectedStdOut, stdOutContents)
+		t.Fatalf("Expected std out to be >>>%s<<<\nBut was: >>>%s<<<", expectedStdOut, stdOutContents)
 	}
 }
 
@@ -1189,5 +1201,3 @@ func createTempFileWithContent(yamlData []byte, suffix string) (*os.File, error)
 	}
 	return testYamlFile, err
 }
-
-// what about bulk files --bulk-file-in? should they have a warning msg too?

--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -4,7 +4,12 @@
 package template_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	cmdcore "github.com/k14s/ytt/pkg/cmd/core"
@@ -826,3 +831,363 @@ func TestLoadYTTModuleFailEarly(t *testing.T) {
 		t.Fatalf("Expected RunWithFiles to fail with error, but was '%s'", out.Err.Error())
 	}
 }
+
+func TestNonYamlFilesSuggestsUsingOutputFlags(t *testing.T) {
+	iniData := []byte(`
+[owner]
+name=John Doe
+organization=Acme Widgets Inc.`)
+
+	testIniFile, err := createTempFileWithContent(iniData, "ini.txt")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testIniFile.Name())
+
+	expectedStdErr := fmt.Sprintf(`Warning: There are templates marked for output that are not included in this output.
+	Non-YAML templates are not rendered to standard output.
+	If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	Non-YAML files are: [%s]`, filepath.Base(testIniFile.Name()))
+
+	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdErr.Name())
+
+	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdOut.Name())
+
+	os.Stdout = fakeStdOut
+	os.Stderr = fakeStdErr
+
+	resetStdOutAndErr := func() {
+		os.Stdout = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+		os.Stderr = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+	}
+	defer resetStdOutAndErr()
+
+	templateOptions := &cmdtpl.TemplateOptions{}
+	cmd := cmdtpl.NewCmd(templateOptions)
+	cmd.SetArgs([]string{"-f", testIniFile.Name()})
+	cmd.SilenceUsage = true
+
+	err = cmd.Execute()
+	resetStdOutAndErr()
+
+	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stderr to not fail")
+	}
+
+	if string(stdErrContents) != expectedStdErr {
+		t.Fatalf("Expected std err to have specific warning message, but was: >>>%s<<<", stdErrContents)
+	}
+
+	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stdout to not fail")
+	}
+
+	if string(stdOutContents) != "" {
+		t.Fatalf("Expected std out to be empty, but was: >>>%s<<<", stdOutContents)
+	}
+}
+
+func TestFileMarkedAsAYamlFilesDoesNotSuggestsUsingOutputFlags(t *testing.T) {
+	expectedStdErr := ""
+	expectedStdOut := `a: b
+`
+
+	testYamlFile, err := createTempFileWithContent([]byte(expectedStdOut), "txt")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testYamlFile.Name())
+
+	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdErr.Name())
+
+	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdOut.Name())
+
+	os.Stdout = fakeStdOut
+	os.Stderr = fakeStdErr
+
+	resetStdOutAndErr := func() {
+		os.Stdout = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+		os.Stderr = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+	}
+	defer resetStdOutAndErr()
+
+	templateOptions := &cmdtpl.TemplateOptions{}
+	cmd := cmdtpl.NewCmd(templateOptions)
+	cmd.SetArgs([]string{"-f", testYamlFile.Name(), "--file-mark", fmt.Sprintf("%s:type=yaml-plain", filepath.Base(testYamlFile.Name()))})
+	cmd.SilenceUsage = true
+
+	err = cmd.Execute()
+	resetStdOutAndErr()
+
+	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stderr to not fail")
+	}
+
+	if string(stdErrContents) != expectedStdErr {
+		t.Fatalf("Expected std err to have >>>%s<<< \n warning message, but was: >>>%s<<<", expectedStdErr, stdErrContents)
+	}
+
+	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stdout to not fail")
+	}
+
+	if string(stdOutContents) != expectedStdOut {
+		t.Fatalf("Expected std out to be empty, but was: >>>%s<<<", stdOutContents)
+	}
+}
+
+func TestMultipleNonYamlFilesSuggestsUsingOutputFlags(t *testing.T) {
+	iniData := []byte(`
+[owner]
+name=John Doe
+organization=Acme Widgets Inc.`)
+
+	testIniFile1, err := createTempFileWithContent(iniData, "ini.txt")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testIniFile1.Name())
+
+	testIniFile2, err := createTempFileWithContent(iniData, "ini.txt")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testIniFile2.Name())
+
+	expectedStdErr := fmt.Sprintf(`Warning: There are templates marked for output that are not included in this output.
+	Non-YAML templates are not rendered to standard output.
+	If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	Non-YAML files are: [%s, %s]`, filepath.Base(testIniFile1.Name()), filepath.Base(testIniFile2.Name()))
+
+	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdErr.Name())
+
+	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdOut.Name())
+
+	os.Stdout = fakeStdOut
+	os.Stderr = fakeStdErr
+
+	resetStdOutAndErr := func() {
+		os.Stdout = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+		os.Stderr = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+	}
+	defer resetStdOutAndErr()
+
+	templateOptions := &cmdtpl.TemplateOptions{}
+	cmd := cmdtpl.NewCmd(templateOptions)
+	cmd.SetArgs([]string{"-f", testIniFile1.Name(), "-f", testIniFile2.Name()})
+	cmd.SilenceUsage = true
+
+	err = cmd.Execute()
+	resetStdOutAndErr()
+
+	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stderr to not fail")
+	}
+
+	if string(stdErrContents) != expectedStdErr {
+		t.Fatalf("Expected std err to have specific warning message, but was: >>>%s<<<", stdErrContents)
+	}
+
+	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stdout to not fail")
+	}
+
+	if string(stdOutContents) != "" {
+		t.Fatalf("Expected std out to be empty, but was: >>>%s<<<", stdOutContents)
+	}
+}
+
+func TestNonYamlAndYamlFilesSuggestsUsingOutputFlags(t *testing.T) {
+	iniData := []byte(`
+[owner]
+name=John Doe
+organization=Acme Widgets Inc.`)
+	yamlData := []byte(`foo: bar`)
+	expectedStdOut := `foo: bar
+`
+	testIniFile, err := createTempFileWithContent(iniData, "ini.txt")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testIniFile.Name())
+
+	testYamlFile, err := createTempFileWithContent(yamlData, "yml")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testYamlFile.Name())
+
+	expectedStdErr := fmt.Sprintf(`Warning: There are templates marked for output that are not included in this output.
+	Non-YAML templates are not rendered to standard output.
+	If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	Non-YAML files are: [%s]`, filepath.Base(testIniFile.Name()))
+
+	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdErr.Name())
+
+	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdOut.Name())
+
+	os.Stdout = fakeStdOut
+	os.Stderr = fakeStdErr
+
+	resetStdOutAndErr := func() {
+		os.Stdout = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+		os.Stderr = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+	}
+	defer resetStdOutAndErr()
+
+	templateOptions := &cmdtpl.TemplateOptions{}
+	cmd := cmdtpl.NewCmd(templateOptions)
+	cmd.SetArgs([]string{"-f", testYamlFile.Name(), "-f", testIniFile.Name()})
+	cmd.SilenceUsage = true
+
+	err = cmd.Execute()
+	resetStdOutAndErr()
+
+	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stderr to not fail")
+	}
+
+	if string(stdErrContents) != expectedStdErr {
+		t.Fatalf("Expected std err to have specific warning message, but was: >>>%s<<<", stdErrContents)
+	}
+
+	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stdout to not fail")
+	}
+
+	if string(stdOutContents) != expectedStdOut {
+		t.Fatalf("Expected std out to be empty, but was: >>>%s<<<", stdOutContents)
+	}
+}
+
+func TestNonYamlUsingOutputFlags(t *testing.T) {
+	iniData := []byte(`
+[owner]
+name=John Doe
+organization=Acme Widgets Inc.`)
+	yamlData := []byte(`foo: bar`)
+
+	testIniFile, err := createTempFileWithContent(iniData, "ini.txt")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testIniFile.Name())
+
+	testYamlFile, err := createTempFileWithContent(yamlData, "yml")
+	if err != nil {
+		t.Fatalf("Expected writing to test file not to fail")
+	}
+	defer os.Remove(testYamlFile.Name())
+
+	outputDir, err := ioutil.TempDir(os.TempDir(), "fakedir")
+	if err != nil {
+		t.Fatalf("Expected creating a temp dir to not fail: %v", err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	iniFilePath := filepath.Join(outputDir, filepath.Base(testIniFile.Name()))
+	yamlFilePath := filepath.Join(outputDir, filepath.Base(testYamlFile.Name()))
+	expectedStdOut := `creating: ` + iniFilePath + "\n" + `creating: ` + yamlFilePath + "\n"
+
+	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdErr.Name())
+
+	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		t.Fatalf("Expected creating a temp file to not fail")
+	}
+	defer os.Remove(fakeStdOut.Name())
+
+	os.Stdout = fakeStdOut
+	os.Stderr = fakeStdErr
+
+	resetStdOutAndErr := func() {
+		os.Stdout = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+		os.Stderr = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+	}
+	defer resetStdOutAndErr()
+
+	templateOptions := &cmdtpl.TemplateOptions{}
+	cmd := cmdtpl.NewCmd(templateOptions)
+	cmd.SetArgs([]string{"-f", testYamlFile.Name(), "-f", testIniFile.Name(), "--output-files", outputDir})
+	cmd.SilenceUsage = true
+
+	err = cmd.Execute()
+	resetStdOutAndErr()
+
+	stdErrContents, err := ioutil.ReadFile(fakeStdErr.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stderr to not fail")
+	}
+
+	if string(stdErrContents) != "" {
+		t.Fatalf("Expected std err to be empty, but was: >>>%s<<<", string(stdErrContents))
+	}
+
+	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
+	if err != nil {
+		t.Fatalf("Expected reading stdout to not fail")
+	}
+
+	if string(stdOutContents) != expectedStdOut {
+		t.Fatalf("Expected std out to be >>>>%s<<<<\nbut was: >>>%s<<<", expectedStdOut, stdOutContents)
+	}
+}
+
+func createTempFileWithContent(yamlData []byte, suffix string) (*os.File, error) {
+	testYamlFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("*test-yaml.%s", suffix))
+	if err != nil {
+		return nil, err
+	}
+
+	err = ioutil.WriteFile(testYamlFile.Name(), yamlData, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	return testYamlFile, err
+}
+
+// what about bulk files --bulk-file-in? should they have a warning msg too?

--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -844,8 +844,8 @@ organization=Acme Widgets Inc.`)
 	}
 	defer os.Remove(testIniFile.Name())
 
-	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
-If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
 Non-YAML files are: [%s]`+"\n", filepath.Base(testIniFile.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
@@ -900,10 +900,8 @@ Non-YAML files are: [%s]`+"\n", filepath.Base(testIniFile.Name()))
 }
 
 func TestFileMarkedAsAYamlFileDoesNotSuggestsUsingOutputFlags(t *testing.T) {
-	expectedStdErr := ""
 	expectedStdOut := `a: b
 `
-
 	testYamlFile, err := createTempFileWithContent([]byte(expectedStdOut), "txt")
 	if err != nil {
 		t.Fatalf("Expected writing to test file not to fail: %v", err)
@@ -947,8 +945,8 @@ func TestFileMarkedAsAYamlFileDoesNotSuggestsUsingOutputFlags(t *testing.T) {
 		t.Fatalf("Expected reading stderr to not fail: %v", err)
 	}
 
-	if string(stdErrContents) != expectedStdErr {
-		t.Fatalf("Expected std err to have >>>%s<<< \n warning message, but was: >>>%s<<<", expectedStdErr, stdErrContents)
+	if string(stdErrContents) != "" {
+		t.Fatalf("Expected std err to be empty but was: >>>%s<<<", stdErrContents)
 	}
 
 	stdOutContents, err := ioutil.ReadFile(fakeStdOut.Name())
@@ -1044,8 +1042,8 @@ func TestFileMarkedAsExclusiveForOutputFileSuggestsUsingOutputFlags(t *testing.T
 	}
 	defer os.Remove(testFile.Name())
 
-	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
-If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
 Non-YAML files are: [%s]`+"\n", filepath.Base(testFile.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
@@ -1121,8 +1119,8 @@ organization=Acme Widgets Inc.`)
 	}
 	defer os.Remove(testIniFile2.Name())
 
-	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
-If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
 Non-YAML files are: [%s, %s]`+"\n", filepath.Base(testIniFile1.Name()), filepath.Base(testIniFile2.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
@@ -1196,8 +1194,8 @@ organization=Acme Widgets Inc.`)
 	}
 	defer os.Remove(testYamlFile.Name())
 
-	expectedStdErr := fmt.Sprintf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
-If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+	expectedStdErr := fmt.Sprintf("\n"+`Warning: Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
 Non-YAML files are: [%s]`+"\n", filepath.Base(testIniFile.Name()))
 
 	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")

--- a/pkg/cmd/template/file_marks.go
+++ b/pkg/cmd/template/file_marks.go
@@ -142,12 +142,3 @@ func (s *FileMarksOpts) clearNils(input []*files.File) []*files.File {
 	}
 	return output
 }
-
-func getFileMarksAsKeyValues(fileMarkStrings []string) map[string]string {
-	fileMarksKV := make(map[string]string)
-	for _, mark := range fileMarkStrings {
-		pieces := strings.SplitN(mark, ":", 2)
-		fileMarksKV[pieces[0]] = pieces[1]
-	}
-	return fileMarksKV
-}

--- a/pkg/cmd/template/file_marks.go
+++ b/pkg/cmd/template/file_marks.go
@@ -142,3 +142,12 @@ func (s *FileMarksOpts) clearNils(input []*files.File) []*files.File {
 	}
 	return output
 }
+
+func getFileMarksAsKeyValues(fileMarkStrings []string) map[string]string {
+	fileMarksKV := make(map[string]string)
+	for _, mark := range fileMarkStrings {
+		pieces := strings.SplitN(mark, ":", 2)
+		fileMarksKV[pieces[0]] = pieces[1]
+	}
+	return fileMarksKV
+}

--- a/pkg/cmd/template/regular_input.go
+++ b/pkg/cmd/template/regular_input.go
@@ -6,7 +6,6 @@ package template
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	cmdcore "github.com/k14s/ytt/pkg/cmd/core"
 	"github.com/k14s/ytt/pkg/files"
@@ -79,7 +78,7 @@ func (s *RegularFilesSource) Output(out TemplateOutput) error {
 		return files.NewOutputDirectory(s.opts.outputFiles, out.Files, s.ui).WriteFiles()
 	default:
 		for _, file := range out.Files {
-			if file.MarkedType != files.TypeYAML {
+			if file.Type() != files.TypeYAML {
 				nonYamlFileNames = append(nonYamlFileNames, file.RelativePath())
 			}
 		}
@@ -109,9 +108,8 @@ func (s *RegularFilesSource) Output(out TemplateOutput) error {
 	s.ui.Printf("%s", combinedDocBytes) // no newline
 
 	if len(nonYamlFileNames) > 0 {
-		s.ui.Warnf("\n"+`Warning: Non-YAML templates are not rendered to standard output.
-If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
-Non-YAML files are: [%s]`+"\n", strings.Join(nonYamlFileNames, ", "))
+		s.ui.Warnf("\n" + `Warning: Found Non-YAML templates in input. Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.` + "\n")
 	}
 	return nil
 }

--- a/pkg/cmd/template/regular_input.go
+++ b/pkg/cmd/template/regular_input.go
@@ -78,14 +78,9 @@ func (s *RegularFilesSource) Output(out TemplateOutput) error {
 	case len(s.opts.outputFiles) > 0:
 		return files.NewOutputDirectory(s.opts.outputFiles, out.Files, s.ui).WriteFiles()
 	default:
-		fileMarkMap := getFileMarksAsKeyValues(out.FileMarks)
 		for _, file := range out.Files {
-			noYAMLFileExt := !strings.Contains(file.RelativePath(), ".yml") && !strings.Contains(file.RelativePath(), ".yaml")
-			if noYAMLFileExt {
-				fileMarkType := fileMarkMap[file.RelativePath()]
-				if fileMarkType != "type=yaml-plain" && fileMarkType != "type=yaml-template" {
-					nonYamlFileNames = append(nonYamlFileNames, file.RelativePath())
-				}
+			if file.MarkedType != files.TypeYAML {
+				nonYamlFileNames = append(nonYamlFileNames, file.RelativePath())
 			}
 		}
 	}
@@ -114,8 +109,8 @@ func (s *RegularFilesSource) Output(out TemplateOutput) error {
 	s.ui.Printf("%s", combinedDocBytes) // no newline
 
 	if len(nonYamlFileNames) > 0 {
-		s.ui.Warnf("\n"+`Warning: There are templates marked for output that are not included in this output. Non-YAML templates are not rendered to standard output.
-If you want to include those results, use the --output-directory or --dangerous-emptied-output-directory flag.
+		s.ui.Warnf("\n"+`Warning: Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
 Non-YAML files are: [%s]`+"\n", strings.Join(nonYamlFileNames, ", "))
 	}
 	return nil

--- a/pkg/cmd/template/regular_input_test.go
+++ b/pkg/cmd/template/regular_input_test.go
@@ -1,0 +1,109 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+
+	cmdcore "github.com/k14s/ytt/pkg/cmd/core"
+	"github.com/k14s/ytt/pkg/cmd/template"
+	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
+	"github.com/k14s/ytt/pkg/files"
+	"github.com/spf13/cobra"
+)
+
+func Test_Non_YAML_Files_With_No_Output_Flag_Produces_Warning(t *testing.T) {
+	iniData := []byte(`
+[owner]
+name=John Doe
+organization=Acme Widgets Inc.`)
+	yamlData := []byte(`foo: bar`)
+
+	expectedStdErr := fmt.Sprintf("\n" + `Warning: Found Non-YAML templates in input. Non-YAML templates are not rendered to standard output.
+If you want to include those results, use the --output-files or --dangerous-emptied-output-directory flag.
+`)
+	expectedStdOut := "foo: bar\n"
+
+	filesToProcess := []*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("ini.txt", iniData)),
+		files.MustNewFileFromSource(files.NewBytesSource("foo.yaml", yamlData)),
+	}
+
+	ui := cmdcore.NewPlainUI(false)
+	opts := cmdtpl.NewOptions()
+	rfsOpts := template.RegularFilesSourceOpts{}
+	rfsOpts.Set(&cobra.Command{})
+	rfs := template.NewRegularFilesSource(rfsOpts, ui)
+
+	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	if out.Err != nil {
+		t.Fatalf("An unexpected error occurred: %v", out.Err)
+	}
+
+	fakeStdOut, fakeStdErr, err := redirectStdOutAndErr()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %v", err)
+	}
+	defer os.Remove(fakeStdErr.Name())
+	defer os.Remove(fakeStdOut.Name())
+	defer restoreStdOutAndErr()
+
+	err = rfs.Output(out)
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %v", err)
+	}
+	restoreStdOutAndErr()
+
+	err = assertStdOutAndStdErr(fakeStdOut, fakeStdErr, expectedStdOut, expectedStdErr)
+	if err != nil {
+		t.Fatalf("Assertion failed:\n%v", err)
+	}
+}
+
+func redirectStdOutAndErr() (*os.File, *os.File, error) {
+	fakeStdErr, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fakeStdOut, err := ioutil.TempFile(os.TempDir(), "fakedev")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	os.Stdout = fakeStdOut
+	os.Stderr = fakeStdErr
+
+	return fakeStdOut, fakeStdErr, nil
+}
+
+func restoreStdOutAndErr() {
+	os.Stdout = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+	os.Stderr = os.NewFile(uintptr(syscall.Stderr), "/dev/stderr")
+}
+
+func assertStdOutAndStdErr(stdout, stderr *os.File, expectedOut, expectedErr string) error {
+	stdErrContents, err := ioutil.ReadFile(stderr.Name())
+	if err != nil {
+		return err
+	}
+
+	if string(stdErrContents) != expectedErr {
+		return fmt.Errorf("Expected std err to be >>>%s<<<\nBut was: >>>%s<<<", expectedErr, stdErrContents)
+	}
+
+	stdOutContents, err := ioutil.ReadFile(stdout.Name())
+	if err != nil {
+		return fmt.Errorf("Expected reading stdout to not fail: %v", err)
+	}
+
+	if string(stdOutContents) != expectedOut {
+		return fmt.Errorf("Expected std out to be >>>%s<<<, but was: >>>%s<<<", expectedOut, stdOutContents)
+	}
+	return nil
+}

--- a/pkg/files/output_file.go
+++ b/pkg/files/output_file.go
@@ -11,10 +11,11 @@ import (
 type OutputFile struct {
 	relativePath string
 	data         []byte
+	MarkedType   Type
 }
 
-func NewOutputFile(relativePath string, data []byte) OutputFile {
-	return OutputFile{relativePath, data}
+func NewOutputFile(relativePath string, data []byte, markedType Type) OutputFile {
+	return OutputFile{relativePath, data, markedType}
 }
 
 func (f OutputFile) RelativePath() string { return f.relativePath }

--- a/pkg/files/output_file.go
+++ b/pkg/files/output_file.go
@@ -11,7 +11,7 @@ import (
 type OutputFile struct {
 	relativePath string
 	data         []byte
-	MarkedType   Type
+	markedType   Type
 }
 
 func NewOutputFile(relativePath string, data []byte, markedType Type) OutputFile {
@@ -23,6 +23,10 @@ func (f OutputFile) Bytes() []byte        { return f.data }
 
 func (f OutputFile) Path(dirPath string) string {
 	return filepath.Join(dirPath, f.relativePath)
+}
+
+func (f OutputFile) Type() Type {
+	return f.markedType
 }
 
 func (f OutputFile) Create(dirPath string) error {

--- a/pkg/workspace/library_loader.go
+++ b/pkg/workspace/library_loader.go
@@ -154,7 +154,7 @@ func (ll *LibraryLoader) Eval(values *DataValues, libraryValues []*DataValues) (
 		}
 
 		ll.ui.Debugf("### %s result\n%s", fileInLib.RelativePath(), resultDocBytes)
-		result.Files = append(result.Files, files.NewOutputFile(fileInLib.RelativePath(), resultDocBytes))
+		result.Files = append(result.Files, files.NewOutputFile(fileInLib.RelativePath(), resultDocBytes, fileInLib.File.Type()))
 	}
 
 	return result, nil
@@ -193,7 +193,7 @@ func (ll *LibraryLoader) eval(values *DataValues, libraryValues []*DataValues) (
 				resultStr := resultVal.AsString()
 
 				ll.ui.Debugf("### %s result\n%s", fileInLib.RelativePath(), resultStr)
-				outputFiles = append(outputFiles, files.NewOutputFile(fileInLib.RelativePath(), []byte(resultStr)))
+				outputFiles = append(outputFiles, files.NewOutputFile(fileInLib.RelativePath(), []byte(resultStr), fileInLib.File.Type()))
 
 			default:
 				return nil, nil, nil, fmt.Errorf("Unknown file type")


### PR DESCRIPTION
Closes #132 

This pull request adds a warning for when non YAML files are provided without output options provided. 