### PR TITLE
Remove alias for UI package and add back Mock UI for Testing

### DIFF
--- a/pkg/cmd/fmt.go
+++ b/pkg/cmd/fmt.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 	"github.com/k14s/ytt/pkg/yamlfmt"
 	"github.com/k14s/ytt/pkg/yamlmeta"
@@ -37,7 +37,7 @@ func NewFmtCmd(o *FmtOptions) *cobra.Command {
 }
 
 func (o *FmtOptions) Run() error {
-	ui := cmdui.NewTTY(o.Debug)
+	ui := ui.NewTTY(o.Debug)
 	t1 := time.Now()
 
 	defer func() {

--- a/pkg/cmd/template/bulk_input.go
+++ b/pkg/cmd/template/bulk_input.go
@@ -5,8 +5,8 @@ package template
 
 import (
 	"encoding/json"
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
 
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 	"github.com/spf13/cobra"
 )
@@ -23,7 +23,7 @@ func (s *BulkFilesSourceOpts) Set(cmd *cobra.Command) {
 
 type BulkFilesSource struct {
 	opts BulkFilesSourceOpts
-	ui   cmdui.UI
+	ui   ui.UI
 }
 
 type BulkFiles struct {
@@ -36,7 +36,7 @@ type BulkFile struct {
 	Data string `json:"data"`
 }
 
-func NewBulkFilesSource(opts BulkFilesSourceOpts, ui cmdui.UI) *BulkFilesSource {
+func NewBulkFilesSource(opts BulkFilesSourceOpts, ui ui.UI) *BulkFilesSource {
 	return &BulkFilesSource{opts, ui}
 }
 

--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -6,7 +6,7 @@ package template
 import (
 	"time"
 
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 	"github.com/k14s/ytt/pkg/schema"
 	"github.com/k14s/ytt/pkg/workspace"
@@ -76,7 +76,7 @@ func NewCmd(o *TemplateOptions) *cobra.Command {
 }
 
 func (o *TemplateOptions) Run() error {
-	ui := cmdui.NewTTY(o.Debug)
+	ui := ui.NewTTY(o.Debug)
 	t1 := time.Now()
 
 	defer func() {
@@ -97,7 +97,7 @@ func (o *TemplateOptions) Run() error {
 	return o.pickSource(srcs, func(s FileSource) bool { return s.HasOutput() }).Output(out)
 }
 
-func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui cmdui.UI) TemplateOutput {
+func (o *TemplateOptions) RunWithFiles(in TemplateInput, ui ui.UI) TemplateOutput {
 	var err error
 
 	in.Files, err = o.FileMarksOpts.Apply(in.Files)

--- a/pkg/cmd/template/cmd_data_values_test.go
+++ b/pkg/cmd/template/cmd_data_values_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 )
 
@@ -32,7 +32,7 @@ str: str`)
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -92,7 +92,7 @@ another:
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
@@ -144,7 +144,7 @@ nested:
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
@@ -219,7 +219,7 @@ nested-lib-val: passes
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/_ytt_lib/nested-lib/config.yml", nestedLibTplBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
@@ -274,7 +274,7 @@ str: str2`)
 		files.MustNewFileFromSource(files.NewBytesSource("data2.yml", yamlData2)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -323,7 +323,7 @@ int: 123`)
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -374,7 +374,7 @@ int: 123`)
 		files.MustNewFileFromSource(files.NewBytesSource("data2.yml", yamlData2)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -426,7 +426,7 @@ data:
 		files.MustNewFileFromSource(files.NewBytesSource("data2.yml", yamlData2)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -461,7 +461,7 @@ non-data-values-doc`)
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -484,7 +484,7 @@ str: str`)
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -528,7 +528,7 @@ data:
 		files.MustNewFileFromSource(files.NewBytesSource("data2.yml", yamlData2)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -596,7 +596,7 @@ nested_val: nested_from_env
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib1/_ytt_lib/nested/tpl.yml", nestedTmplBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{

--- a/pkg/cmd/template/cmd_library_module_test.go
+++ b/pkg/cmd/template/cmd_library_module_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 )
 
@@ -281,7 +281,7 @@ func TestLibraryModuleWithExportConflicts(t *testing.T) {
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/config2.lib.yml", libConfig2LibData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -313,7 +313,7 @@ func TestLibraryModuleWithExportPrivate(t *testing.T) {
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/config1.lib.yml", libConfig1LibData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -832,7 +832,7 @@ lib_val2: #@ data.values.lib_val2`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/config.yml", libConfigBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -884,7 +884,7 @@ nested_lib_val1: override-me`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/with-nested-lib/_ytt_lib/lib/config.yml", nestedLibTmplBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -917,7 +917,7 @@ nested_lib_val1: new-val1`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/with-nested-lib/config.yml", withNestedLibTmplBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -950,7 +950,7 @@ nested_lib_val1: new-val1`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/with-nested-lib/config.yml", withNestedLibTmplBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -976,7 +976,7 @@ lib_val1: val1
 		files.MustNewFileFromSource(files.NewBytesSource("values.yml", dataValueBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -1001,7 +1001,7 @@ lib_val1: val1
 		files.MustNewFileFromSource(files.NewBytesSource("values.yml", dataValueBytes)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -1112,7 +1112,7 @@ lib_int: #@ data.values.int`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/config1.yml", libConfig1TplData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -1126,7 +1126,7 @@ lib_int: #@ data.values.int`)
 }
 
 func runAndCompare(t *testing.T, filesToProcess []*files.File, expectedYAMLTplData string) {
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)

--- a/pkg/cmd/template/cmd_overlays_test.go
+++ b/pkg/cmd/template/cmd_overlays_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 )
 
@@ -50,7 +50,7 @@ yamlfunc: yamlfunc`)
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.lib.yml", yamlFuncsData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -126,7 +126,7 @@ yamlfunc: yamlfunc`)
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.lib.yml", yamlFuncsData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -181,7 +181,7 @@ map: {}
 		files.MustNewFileFromSource(files.NewBytesSource("overlay2.yml", yamlOverlay2TplData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -221,7 +221,7 @@ overlayed: true
 		files.MustNewFileFromSource(files.NewBytesSource("overlay.yml", yamlOverlayTplData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -264,7 +264,7 @@ key: value_from_data_value_overlay
 		files.MustNewFileFromSource(files.NewBytesSource("datavalue_non_empty.yml", nonEmptyYamlDataValue)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -314,7 +314,7 @@ array:
 		files.MustNewFileFromSource(files.NewBytesSource("datavalue.yml", yamlDataValue)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)

--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 )
 
@@ -60,7 +60,7 @@ end`)
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.star", starlarkFuncsData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -127,7 +127,7 @@ data: #@ data.read("data")`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib1/other", []byte("lib1\ndata"))),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -207,7 +207,7 @@ data: #@ data.read("/funcs/data")`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib1/other", []byte("lib1\ndata"))),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -272,7 +272,7 @@ libdata2: #@ data.read("/other")
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib1/funcs/funcs.lib.yml", yamlLibFuncsData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -325,7 +325,7 @@ simple_key: #@ another_data()
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.lib.yml", yamlFuncsData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -351,7 +351,7 @@ func TestDisallowDirectLibraryLoading(t *testing.T) {
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/data.lib.star", []byte("data = 3"))),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -418,7 +418,7 @@ end`)
 		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/library2/_ytt_lib/funcs/funcs.star", starlarkFuncsLibData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -461,7 +461,7 @@ end`)
 		files.MustNewFileFromSource(files.NewBytesSource("non-top-level/_ytt_lib/funcs/funcs.star", nonTopLevelStarlarkFuncsLibData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -499,7 +499,7 @@ yamlfunc: yamlfunc`)
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.lib.yml", yamlFuncsData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -531,7 +531,7 @@ yamlfunc: yamlfunc`)
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.lib.yml", yamlFuncsData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 	opts.IgnoreUnknownComments = true
 
@@ -564,7 +564,7 @@ yamlfunc yamlfunc`)
 		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -593,7 +593,7 @@ yamlfunc yamlfunc
 		files.MustNewFileFromSource(files.NewBytesSource("funcs/funcs.lib.yml", yamlFuncsData)),
 	}
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -622,7 +622,7 @@ text_template: (@= "string" @)
 
 	filesToProcess[0].MarkTemplate(false)
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -655,7 +655,7 @@ func TestPlainTextNoTemplateProcessing(t *testing.T) {
 
 	filesToProcess[0].MarkTemplate(false)
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
@@ -688,7 +688,7 @@ data_str: yes`)
 		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 	opts.StrictYAML = true
 
@@ -722,7 +722,7 @@ str: yes`)
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 	opts.StrictYAML = true
 
@@ -756,7 +756,7 @@ str: `)
 		files.MustNewFileFromSource(files.NewBytesSource("data.yml", yamlData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 	opts.StrictYAML = true
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
@@ -814,7 +814,7 @@ func TestLoadYTTModuleFailEarly(t *testing.T) {
 		files.MustNewFileFromSource(files.NewBytesSource("config.yml", configTplData)),
 	})
 
-	ui := cmdui.NewTTY(false)
+	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
 	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)

--- a/pkg/cmd/template/regular_input.go
+++ b/pkg/cmd/template/regular_input.go
@@ -5,9 +5,9 @@ package template
 
 import (
 	"fmt"
-	ui2 "github.com/k14s/ytt/pkg/cmd/ui"
 	"io"
 
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 	"github.com/spf13/cobra"
@@ -46,10 +46,10 @@ func (s *RegularFilesSourceOpts) Set(cmd *cobra.Command) {
 
 type RegularFilesSource struct {
 	opts RegularFilesSourceOpts
-	ui   ui2.UI
+	ui   ui.UI
 }
 
-func NewRegularFilesSource(opts RegularFilesSourceOpts, ui ui2.UI) *RegularFilesSource {
+func NewRegularFilesSource(opts RegularFilesSourceOpts, ui ui.UI) *RegularFilesSource {
 	return &RegularFilesSource{opts, ui}
 }
 

--- a/pkg/cmd/template/regular_input_test.go
+++ b/pkg/cmd/template/regular_input_test.go
@@ -6,13 +6,13 @@ package template_test
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/k14s/ytt/pkg/cmd/template"
 	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 )
 
@@ -35,10 +35,7 @@ If you want to include those results, use the --output-files or --dangerous-empt
 
 	stdout := bytes.NewBufferString("")
 	stderr := bytes.NewBufferString("")
-	ui := fakeUI{
-		stdout: stdout,
-		stderr: stderr,
-	}
+	ui := ui.NewCustomWriterTTY(false, stdout, stderr)
 	opts := cmdtpl.NewOptions()
 	rfsOpts := template.RegularFilesSourceOpts{OutputType: "yaml"}
 	rfs := template.NewRegularFilesSource(rfsOpts, ui)
@@ -83,10 +80,7 @@ organization=Acme Widgets Inc.`)
 
 	stdout := bytes.NewBufferString("")
 	stderr := bytes.NewBufferString("")
-	ui := fakeUI{
-		stdout: stdout,
-		stderr: stderr,
-	}
+	ui := ui.NewCustomWriterTTY(false, stdout, stderr)
 	opts := cmdtpl.NewOptions()
 	rfsOpts := template.RegularFilesSourceOpts{OutputType: "yaml", OutputFiles: outputDir}
 	rfs := template.NewRegularFilesSource(rfsOpts, ui)
@@ -119,10 +113,7 @@ func Test_FileMark_YAML_Shows_No_Warning(t *testing.T) {
 
 	stdout := bytes.NewBufferString("")
 	stderr := bytes.NewBufferString("")
-	ui := fakeUI{
-		stdout: stdout,
-		stderr: stderr,
-	}
+	ui := ui.NewCustomWriterTTY(false, stdout, stderr)
 	opts := cmdtpl.NewOptions()
 	opts.FileMarksOpts.FileMarks = []string{"yaml.txt:type=yaml-plain"}
 	rfsOpts := template.RegularFilesSourceOpts{OutputType: "yaml"}
@@ -163,25 +154,4 @@ func assertStdoutAndStderr(stdout *bytes.Buffer, stderr *bytes.Buffer, expectedS
 		return fmt.Errorf("Expected stderr to be >>>%s<<<\nBut was: >>>%s<<<", expectedStdErr, string(stderrOutput))
 	}
 	return nil
-}
-
-type fakeUI struct {
-	stdout io.Writer
-	stderr io.Writer
-}
-
-func (ui fakeUI) DebugWriter() io.Writer {
-	return ui.stderr
-}
-
-func (ui fakeUI) Printf(str string, args ...interface{}) {
-	fmt.Fprintf(ui.stdout, str, args...)
-}
-
-func (ui fakeUI) Warnf(str string, args ...interface{}) {
-	fmt.Fprintf(ui.stderr, str, args...)
-}
-
-func (ui fakeUI) Debugf(str string, args ...interface{}) {
-	fmt.Fprintf(ui.stderr, str, args...)
 }

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/k14s/difflib"
 	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
-	cmdui "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 )
 
@@ -627,7 +627,7 @@ rendered: true`
 
 func assertYTTWorkflowSucceedsWithOutput(t *testing.T, filesToProcess []*files.File, expectedOut string) {
 	t.Helper()
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, cmdui.NewTTY(false))
+	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui.NewTTY(false))
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -644,7 +644,7 @@ func assertYTTWorkflowSucceedsWithOutput(t *testing.T, filesToProcess []*files.F
 
 func assertYTTWorkflowFailsWithErrorMessage(t *testing.T, filesToProcess []*files.File, expectedErr string) {
 	t.Helper()
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, cmdui.NewTTY(false))
+	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui.NewTTY(false))
 	if out.Err == nil {
 		t.Fatalf("Expected an error, but succeeded.")
 	}

--- a/pkg/cmd/ui/tty.go
+++ b/pkg/cmd/ui/tty.go
@@ -9,33 +9,33 @@ import (
 	"os"
 )
 
-type tty struct {
+type TTY struct {
 	debug  bool
 	stdout io.Writer
 	stderr io.Writer
 }
 
-var _ UI = tty{}
+var _ UI = TTY{}
 
-func NewTTY(debug bool) tty {
-	return tty{debug, os.Stdout, os.Stderr}
+func NewTTY(debug bool) TTY {
+	return TTY{debug, os.Stdout, os.Stderr}
 }
 
-func (t tty) Printf(str string, args ...interface{}) {
+func (t TTY) Printf(str string, args ...interface{}) {
 	fmt.Fprintf(t.stdout, str, args...)
 }
 
-func (t tty) Warnf(str string, args ...interface{}) {
+func (t TTY) Warnf(str string, args ...interface{}) {
 	fmt.Fprintf(t.stderr, str, args...)
 }
 
-func (t tty) Debugf(str string, args ...interface{}) {
+func (t TTY) Debugf(str string, args ...interface{}) {
 	if t.debug {
 		fmt.Fprintf(t.stderr, str, args...)
 	}
 }
 
-func (t tty) DebugWriter() io.Writer {
+func (t TTY) DebugWriter() io.Writer {
 	if t.debug {
 		return os.Stderr
 	}
@@ -47,3 +47,14 @@ type noopWriter struct{}
 var _ io.Writer = noopWriter{}
 
 func (w noopWriter) Write(data []byte) (int, error) { return len(data), nil }
+
+// Used for testing whether TTY writes correct output to stdout/stderr
+func NewCustomWriterTTY(debug bool, stdout, stderr io.Writer) TTY {
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	return TTY{debug, stdout, stderr}
+}

--- a/pkg/files/output_directory.go
+++ b/pkg/files/output_directory.go
@@ -5,10 +5,11 @@ package files
 
 import (
 	"fmt"
-	ui2 "github.com/k14s/ytt/pkg/cmd/ui"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/k14s/ytt/pkg/cmd/ui"
 )
 
 var (
@@ -18,10 +19,10 @@ var (
 type OutputDirectory struct {
 	path  string
 	files []OutputFile
-	ui    ui2.UI
+	ui    ui.UI
 }
 
-func NewOutputDirectory(path string, files []OutputFile, ui ui2.UI) *OutputDirectory {
+func NewOutputDirectory(path string, files []OutputFile, ui ui.UI) *OutputDirectory {
 	return &OutputDirectory{path, files, ui}
 }
 

--- a/pkg/workspace/library_execution_factory.go
+++ b/pkg/workspace/library_execution_factory.go
@@ -4,7 +4,7 @@
 package workspace
 
 import (
-	ui2 "github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 )
 
 type LibraryExecutionContext struct {
@@ -13,11 +13,11 @@ type LibraryExecutionContext struct {
 }
 
 type LibraryExecutionFactory struct {
-	ui                 ui2.UI
+	ui                 ui.UI
 	templateLoaderOpts TemplateLoaderOpts
 }
 
-func NewLibraryExecutionFactory(ui ui2.UI, templateLoaderOpts TemplateLoaderOpts) *LibraryExecutionFactory {
+func NewLibraryExecutionFactory(ui ui.UI, templateLoaderOpts TemplateLoaderOpts) *LibraryExecutionFactory {
 	return &LibraryExecutionFactory{ui, templateLoaderOpts}
 }
 

--- a/pkg/workspace/library_loader.go
+++ b/pkg/workspace/library_loader.go
@@ -5,8 +5,9 @@ package workspace
 
 import (
 	"fmt"
-	ui2 "github.com/k14s/ytt/pkg/cmd/ui"
 	"strings"
+
+	"github.com/k14s/ytt/pkg/cmd/ui"
 
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/ytt/pkg/files"
@@ -18,7 +19,7 @@ import (
 
 type LibraryLoader struct {
 	libraryCtx         LibraryExecutionContext
-	ui                 ui2.UI
+	ui                 ui.UI
 	templateLoaderOpts TemplateLoaderOpts
 	libraryExecFactory *LibraryExecutionFactory
 }
@@ -35,7 +36,7 @@ type EvalExport struct {
 }
 
 func NewLibraryLoader(libraryCtx LibraryExecutionContext,
-	ui ui2.UI, templateLoaderOpts TemplateLoaderOpts,
+	ui ui.UI, templateLoaderOpts TemplateLoaderOpts,
 	libraryExecFactory *LibraryExecutionFactory) *LibraryLoader {
 
 	return &LibraryLoader{

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -5,10 +5,10 @@ package workspace
 
 import (
 	"fmt"
-	ui2 "github.com/k14s/ytt/pkg/cmd/ui"
 	"strings"
 
 	"github.com/k14s/starlark-go/starlark"
+	"github.com/k14s/ytt/pkg/cmd/ui"
 	"github.com/k14s/ytt/pkg/files"
 	"github.com/k14s/ytt/pkg/template"
 	"github.com/k14s/ytt/pkg/texttemplate"
@@ -18,7 +18,7 @@ import (
 )
 
 type TemplateLoader struct {
-	ui                 ui2.UI
+	ui                 ui.UI
 	values             *DataValues
 	libraryValuess     []*DataValues
 	opts               TemplateLoaderOpts
@@ -39,7 +39,7 @@ type TemplateLoaderOptsOverrides struct {
 	StrictYAML              *bool
 }
 
-func NewTemplateLoader(values *DataValues, libraryValuess []*DataValues, ui ui2.UI, opts TemplateLoaderOpts, libraryExecFactory *LibraryExecutionFactory, schema Schema) *TemplateLoader {
+func NewTemplateLoader(values *DataValues, libraryValuess []*DataValues, ui ui.UI, opts TemplateLoaderOpts, libraryExecFactory *LibraryExecutionFactory, schema Schema) *TemplateLoader {
 
 	if values == nil {
 		panic("Expected values to be non-nil")


### PR DESCRIPTION
This is a follow up for pr #265. It addresses the following feedback points:
* Standardize how `github.com/k14s/ytt/pkg/cmd/ui` is aliased when imported (previously was ui2 or cmdui). I just removed the alias for all and refer to it as ui.
* Move the fakeUI concept into the ui package instead of in regular_input_tests. This makes this testing pattern easier to find/use. The changes in #265 make it so the `io.Writer` on the new `tty` struct aren't able to be set for testing since no fields are exported.
