### PR TITLE
Adding golint and goheader linters via golangci-lint

### DIFF
--- a/.git-together
+++ b/.git-together
@@ -8,3 +8,5 @@
     dk = "Dmitriy Kalinin; cppforlife@gmail.com"
     dl = "Dennis Leon; leonde@vmware.com"
     sl = "Steven Locke; slocke"
+    dh = "Daniel Helfand; helfand.4@gmail.com"
+

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.34
+          args: -v --max-same-issues 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  enable:
+    - goheader
+    - golint
+  disable-all: true
+# all available settings of specific linters
+linters-settings:
+  goheader:
+    template-path: code-header-template.txt

--- a/code-header-template.txt
+++ b/code-header-template.txt
@@ -1,0 +1,2 @@
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/hack/build-and-lint.sh
+++ b/hack/build-and-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x -u
+
+./hack/build.sh
+./hack/linter.sh

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+golangci-lint cache clean
+golangci-lint run --max-same-issues 0 --tests=false

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -2,4 +2,4 @@
 set -e
 
 golangci-lint cache clean
-golangci-lint run --max-same-issues 0 --tests=false
+golangci-lint run --max-same-issues 0

--- a/pkg/cmd/template/bulk_input.go
+++ b/pkg/cmd/template/bulk_input.go
@@ -43,11 +43,11 @@ func NewBulkFilesSource(opts BulkFilesSourceOpts, ui ui.UI) *BulkFilesSource {
 func (s *BulkFilesSource) HasInput() bool  { return len(s.opts.bulkIn) > 0 }
 func (s *BulkFilesSource) HasOutput() bool { return s.opts.bulkOut }
 
-func (s BulkFilesSource) Input() (TemplateInput, error) {
+func (s BulkFilesSource) Input() (Input, error) {
 	var fs BulkFiles
 	err := json.Unmarshal([]byte(s.opts.bulkIn), &fs)
 	if err != nil {
-		return TemplateInput{}, err
+		return Input{}, err
 	}
 
 	var result []*files.File
@@ -55,16 +55,16 @@ func (s BulkFilesSource) Input() (TemplateInput, error) {
 	for _, f := range fs.Files {
 		file, err := files.NewFileFromSource(files.NewBytesSource(f.Name, []byte(f.Data)))
 		if err != nil {
-			return TemplateInput{}, err
+			return Input{}, err
 		}
 
 		result = append(result, file)
 	}
 
-	return TemplateInput{files.NewSortedFiles(result)}, nil
+	return Input{files.NewSortedFiles(result)}, nil
 }
 
-func (s *BulkFilesSource) Output(out TemplateOutput) error {
+func (s *BulkFilesSource) Output(out Output) error {
 	fs := BulkFiles{}
 
 	if out.Err != nil {

--- a/pkg/cmd/template/cmd_data_values_test.go
+++ b/pkg/cmd/template/cmd_data_values_test.go
@@ -35,7 +35,7 @@ str: str`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -100,7 +100,7 @@ another:
 		KVsFromYAML: []string{"int=124", "boolean=true", "nested.value=\"str\"", "another.nested.map=567"},
 	}
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -152,7 +152,7 @@ nested:
 		KVsFromYAML: []string{"another_nested+.other_value=str2"},
 	}
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -227,7 +227,7 @@ nested-lib-val: passes
 		KVsFromYAML: []string{"@~inst1:lib_val=test", "@~inst1@nested-lib:nested_lib_val=passes"},
 	}
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -277,7 +277,7 @@ str: str2`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -326,7 +326,7 @@ int: 123`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -377,7 +377,7 @@ int: 123`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -429,7 +429,7 @@ data:
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -464,7 +464,7 @@ non-data-values-doc`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail, but was no error")
 	}
@@ -487,7 +487,7 @@ str: str`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail, but was no error")
 	}
@@ -531,7 +531,7 @@ data:
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -609,7 +609,7 @@ nested_val: nested_from_env
 		},
 	}
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}

--- a/pkg/cmd/template/cmd_library_module_test.go
+++ b/pkg/cmd/template/cmd_library_module_test.go
@@ -284,7 +284,7 @@ func TestLibraryModuleWithExportConflicts(t *testing.T) {
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail, but was no error")
 	}
@@ -316,7 +316,7 @@ func TestLibraryModuleWithExportPrivate(t *testing.T) {
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail, but was no error")
 	}
@@ -835,7 +835,7 @@ lib_val2: #@ data.values.lib_val2`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -887,7 +887,7 @@ nested_lib_val1: override-me`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -920,7 +920,7 @@ nested_lib_val1: new-val1`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -953,7 +953,7 @@ nested_lib_val1: new-val1`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -979,7 +979,7 @@ lib_val1: val1
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -1004,7 +1004,7 @@ lib_val1: val1
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -1115,7 +1115,7 @@ lib_int: #@ data.values.int`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error but it did not")
 	}
@@ -1129,7 +1129,7 @@ func runAndCompare(t *testing.T, filesToProcess []*files.File, expectedYAMLTplDa
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}

--- a/pkg/cmd/template/cmd_overlays_test.go
+++ b/pkg/cmd/template/cmd_overlays_test.go
@@ -53,7 +53,7 @@ yamlfunc: yamlfunc`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -129,7 +129,7 @@ yamlfunc: yamlfunc`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -184,7 +184,7 @@ map: {}
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error")
 	}
@@ -224,7 +224,7 @@ overlayed: true
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to error")
 	}
@@ -267,7 +267,7 @@ key: value_from_data_value_overlay
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -317,7 +317,7 @@ array:
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}

--- a/pkg/cmd/template/cmd_test.go
+++ b/pkg/cmd/template/cmd_test.go
@@ -63,7 +63,7 @@ end`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -130,7 +130,7 @@ data: #@ data.read("data")`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -210,7 +210,7 @@ data: #@ data.read("/funcs/data")`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -275,7 +275,7 @@ libdata2: #@ data.read("/other")
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -328,7 +328,7 @@ simple_key: #@ another_data()
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles fail")
 	}
@@ -354,7 +354,7 @@ func TestDisallowDirectLibraryLoading(t *testing.T) {
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles fail")
 	}
@@ -421,7 +421,7 @@ end`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -464,7 +464,7 @@ end`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -502,7 +502,7 @@ yamlfunc: yamlfunc`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}
@@ -535,7 +535,7 @@ yamlfunc: yamlfunc`)
 	opts := cmdtpl.NewOptions()
 	opts.IgnoreUnknownComments = true
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -567,7 +567,7 @@ yamlfunc yamlfunc`)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}
@@ -596,7 +596,7 @@ yamlfunc yamlfunc
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}
@@ -625,7 +625,7 @@ text_template: (@= "string" @)
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -658,7 +658,7 @@ func TestPlainTextNoTemplateProcessing(t *testing.T) {
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -692,7 +692,7 @@ data_str: yes`)
 	opts := cmdtpl.NewOptions()
 	opts.StrictYAML = true
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}
@@ -726,7 +726,7 @@ str: yes`)
 	opts := cmdtpl.NewOptions()
 	opts.StrictYAML = true
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}
@@ -763,7 +763,7 @@ str: `)
 		KVsFromYAML: []string{"str=yes"},
 	}
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}
@@ -817,7 +817,7 @@ func TestLoadYTTModuleFailEarly(t *testing.T) {
 	ui := ui.NewTTY(false)
 	opts := cmdtpl.NewOptions()
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err == nil {
 		t.Fatalf("Expected RunWithFiles to fail")
 	}

--- a/pkg/cmd/template/regular_input.go
+++ b/pkg/cmd/template/regular_input.go
@@ -56,16 +56,16 @@ func NewRegularFilesSource(opts RegularFilesSourceOpts, ui ui.UI) *RegularFilesS
 func (s *RegularFilesSource) HasInput() bool  { return len(s.opts.files) > 0 }
 func (s *RegularFilesSource) HasOutput() bool { return true }
 
-func (s *RegularFilesSource) Input() (TemplateInput, error) {
+func (s *RegularFilesSource) Input() (Input, error) {
 	filesToProcess, err := files.NewSortedFilesFromPaths(s.opts.files, s.opts.SymlinkAllowOpts)
 	if err != nil {
-		return TemplateInput{}, err
+		return Input{}, err
 	}
 
-	return TemplateInput{Files: filesToProcess}, nil
+	return Input{Files: filesToProcess}, nil
 }
 
-func (s *RegularFilesSource) Output(out TemplateOutput) error {
+func (s *RegularFilesSource) Output(out Output) error {
 	if out.Err != nil {
 		return out.Err
 	}

--- a/pkg/cmd/template/regular_input_test.go
+++ b/pkg/cmd/template/regular_input_test.go
@@ -40,7 +40,7 @@ If you want to include those results, use the --output-files or --dangerous-empt
 	rfsOpts := template.RegularFilesSourceOpts{OutputType: "yaml"}
 	rfs := template.NewRegularFilesSource(rfsOpts, ui)
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("An unexpected error occurred: %v", out.Err)
 	}
@@ -85,7 +85,7 @@ organization=Acme Widgets Inc.`)
 	rfsOpts := template.RegularFilesSourceOpts{OutputType: "yaml", OutputFiles: outputDir}
 	rfs := template.NewRegularFilesSource(rfsOpts, ui)
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("An unexpected error occurred: %v", out.Err)
 	}
@@ -119,7 +119,7 @@ func Test_FileMark_YAML_Shows_No_Warning(t *testing.T) {
 	rfsOpts := template.RegularFilesSourceOpts{OutputType: "yaml"}
 	rfs := template.NewRegularFilesSource(rfsOpts, ui)
 
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui)
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	if out.Err != nil {
 		t.Fatalf("An unexpected error occurred: %v", out.Err)
 	}

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/k14s/ytt/pkg/files"
 )
 
-var opts *cmdtpl.TemplateOptions
+var opts *cmdtpl.Options
 
 func TestMain(m *testing.M) {
 	opts = cmdtpl.NewOptions()
@@ -627,7 +627,7 @@ rendered: true`
 
 func assertYTTWorkflowSucceedsWithOutput(t *testing.T, filesToProcess []*files.File, expectedOut string) {
 	t.Helper()
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui.NewTTY(false))
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui.NewTTY(false))
 	if out.Err != nil {
 		t.Fatalf("Expected RunWithFiles to succeed, but was error: %s", out.Err)
 	}
@@ -644,7 +644,7 @@ func assertYTTWorkflowSucceedsWithOutput(t *testing.T, filesToProcess []*files.F
 
 func assertYTTWorkflowFailsWithErrorMessage(t *testing.T, filesToProcess []*files.File, expectedErr string) {
 	t.Helper()
-	out := opts.RunWithFiles(cmdtpl.TemplateInput{Files: filesToProcess}, ui.NewTTY(false))
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui.NewTTY(false))
 	if out.Err == nil {
 		t.Fatalf("Expected an error, but succeeded.")
 	}

--- a/pkg/cmd/website.go
+++ b/pkg/cmd/website.go
@@ -17,7 +17,7 @@ import (
 
 type WebsiteOptions struct {
 	ListenAddr      string
-	RedirectToHTTPs bool
+	RedirectToHTTPS bool
 	BinaryPath      string
 	CheckCookie     bool
 }
@@ -35,14 +35,14 @@ func NewWebsiteCmd(o *WebsiteOptions) *cobra.Command {
 		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
 	}
 	cmd.Flags().StringVar(&o.ListenAddr, "listen-addr", "localhost:8080", "Listen address")
-	cmd.Flags().BoolVar(&o.RedirectToHTTPs, "redirect-to-https", true, "Redirect to HTTPs address")
+	cmd.Flags().BoolVar(&o.RedirectToHTTPS, "redirect-to-https", true, "Redirect to HTTPs address")
 	return cmd
 }
 
 func (o *WebsiteOptions) Server() *website.Server {
 	opts := website.ServerOpts{
 		ListenAddr:      o.ListenAddr,
-		RedirectToHTTPs: o.RedirectToHTTPs,
+		RedirectToHTTPS: o.RedirectToHTTPS,
 		TemplateFunc:    o.execBinary,
 		ErrorFunc:       o.bulkOutErr,
 		CheckCookie:     o.CheckCookie,

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -135,7 +135,7 @@ func NewSortedFilesFromPaths(paths []string, opts SymlinkAllowOpts) ([]*File, er
 
 		for _, file := range files {
 			file.order = currOrder
-			currOrder += 1
+			currOrder++
 		}
 
 		allFiles = append(allFiles, files...)
@@ -148,7 +148,7 @@ func NewSortedFiles(files []*File) []*File {
 	currOrder := 1
 	for _, file := range files {
 		file.order = currOrder
-		currOrder += 1
+		currOrder++
 	}
 	return files
 }

--- a/pkg/files/symlink.go
+++ b/pkg/files/symlink.go
@@ -71,7 +71,7 @@ func (s Symlink) isIn(path, allowedPath string) (bool, error) {
 		return false, nil
 	}
 
-	for i, _ := range allowedPathPieces {
+	for i := range allowedPathPieces {
 		if allowedPathPieces[i] != pathPieces[i] {
 			return false, nil
 		}

--- a/pkg/orderedmap/convert.go
+++ b/pkg/orderedmap/convert.go
@@ -82,7 +82,7 @@ func (c Conversion) fromUnorderedMaps(object interface{}) interface{} {
 
 func (Conversion) mapKeysFromInterfaceMap(m map[interface{}]interface{}) []interface{} {
 	var keys []interface{}
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	return keys
@@ -90,7 +90,7 @@ func (Conversion) mapKeysFromInterfaceMap(m map[interface{}]interface{}) []inter
 
 func (Conversion) mapKeysFromStringMap(m map[string]interface{}) []interface{} {
 	var keys []interface{}
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	return keys

--- a/pkg/template/annotations.go
+++ b/pkg/template/annotations.go
@@ -66,7 +66,7 @@ func (as NodeAnnotations) Kwargs(name structmeta.AnnotationName) []starlark.Tupl
 
 func (as NodeAnnotations) DeleteNs(ns structmeta.AnnotationNs) {
 	prefix := string(ns) + "/"
-	for k, _ := range as {
+	for k := range as {
 		if strings.HasPrefix(string(k), prefix) {
 			delete(as, k)
 		}

--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -19,7 +19,7 @@ type EvaluationCtxDialects map[EvaluationCtxDialectName]EvaluationCtxDialect
 
 type CompiledTemplate struct {
 	name         string
-	code         []TemplateLine
+	code         []Line
 	instructions *InstructionSet
 	nodes        *Nodes
 	evalDialects EvaluationCtxDialects
@@ -27,7 +27,7 @@ type CompiledTemplate struct {
 	ctxs         []*EvaluationCtx
 }
 
-func NewCompiledTemplate(name string, code []TemplateLine,
+func NewCompiledTemplate(name string, code []Line,
 	instructions *InstructionSet, nodes *Nodes,
 	evalDialects EvaluationCtxDialects) *CompiledTemplate {
 
@@ -49,9 +49,9 @@ func NewCompiledTemplate(name string, code []TemplateLine,
 	}
 }
 
-func (e *CompiledTemplate) Code() []TemplateLine { return e.code }
+func (e *CompiledTemplate) Code() []Line { return e.code }
 
-func (e *CompiledTemplate) CodeAtLine(pos *filepos.Position) *TemplateLine {
+func (e *CompiledTemplate) CodeAtLine(pos *filepos.Position) *Line {
 	for i, line := range e.code {
 		if i+1 == pos.Line() {
 			return &line
@@ -183,7 +183,7 @@ func (e *CompiledTemplate) eval(
 func (e *CompiledTemplate) hidePrivateGlobals(globals starlark.StringDict) {
 	var privateKeys []string
 
-	for k, _ := range globals {
+	for k := range globals {
 		if strings.HasPrefix(k, "_") {
 			privateKeys = append(privateKeys, k)
 		}

--- a/pkg/template/compiled_template_error.go
+++ b/pkg/template/compiled_template_error.go
@@ -28,10 +28,10 @@ type CompiledTemplateError struct {
 type CompiledTemplateErrorPosition struct {
 	Filename     string
 	ContextName  string
-	TemplateLine *TemplateLine
+	TemplateLine *Line
 
-	BeforeTemplateLine *TemplateLine
-	AfterTemplateLine  *TemplateLine
+	BeforeTemplateLine *Line
+	AfterTemplateLine  *Line
 }
 
 func NewCompiledTemplateMultiError(err error, loader CompiledTemplateLoader) error {
@@ -173,7 +173,7 @@ func (e CompiledTemplateMultiError) buildPos(pos syntax.Position) CompiledTempla
 	}
 }
 
-func (CompiledTemplateMultiError) findClosestLine(ct *CompiledTemplate, posLine int, lineInc int) *TemplateLine {
+func (CompiledTemplateMultiError) findClosestLine(ct *CompiledTemplate, posLine int, lineInc int) *Line {
 	for {
 		posLine += lineInc
 		if posLine < 1 {

--- a/pkg/template/instructions.go
+++ b/pkg/template/instructions.go
@@ -23,22 +23,22 @@ type InstructionSet struct {
 }
 
 var (
-	globalInsSetId = 1
+	globalInsSetID = 1
 )
 
 func NewInstructionSet() *InstructionSet {
-	globalInsSetId += 1
-	uniqueId := globalInsSetId
+	globalInsSetID++
+	uniqueID := globalInsSetID
 	return &InstructionSet{
-		SetCtxType:            InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_ctx_type", uniqueId)},
-		StartCtx:              InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_ctx", uniqueId)},
-		EndCtx:                InstructionOp{fmt.Sprintf("__ytt_tpl%d_end_ctx", uniqueId)},
-		StartNodeAnnotation:   InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_node_annotation", uniqueId)},
-		CollectNodeAnnotation: InstructionOp{fmt.Sprintf("__ytt_tpl%d_collect_node_annotation", uniqueId)},
-		StartNode:             InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_node", uniqueId)},
-		SetNode:               InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_node", uniqueId)},
-		SetMapItemKey:         InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_map_item_key", uniqueId)},
-		ReplaceNode:           InstructionOp{fmt.Sprintf("__ytt_tpl%d_replace_node", uniqueId)},
+		SetCtxType:            InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_ctx_type", uniqueID)},
+		StartCtx:              InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_ctx", uniqueID)},
+		EndCtx:                InstructionOp{fmt.Sprintf("__ytt_tpl%d_end_ctx", uniqueID)},
+		StartNodeAnnotation:   InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_node_annotation", uniqueID)},
+		CollectNodeAnnotation: InstructionOp{fmt.Sprintf("__ytt_tpl%d_collect_node_annotation", uniqueID)},
+		StartNode:             InstructionOp{fmt.Sprintf("__ytt_tpl%d_start_node", uniqueID)},
+		SetNode:               InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_node", uniqueID)},
+		SetMapItemKey:         InstructionOp{fmt.Sprintf("__ytt_tpl%d_set_map_item_key", uniqueID)},
+		ReplaceNode:           InstructionOp{fmt.Sprintf("__ytt_tpl%d_replace_node", uniqueID)},
 	}
 }
 

--- a/pkg/template/nodes.go
+++ b/pkg/template/nodes.go
@@ -30,7 +30,7 @@ func NewNodes() *Nodes {
 func (n *Nodes) Ancestors() Ancestors { return NewAncestors(n.childToParentTag) }
 
 func (n *Nodes) AddRootNode(node EvaluationNode) NodeTag {
-	n.id += 1
+	n.id++
 	tag := NodeTag{n.id}
 	n.tagToNode[tag] = node
 	n.childToParentTag[tag] = NodeTagRoot
@@ -38,7 +38,7 @@ func (n *Nodes) AddRootNode(node EvaluationNode) NodeTag {
 }
 
 func (n *Nodes) AddNode(node EvaluationNode, parentTag NodeTag) NodeTag {
-	n.id += 1
+	n.id++
 	tag := NodeTag{n.id}
 	n.tagToNode[tag] = node
 	n.childToParentTag[tag] = parentTag

--- a/pkg/template/source.go
+++ b/pkg/template/source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/k14s/ytt/pkg/filepos"
 )
 
-type TemplateLine struct {
+type Line struct {
 	Instruction Instruction
 	SourceLine  *SourceLine
 }
@@ -20,15 +20,15 @@ type SourceLine struct {
 	Selection *SourceLine
 }
 
-func NewCodeFromBytes(bs []byte, instructions *InstructionSet) []TemplateLine {
+func NewCodeFromBytes(bs []byte, instructions *InstructionSet) []Line {
 	return NewCodeFromBytesAtPosition(bs, filepos.NewPosition(1), instructions)
 }
 
-func NewCodeFromBytesAtPosition(bs []byte, pos *filepos.Position, instructions *InstructionSet) []TemplateLine {
-	var result []TemplateLine
+func NewCodeFromBytesAtPosition(bs []byte, pos *filepos.Position, instructions *InstructionSet) []Line {
+	var result []Line
 
 	for i, line := range bytes.Split(bs, []byte("\n")) {
-		result = append(result, TemplateLine{
+		result = append(result, Line{
 			Instruction: instructions.NewCode(string(line)),
 			SourceLine:  NewSourceLine(pos.DeepCopyWithLineOffset(i), string(line)),
 		})

--- a/pkg/texttemplate/parser.go
+++ b/pkg/texttemplate/parser.go
@@ -77,10 +77,10 @@ func (p *Parser) parse(dataBs []byte, associatedName string, startPos *filepos.P
 		}
 
 		if currChar == '\n' {
-			currLine += 1
+			currLine++
 			currCol = 1
 		} else {
-			currCol += 1
+			currCol++
 		}
 
 		lastChar = currChar

--- a/pkg/texttemplate/template.go
+++ b/pkg/texttemplate/template.go
@@ -20,7 +20,7 @@ func NewTemplate(name string) *Template {
 }
 
 func (e *Template) CompileInline(rootNode *NodeRoot,
-	instructions *template.InstructionSet, nodes *template.Nodes) ([]template.TemplateLine, error) {
+	instructions *template.InstructionSet, nodes *template.Nodes) ([]template.Line, error) {
 
 	return e.compile(rootNode, instructions, nodes)
 }
@@ -43,12 +43,12 @@ func (e *Template) Compile(rootNode *NodeRoot) (*template.CompiledTemplate, erro
 }
 
 func (e *Template) compile(rootNode *NodeRoot,
-	instructions *template.InstructionSet, nodes *template.Nodes) ([]template.TemplateLine, error) {
+	instructions *template.InstructionSet, nodes *template.Nodes) ([]template.Line, error) {
 
-	code := []template.TemplateLine{}
+	code := []template.Line{}
 	rootNodeTag := nodes.AddRootNode(&NodeRoot{}) // fresh copy to avoid leaking out NodeCode
 
-	code = append(code, []template.TemplateLine{
+	code = append(code, []template.Line{
 		{Instruction: instructions.NewSetCtxType(EvaluationCtxDialectName)},
 		{Instruction: instructions.NewStartCtx(EvaluationCtxDialectName)},
 		{Instruction: instructions.NewStartNode(rootNodeTag)},
@@ -66,12 +66,12 @@ func (e *Template) compile(rootNode *NodeRoot,
 
 			nodeTag := nodes.AddNode(typedNode, rootNodeTag)
 
-			code = append(code, template.TemplateLine{
+			code = append(code, template.Line{
 				Instruction: instructions.NewStartNode(nodeTag),
 				SourceLine:  template.NewSourceLine(typedNode.Position, typedNode.Content),
 			})
 
-			code = append(code, template.TemplateLine{
+			code = append(code, template.Line{
 				Instruction: instructions.NewSetNode(nodeTag),
 				SourceLine:  template.NewSourceLine(typedNode.Position, typedNode.Content),
 			})
@@ -90,12 +90,12 @@ func (e *Template) compile(rootNode *NodeRoot,
 			if meta.ShouldPrint() {
 				nodeTag := nodes.AddNode(&NodeText{}, rootNodeTag)
 
-				code = append(code, template.TemplateLine{
+				code = append(code, template.Line{
 					Instruction: instructions.NewStartNode(nodeTag),
 					SourceLine:  template.NewSourceLine(typedNode.Position, typedNode.Content),
 				})
 
-				code = append(code, template.TemplateLine{
+				code = append(code, template.Line{
 					Instruction: instructions.NewSetNodeValue(nodeTag, meta.Code()),
 					SourceLine:  template.NewSourceLine(typedNode.Position, typedNode.Content),
 				})
@@ -109,7 +109,7 @@ func (e *Template) compile(rootNode *NodeRoot,
 		}
 	}
 
-	code = append(code, template.TemplateLine{
+	code = append(code, template.Line{
 		Instruction: instructions.NewEndCtx(),
 	})
 

--- a/pkg/website/server.go
+++ b/pkg/website/server.go
@@ -16,7 +16,7 @@ import (
 
 type ServerOpts struct {
 	ListenAddr      string
-	RedirectToHTTPs bool
+	RedirectToHTTPS bool
 	CheckCookie     bool
 	TemplateFunc    func([]byte) ([]byte, error)
 	ErrorFunc       func(error) ([]byte, error)
@@ -32,13 +32,13 @@ func NewServer(opts ServerOpts) *Server {
 
 func (s *Server) Mux() *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", s.redirectToHTTPs(s.noCacheHandler(s.mainHandler)))
-	mux.HandleFunc("/js/", s.redirectToHTTPs(s.noCacheHandler(s.assetHandler)))
-	mux.HandleFunc("/examples", s.redirectToHTTPs(s.noCacheHandler(s.corsHandler(s.exampleSetsHandler))))
-	mux.HandleFunc("/examples/", s.redirectToHTTPs(s.noCacheHandler(s.corsHandler(s.examplesHandler))))
+	mux.HandleFunc("/", s.redirectToHTTPS(s.noCacheHandler(s.mainHandler)))
+	mux.HandleFunc("/js/", s.redirectToHTTPS(s.noCacheHandler(s.assetHandler)))
+	mux.HandleFunc("/examples", s.redirectToHTTPS(s.noCacheHandler(s.corsHandler(s.exampleSetsHandler))))
+	mux.HandleFunc("/examples/", s.redirectToHTTPS(s.noCacheHandler(s.corsHandler(s.examplesHandler))))
 	// no need for caching as it's a POST
-	mux.HandleFunc("/template", s.redirectToHTTPs(s.corsHandler(s.templateHandler)))
-	mux.HandleFunc("/alpha-test", s.redirectToHTTPs(s.noCacheHandler(s.alphaTestHandler)))
+	mux.HandleFunc("/template", s.redirectToHTTPS(s.corsHandler(s.templateHandler)))
+	mux.HandleFunc("/alpha-test", s.redirectToHTTPS(s.noCacheHandler(s.alphaTestHandler)))
 	mux.HandleFunc("/health", s.healthHandler)
 	return mux
 }
@@ -150,20 +150,20 @@ func (s *Server) write(w http.ResponseWriter, data []byte) {
 	w.Write(data) // not fmt.Fprintf!
 }
 
-func (s *Server) redirectToHTTPs(wrappedFunc func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
-	if !s.opts.RedirectToHTTPs {
+func (s *Server) redirectToHTTPS(wrappedFunc func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+	if !s.opts.RedirectToHTTPS {
 		return wrappedFunc
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		checkHTTPs := true
+		checkHTTPS := true
 		clientIP, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err == nil {
 			if clientIP == "127.0.0.1" {
-				checkHTTPs = false
+				checkHTTPS = false
 			}
 		}
 
-		if checkHTTPs && r.Header.Get(http.CanonicalHeaderKey("x-forwarded-proto")) != "https" {
+		if checkHTTPS && r.Header.Get(http.CanonicalHeaderKey("x-forwarded-proto")) != "https" {
 			if r.Method == http.MethodGet || r.Method == http.MethodHead {
 				host := r.Header.Get("host")
 				if len(host) == 0 {

--- a/pkg/workspace/library_loader.go
+++ b/pkg/workspace/library_loader.go
@@ -249,7 +249,7 @@ func (ll *LibraryLoader) eval(values *DataValues, libraryValues []*DataValues) (
 
 func (*LibraryLoader) sortedOutputDocSets(outputDocSets map[*FileInLibrary]*yamlmeta.DocumentSet) []*FileInLibrary {
 	var files []*FileInLibrary
-	for file, _ := range outputDocSets {
+	for file := range outputDocSets {
 		files = append(files, file)
 	}
 	SortFilesInLibrary(files)

--- a/pkg/workspace/library_module.go
+++ b/pkg/workspace/library_module.go
@@ -40,7 +40,7 @@ func (b LibraryModule) AsModule() starlark.StringDict {
 	}
 }
 
-func (l LibraryModule) Get(thread *starlark.Thread, f *starlark.Builtin,
+func (b LibraryModule) Get(thread *starlark.Thread, f *starlark.Builtin,
 	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 
 	if args.Len() != 1 {
@@ -52,7 +52,7 @@ func (l LibraryModule) Get(thread *starlark.Thread, f *starlark.Builtin,
 		return starlark.None, err
 	}
 
-	libAlias, tplLoaderOptsOverrides, err := l.getOpts(kwargs)
+	libAlias, tplLoaderOptsOverrides, err := b.getOpts(kwargs)
 	if err != nil {
 		return starlark.None, err
 	}
@@ -62,21 +62,21 @@ func (l LibraryModule) Get(thread *starlark.Thread, f *starlark.Builtin,
 			"Expected library '%s' to be specified without '@'", libPath)
 	}
 
-	foundLib, err := l.libraryCtx.Current.FindAccessibleLibrary(libPath)
+	foundLib, err := b.libraryCtx.Current.FindAccessibleLibrary(libPath)
 	if err != nil {
 		return starlark.None, err
 	}
 
 	// copy over library values
-	dataValuess := append([]*DataValues{}, l.libraryValues...)
+	dataValuess := append([]*DataValues{}, b.libraryValues...)
 	libraryCtx := LibraryExecutionContext{Current: foundLib, Root: foundLib}
 
 	return (&libraryValue{libPath, libAlias, dataValuess, libraryCtx,
-		l.libraryExecutionFactory.WithTemplateLoaderOptsOverrides(tplLoaderOptsOverrides),
+		b.libraryExecutionFactory.WithTemplateLoaderOptsOverrides(tplLoaderOptsOverrides),
 	}).AsStarlarkValue(), nil
 }
 
-func (l LibraryModule) getOpts(kwargs []starlark.Tuple) (string, TemplateLoaderOptsOverrides, error) {
+func (b LibraryModule) getOpts(kwargs []starlark.Tuple) (string, TemplateLoaderOptsOverrides, error) {
 	var alias string
 	var overrides TemplateLoaderOptsOverrides
 

--- a/pkg/workspace/overlay_post_processing.go
+++ b/pkg/workspace/overlay_post_processing.go
@@ -45,14 +45,14 @@ func (o OverlayPostProcessing) Apply() (map[*FileInLibrary]*yamlmeta.DocumentSet
 
 	// Respect assigned file order for data values overlaying to succeed
 	var sortedOverlayFiles []*FileInLibrary
-	for file, _ := range overlayDocSets {
+	for file := range overlayDocSets {
 		sortedOverlayFiles = append(sortedOverlayFiles, file)
 	}
 	SortFilesInLibrary(sortedOverlayFiles)
 
 	for _, file := range sortedOverlayFiles {
 		for _, overlay := range overlayDocSets[file] {
-			op := yttoverlay.OverlayOp{
+			op := yttoverlay.Op{
 				// special case: array of docsets so that file association can be preserved
 				Left: docSetsWithoutOverlays,
 				Right: &yamlmeta.DocumentSet{

--- a/pkg/yamlfmt/printer_test.go
+++ b/pkg/yamlfmt/printer_test.go
@@ -113,7 +113,7 @@ func evalTemplate(t *testing.T, data string) (string, *testErr) {
 func expectEquals(t *testing.T, resultStr, expectedStr string) error {
 	if resultStr != expectedStr {
 		diff := difflib.PPDiff(strings.Split(expectedStr, "\n"), strings.Split(resultStr, "\n"))
-		return fmt.Errorf("Not equal; diff expected...actual:\n%v\n", diff)
+		return fmt.Errorf("Not equal; diff expected...actual:\n%v", diff)
 	}
 	return nil
 }

--- a/pkg/yamlmeta/document.go
+++ b/pkg/yamlmeta/document.go
@@ -7,24 +7,24 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta/internal/yaml.v2"
 )
 
-func (d *Document) IsEmpty() bool {
-	if d.Value == nil {
+func (n *Document) IsEmpty() bool {
+	if n.Value == nil {
 		return true
 	}
 	// TODO remove doc empty checks for map and array
-	if typedMap, isMap := d.Value.(*Map); isMap {
+	if typedMap, isMap := n.Value.(*Map); isMap {
 		return len(typedMap.Items) == 0
 	}
-	if typedArray, isArray := d.Value.(*Array); isArray {
+	if typedArray, isArray := n.Value.(*Array); isArray {
 		return len(typedArray.Items) == 0
 	}
 	return false
 }
 
-func (d *Document) AsYAMLBytes() ([]byte, error) {
-	return yaml.Marshal(convertToLowYAML(convertToGo(d.Value)))
+func (n *Document) AsYAMLBytes() ([]byte, error) {
+	return yaml.Marshal(convertToLowYAML(convertToGo(n.Value)))
 }
 
-func (d *Document) AsInterface() interface{} {
-	return convertToGo(d.Value)
+func (n *Document) AsInterface() interface{} {
+	return convertToGo(n.Value)
 }

--- a/pkg/yamlmeta/document_set.go
+++ b/pkg/yamlmeta/document_set.go
@@ -26,24 +26,24 @@ func NewDocumentSetFromBytes(data []byte, opts DocSetOpts) (*DocumentSet, error)
 	return docSet, nil
 }
 
-func (d *DocumentSet) Print(writer io.Writer) {
-	NewPrinter(writer).Print(d)
+func (n *DocumentSet) Print(writer io.Writer) {
+	NewPrinter(writer).Print(n)
 }
 
 // AsSourceBytes() returns bytes used to make original DocumentSet.
 // Any changes made to the DocumentSet are not reflected in any way
-func (d *DocumentSet) AsSourceBytes() ([]byte, bool) {
-	if d.originalBytes != nil {
-		return *d.originalBytes, true
+func (n *DocumentSet) AsSourceBytes() ([]byte, bool) {
+	if n.originalBytes != nil {
+		return *n.originalBytes, true
 	}
 	return nil, false
 }
 
-func (d *DocumentSet) AsBytes() ([]byte, error) {
-	return d.AsBytesWithPrinter(nil)
+func (n *DocumentSet) AsBytes() ([]byte, error) {
+	return n.AsBytesWithPrinter(nil)
 }
 
-func (d *DocumentSet) AsBytesWithPrinter(printerFunc func(io.Writer) DocumentPrinter) ([]byte, error) {
+func (n *DocumentSet) AsBytesWithPrinter(printerFunc func(io.Writer) DocumentPrinter) ([]byte, error) {
 	if printerFunc == nil {
 		printerFunc = func(w io.Writer) DocumentPrinter { return NewYAMLPrinter(w) }
 	}
@@ -51,7 +51,7 @@ func (d *DocumentSet) AsBytesWithPrinter(printerFunc func(io.Writer) DocumentPri
 	buf := new(bytes.Buffer)
 	printer := printerFunc(buf)
 
-	for _, item := range d.Items {
+	for _, item := range n.Items {
 		if item.injected || item.IsEmpty() {
 			continue
 		}

--- a/pkg/yamlmeta/internal/yaml.v2/apic.go
+++ b/pkg/yamlmeta/internal/yaml.v2/apic.go
@@ -1,168 +1,171 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml
 
 import (
 	"io"
 )
 
-func yaml_insert_token(parser *yaml_parser_t, pos int, token *yaml_token_t) {
+func yamlInsertToken(parser *yamlParserT, pos int, token *yamlTokenT) {
 	//fmt.Println("yaml_insert_token", "pos:", pos, "typ:", token.typ, "head:", parser.tokens_head, "len:", len(parser.tokens))
 
 	// Check if we can move the queue at the beginning of the buffer.
-	if parser.tokens_head > 0 && len(parser.tokens) == cap(parser.tokens) {
-		if parser.tokens_head != len(parser.tokens) {
-			copy(parser.tokens, parser.tokens[parser.tokens_head:])
+	if parser.tokensHead > 0 && len(parser.tokens) == cap(parser.tokens) {
+		if parser.tokensHead != len(parser.tokens) {
+			copy(parser.tokens, parser.tokens[parser.tokensHead:])
 		}
-		parser.tokens = parser.tokens[:len(parser.tokens)-parser.tokens_head]
-		parser.tokens_head = 0
+		parser.tokens = parser.tokens[:len(parser.tokens)-parser.tokensHead]
+		parser.tokensHead = 0
 	}
 	parser.tokens = append(parser.tokens, *token)
 	if pos < 0 {
 		return
 	}
-	copy(parser.tokens[parser.tokens_head+pos+1:], parser.tokens[parser.tokens_head+pos:])
-	parser.tokens[parser.tokens_head+pos] = *token
+	copy(parser.tokens[parser.tokensHead+pos+1:], parser.tokens[parser.tokensHead+pos:])
+	parser.tokens[parser.tokensHead+pos] = *token
 }
 
 // Create a new parser object.
-func yaml_parser_initialize(parser *yaml_parser_t) bool {
-	*parser = yaml_parser_t{
-		raw_buffer: make([]byte, 0, input_raw_buffer_size),
-		buffer:     make([]byte, 0, input_buffer_size),
+func yamlParserInitialize(parser *yamlParserT) bool {
+	*parser = yamlParserT{
+		rawBuffer: make([]byte, 0, inputRawBufferSize),
+		buffer:    make([]byte, 0, inputBufferSize),
 	}
 	return true
 }
 
 // Destroy a parser object.
-func yaml_parser_delete(parser *yaml_parser_t) {
-	*parser = yaml_parser_t{}
+func yamlParserDelete(parser *yamlParserT) {
+	*parser = yamlParserT{}
 }
 
 // String read handler.
-func yaml_string_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err error) {
-	if parser.input_pos == len(parser.input) {
+func yamlStringReadHandler(parser *yamlParserT, buffer []byte) (n int, err error) {
+	if parser.inputPos == len(parser.input) {
 		return 0, io.EOF
 	}
-	n = copy(buffer, parser.input[parser.input_pos:])
-	parser.input_pos += n
+	n = copy(buffer, parser.input[parser.inputPos:])
+	parser.inputPos += n
 	return n, nil
 }
 
 // Reader read handler.
-func yaml_reader_read_handler(parser *yaml_parser_t, buffer []byte) (n int, err error) {
-	return parser.input_reader.Read(buffer)
+func yamlReaderReadHandler(parser *yamlParserT, buffer []byte) (n int, err error) {
+	return parser.inputReader.Read(buffer)
 }
 
 // Set a string input.
-func yaml_parser_set_input_string(parser *yaml_parser_t, input []byte) {
-	if parser.read_handler != nil {
+func yamlParserSetInputString(parser *yamlParserT, input []byte) {
+	if parser.readHandler != nil {
 		panic("must set the input source only once")
 	}
-	parser.read_handler = yaml_string_read_handler
+	parser.readHandler = yamlStringReadHandler
 	parser.input = input
-	parser.input_pos = 0
+	parser.inputPos = 0
 }
 
 // Set a file input.
-func yaml_parser_set_input_reader(parser *yaml_parser_t, r io.Reader) {
-	if parser.read_handler != nil {
+func yamlParserSetInputReader(parser *yamlParserT, r io.Reader) {
+	if parser.readHandler != nil {
 		panic("must set the input source only once")
 	}
-	parser.read_handler = yaml_reader_read_handler
-	parser.input_reader = r
+	parser.readHandler = yamlReaderReadHandler
+	parser.inputReader = r
 }
 
 // Set the source encoding.
-func yaml_parser_set_encoding(parser *yaml_parser_t, encoding yaml_encoding_t) {
-	if parser.encoding != yaml_ANY_ENCODING {
+func yamlParserSetEncoding(parser *yamlParserT, encoding yamlEncodingT) {
+	if parser.encoding != yamlAnyEncoding {
 		panic("must set the encoding only once")
 	}
 	parser.encoding = encoding
 }
 
 // Create a new emitter object.
-func yaml_emitter_initialize(emitter *yaml_emitter_t) {
-	*emitter = yaml_emitter_t{
-		buffer:     make([]byte, output_buffer_size),
-		raw_buffer: make([]byte, 0, output_raw_buffer_size),
-		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
-		events:     make([]yaml_event_t, 0, initial_queue_size),
-		best_width: -1,
+func yamlEmitterInitialize(emitter *yamlEmitterT) {
+	*emitter = yamlEmitterT{
+		buffer:    make([]byte, outputBufferSize),
+		rawBuffer: make([]byte, 0, outputRawBufferSize),
+		states:    make([]yamlEmitterStateT, 0, initialStackSize),
+		events:    make([]yamlEventT, 0, initialQueueSize),
+		bestWidth: -1,
 	}
 }
 
 // Destroy an emitter object.
-func yaml_emitter_delete(emitter *yaml_emitter_t) {
-	*emitter = yaml_emitter_t{}
+func yamlEmitterDelete(emitter *yamlEmitterT) {
+	*emitter = yamlEmitterT{}
 }
 
 // String write handler.
-func yaml_string_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
-	*emitter.output_buffer = append(*emitter.output_buffer, buffer...)
+func yamlStringWriteHandler(emitter *yamlEmitterT, buffer []byte) error {
+	*emitter.outputBuffer = append(*emitter.outputBuffer, buffer...)
 	return nil
 }
 
 // yaml_writer_write_handler uses emitter.output_writer to write the
 // emitted text.
-func yaml_writer_write_handler(emitter *yaml_emitter_t, buffer []byte) error {
-	_, err := emitter.output_writer.Write(buffer)
+func yamlWriterWriteHandler(emitter *yamlEmitterT, buffer []byte) error {
+	_, err := emitter.outputWriter.Write(buffer)
 	return err
 }
 
 // Set a string output.
-func yaml_emitter_set_output_string(emitter *yaml_emitter_t, output_buffer *[]byte) {
-	if emitter.write_handler != nil {
+func yamlEmitterSetOutputString(emitter *yamlEmitterT, outputBuffer *[]byte) {
+	if emitter.writeHandler != nil {
 		panic("must set the output target only once")
 	}
-	emitter.write_handler = yaml_string_write_handler
-	emitter.output_buffer = output_buffer
+	emitter.writeHandler = yamlStringWriteHandler
+	emitter.outputBuffer = outputBuffer
 }
 
 // Set a file output.
-func yaml_emitter_set_output_writer(emitter *yaml_emitter_t, w io.Writer) {
-	if emitter.write_handler != nil {
+func yamlEmitterSetOutputWriter(emitter *yamlEmitterT, w io.Writer) {
+	if emitter.writeHandler != nil {
 		panic("must set the output target only once")
 	}
-	emitter.write_handler = yaml_writer_write_handler
-	emitter.output_writer = w
+	emitter.writeHandler = yamlWriterWriteHandler
+	emitter.outputWriter = w
 }
 
 // Set the output encoding.
-func yaml_emitter_set_encoding(emitter *yaml_emitter_t, encoding yaml_encoding_t) {
-	if emitter.encoding != yaml_ANY_ENCODING {
+func yamlEmitterSetEncoding(emitter *yamlEmitterT, encoding yamlEncodingT) {
+	if emitter.encoding != yamlAnyEncoding {
 		panic("must set the output encoding only once")
 	}
 	emitter.encoding = encoding
 }
 
 // Set the canonical output style.
-func yaml_emitter_set_canonical(emitter *yaml_emitter_t, canonical bool) {
+func yamlEmitterSetCanonical(emitter *yamlEmitterT, canonical bool) {
 	emitter.canonical = canonical
 }
 
 //// Set the indentation increment.
-func yaml_emitter_set_indent(emitter *yaml_emitter_t, indent int) {
+func yamlEmitterSetIndent(emitter *yamlEmitterT, indent int) {
 	if indent < 2 || indent > 9 {
 		indent = 2
 	}
-	emitter.best_indent = indent
+	emitter.bestIndent = indent
 }
 
 // Set the preferred line width.
-func yaml_emitter_set_width(emitter *yaml_emitter_t, width int) {
+func yamlEmitterSetWidth(emitter *yamlEmitterT, width int) {
 	if width < 0 {
 		width = -1
 	}
-	emitter.best_width = width
+	emitter.bestWidth = width
 }
 
 // Set if unescaped non-ASCII characters are allowed.
-func yaml_emitter_set_unicode(emitter *yaml_emitter_t, unicode bool) {
+func yamlEmitterSetUnicode(emitter *yamlEmitterT, unicode bool) {
 	emitter.unicode = unicode
 }
 
 // Set the preferred line break character.
-func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
-	emitter.line_break = line_break
+func yamlEmitterSetBreak(emitter *yamlEmitterT, lineBreak yamlBreakT) {
+	emitter.lineBreak = lineBreak
 }
 
 ///*
@@ -252,39 +255,39 @@ func yaml_emitter_set_break(emitter *yaml_emitter_t, line_break yaml_break_t) {
 //
 
 // Create STREAM-START.
-func yaml_stream_start_event_initialize(event *yaml_event_t, encoding yaml_encoding_t) {
-	*event = yaml_event_t{
-		typ:      yaml_STREAM_START_EVENT,
+func yamlStreamStartEventInitialize(event *yamlEventT, encoding yamlEncodingT) {
+	*event = yamlEventT{
+		typ:      yamlStreamStartEvent,
 		encoding: encoding,
 	}
 }
 
 // Create STREAM-END.
-func yaml_stream_end_event_initialize(event *yaml_event_t) {
-	*event = yaml_event_t{
-		typ: yaml_STREAM_END_EVENT,
+func yamlStreamEndEventInitialize(event *yamlEventT) {
+	*event = yamlEventT{
+		typ: yamlStreamEndEvent,
 	}
 }
 
 // Create DOCUMENT-START.
-func yaml_document_start_event_initialize(
-	event *yaml_event_t,
-	version_directive *yaml_version_directive_t,
-	tag_directives []yaml_tag_directive_t,
+func yamlDocumentStartEventInitialize(
+	event *yamlEventT,
+	versionDirective *yamlVersionDirectiveT,
+	tagDirectives []yamlTagDirectiveT,
 	implicit bool,
 ) {
-	*event = yaml_event_t{
-		typ:               yaml_DOCUMENT_START_EVENT,
-		version_directive: version_directive,
-		tag_directives:    tag_directives,
-		implicit:          implicit,
+	*event = yamlEventT{
+		typ:              yamlDocumentStartEvent,
+		versionDirective: versionDirective,
+		tagDirectives:    tagDirectives,
+		implicit:         implicit,
 	}
 }
 
 // Create DOCUMENT-END.
-func yaml_document_end_event_initialize(event *yaml_event_t, implicit bool) {
-	*event = yaml_event_t{
-		typ:      yaml_DOCUMENT_END_EVENT,
+func yamlDocumentEndEventInitialize(event *yamlEventT, implicit bool) {
+	*event = yamlEventT{
+		typ:      yamlDocumentEndEvent,
 		implicit: implicit,
 	}
 }
@@ -314,60 +317,60 @@ func yaml_document_end_event_initialize(event *yaml_event_t, implicit bool) {
 //}
 
 // Create SCALAR.
-func yaml_scalar_event_initialize(event *yaml_event_t, anchor, tag, value []byte, plain_implicit, quoted_implicit bool, style yaml_scalar_style_t) bool {
-	*event = yaml_event_t{
-		typ:             yaml_SCALAR_EVENT,
-		anchor:          anchor,
-		tag:             tag,
-		value:           value,
-		implicit:        plain_implicit,
-		quoted_implicit: quoted_implicit,
-		style:           yaml_style_t(style),
+func yamlScalarEventInitialize(event *yamlEventT, anchor, tag, value []byte, plainImplicit, quotedImplicit bool, style yamlScalarStyleT) bool {
+	*event = yamlEventT{
+		typ:            yamlScalarEvent,
+		anchor:         anchor,
+		tag:            tag,
+		value:          value,
+		implicit:       plainImplicit,
+		quotedImplicit: quotedImplicit,
+		style:          yamlStyleT(style),
 	}
 	return true
 }
 
 // Create SEQUENCE-START.
-func yaml_sequence_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_sequence_style_t) bool {
-	*event = yaml_event_t{
-		typ:      yaml_SEQUENCE_START_EVENT,
+func yamlSequenceStartEventInitialize(event *yamlEventT, anchor, tag []byte, implicit bool, style yamlSequenceStyleT) bool {
+	*event = yamlEventT{
+		typ:      yamlSequenceStartEvent,
 		anchor:   anchor,
 		tag:      tag,
 		implicit: implicit,
-		style:    yaml_style_t(style),
+		style:    yamlStyleT(style),
 	}
 	return true
 }
 
 // Create SEQUENCE-END.
-func yaml_sequence_end_event_initialize(event *yaml_event_t) bool {
-	*event = yaml_event_t{
-		typ: yaml_SEQUENCE_END_EVENT,
+func yamlSequenceEndEventInitialize(event *yamlEventT) bool {
+	*event = yamlEventT{
+		typ: yamlSequenceEndEvent,
 	}
 	return true
 }
 
 // Create MAPPING-START.
-func yaml_mapping_start_event_initialize(event *yaml_event_t, anchor, tag []byte, implicit bool, style yaml_mapping_style_t) {
-	*event = yaml_event_t{
-		typ:      yaml_MAPPING_START_EVENT,
+func yamlMappingStartEventInitialize(event *yamlEventT, anchor, tag []byte, implicit bool, style yamlMappingStyleT) {
+	*event = yamlEventT{
+		typ:      yamlMappingStartEvent,
 		anchor:   anchor,
 		tag:      tag,
 		implicit: implicit,
-		style:    yaml_style_t(style),
+		style:    yamlStyleT(style),
 	}
 }
 
 // Create MAPPING-END.
-func yaml_mapping_end_event_initialize(event *yaml_event_t) {
-	*event = yaml_event_t{
-		typ: yaml_MAPPING_END_EVENT,
+func yamlMappingEndEventInitialize(event *yamlEventT) {
+	*event = yamlEventT{
+		typ: yamlMappingEndEvent,
 	}
 }
 
 // Destroy an event object.
-func yaml_event_delete(event *yaml_event_t) {
-	*event = yaml_event_t{}
+func yamlEventDelete(event *yamlEventT) {
+	*event = yamlEventT{}
 }
 
 ///*

--- a/pkg/yamlmeta/internal/yaml.v2/decode_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/decode_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml_test
 
 import (
@@ -1017,15 +1020,15 @@ func (s *S) TestUnmarshalerTypeErrorProxying(c *C) {
 
 type failingUnmarshaler struct{}
 
-var failingErr = errors.New("failingErr")
+var errFailing = errors.New("errFailing")
 
 func (ft *failingUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	return failingErr
+	return errFailing
 }
 
 func (s *S) TestUnmarshalerError(c *C) {
 	err := yaml.Unmarshal([]byte("a: b"), &failingUnmarshaler{})
-	c.Assert(err, Equals, failingErr)
+	c.Assert(err, Equals, errFailing)
 }
 
 type sliceUnmarshaler []int

--- a/pkg/yamlmeta/internal/yaml.v2/encode_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/encode_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml_test
 
 import (
@@ -540,12 +543,12 @@ func (s *S) TestMarshalerWholeDocument(c *C) {
 type failingMarshaler struct{}
 
 func (ft *failingMarshaler) MarshalYAML() (interface{}, error) {
-	return nil, failingErr
+	return nil, errFailing
 }
 
 func (s *S) TestMarshalerError(c *C) {
 	_, err := yaml.Marshal(&failingMarshaler{})
-	c.Assert(err, Equals, failingErr)
+	c.Assert(err, Equals, errFailing)
 }
 
 func (s *S) TestSortedOutput(c *C) {

--- a/pkg/yamlmeta/internal/yaml.v2/example_embedded_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/example_embedded_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml_test
 
 import (

--- a/pkg/yamlmeta/internal/yaml.v2/parserc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/parserc.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml
 
 import (
@@ -43,125 +46,125 @@ import (
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 
 // Peek the next token in the token queue.
-func peek_token(parser *yaml_parser_t) *yaml_token_t {
-	if parser.token_available || yaml_parser_fetch_more_tokens(parser) {
-		return &parser.tokens[parser.tokens_head]
+func peekToken(parser *yamlParserT) *yamlTokenT {
+	if parser.tokenAvailable || yamlParserFetchMoreTokens(parser) {
+		return &parser.tokens[parser.tokensHead]
 	}
 	return nil
 }
 
 // Remove the next token from the queue (must be called after peek_token).
-func skip_token(parser *yaml_parser_t) {
-	parser.token_available = false
-	parser.tokens_parsed++
-	parser.stream_end_produced = parser.tokens[parser.tokens_head].typ == yaml_STREAM_END_TOKEN
-	parser.tokens_head++
+func skipToken(parser *yamlParserT) {
+	parser.tokenAvailable = false
+	parser.tokensParsed++
+	parser.streamEndProduced = parser.tokens[parser.tokensHead].typ == yamlStreamEndToken
+	parser.tokensHead++
 }
 
 // Get the next event.
-func yaml_parser_parse(parser *yaml_parser_t, event *yaml_event_t) bool {
+func yamlParserParse(parser *yamlParserT, event *yamlEventT) bool {
 	// Erase the event object.
-	*event = yaml_event_t{}
+	*event = yamlEventT{}
 
 	// No events after the end of the stream or error.
-	if parser.stream_end_produced || parser.error != yaml_NO_ERROR || parser.state == yaml_PARSE_END_STATE {
+	if parser.streamEndProduced || parser.error != yamlNoError || parser.state == yamlParseEndState {
 		return true
 	}
 
 	// Generate the next event.
-	return yaml_parser_state_machine(parser, event)
+	return yamlParserStateMachine(parser, event)
 }
 
 // Set parser error.
-func yaml_parser_set_parser_error(parser *yaml_parser_t, problem string, problem_mark yaml_mark_t) bool {
-	parser.error = yaml_PARSER_ERROR
+func yamlParserSetParserError(parser *yamlParserT, problem string, problemMark yamlMarkT) bool {
+	parser.error = yamlParserError
 	parser.problem = problem
-	parser.problem_mark = problem_mark
+	parser.problemMark = problemMark
 	return false
 }
 
-func yaml_parser_set_parser_error_context(parser *yaml_parser_t, context string, context_mark yaml_mark_t, problem string, problem_mark yaml_mark_t) bool {
-	parser.error = yaml_PARSER_ERROR
+func yamlParserSetParserErrorContext(parser *yamlParserT, context string, contextMark yamlMarkT, problem string, problemMark yamlMarkT) bool {
+	parser.error = yamlParserError
 	parser.context = context
-	parser.context_mark = context_mark
+	parser.contextMark = contextMark
 	parser.problem = problem
-	parser.problem_mark = problem_mark
+	parser.problemMark = problemMark
 	return false
 }
 
 // State dispatcher.
-func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool {
+func yamlParserStateMachine(parser *yamlParserT, event *yamlEventT) bool {
 	//trace("yaml_parser_state_machine", "state:", parser.state.String())
 
 	switch parser.state {
-	case yaml_PARSE_STREAM_START_STATE:
-		return yaml_parser_parse_stream_start(parser, event)
+	case yamlParseStreamStartState:
+		return yamlParserParseStreamStart(parser, event)
 
-	case yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE:
-		return yaml_parser_parse_document_start(parser, event, true)
+	case yamlParseImplicitDocumentStartState:
+		return yamlParserParseDocumentStart(parser, event, true)
 
-	case yaml_PARSE_DOCUMENT_START_STATE:
-		return yaml_parser_parse_document_start(parser, event, false)
+	case yamlParseDocumentStartState:
+		return yamlParserParseDocumentStart(parser, event, false)
 
-	case yaml_PARSE_DOCUMENT_CONTENT_STATE:
-		return yaml_parser_parse_document_content(parser, event)
+	case yamlParseDocumentContentState:
+		return yamlParserParseDocumentContent(parser, event)
 
-	case yaml_PARSE_DOCUMENT_END_STATE:
-		return yaml_parser_parse_document_end(parser, event)
+	case yamlParseDocumentEndState:
+		return yamlParserParseDocumentEnd(parser, event)
 
-	case yaml_PARSE_BLOCK_NODE_STATE:
-		return yaml_parser_parse_node(parser, event, true, false)
+	case yamlParseBlockNodeState:
+		return yamlParserParseNode(parser, event, true, false)
 
-	case yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
-		return yaml_parser_parse_node(parser, event, true, true)
+	case yamlParseBlockNodeOrIndentlessSequenceState:
+		return yamlParserParseNode(parser, event, true, true)
 
-	case yaml_PARSE_FLOW_NODE_STATE:
-		return yaml_parser_parse_node(parser, event, false, false)
+	case yamlParseFlowNodeState:
+		return yamlParserParseNode(parser, event, false, false)
 
-	case yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
-		return yaml_parser_parse_block_sequence_entry(parser, event, true)
+	case yamlParseBlockSequenceFirstEntryState:
+		return yamlParserParseBlockSequenceEntry(parser, event, true)
 
-	case yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE:
-		return yaml_parser_parse_block_sequence_entry(parser, event, false)
+	case yamlParseBlockSequenceEntryState:
+		return yamlParserParseBlockSequenceEntry(parser, event, false)
 
-	case yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE:
-		return yaml_parser_parse_indentless_sequence_entry(parser, event)
+	case yamlParseIndentlessSequenceEntryState:
+		return yamlParserParseIndentlessSequenceEntry(parser, event)
 
-	case yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE:
-		return yaml_parser_parse_block_mapping_key(parser, event, true)
+	case yamlParseBlockMappingFirstKeyState:
+		return yamlParserParseBlockMappingKey(parser, event, true)
 
-	case yaml_PARSE_BLOCK_MAPPING_KEY_STATE:
-		return yaml_parser_parse_block_mapping_key(parser, event, false)
+	case yamlParseBlockMappingKeyState:
+		return yamlParserParseBlockMappingKey(parser, event, false)
 
-	case yaml_PARSE_BLOCK_MAPPING_VALUE_STATE:
-		return yaml_parser_parse_block_mapping_value(parser, event)
+	case yamlParseBlockMappingValueState:
+		return yamlParserParseBlockMappingValue(parser, event)
 
-	case yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE:
-		return yaml_parser_parse_flow_sequence_entry(parser, event, true)
+	case yamlParseFlowSequenceFirstEntryState:
+		return yamlParserParseFlowSequenceEntry(parser, event, true)
 
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE:
-		return yaml_parser_parse_flow_sequence_entry(parser, event, false)
+	case yamlParseFlowSequenceEntryState:
+		return yamlParserParseFlowSequenceEntry(parser, event, false)
 
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE:
-		return yaml_parser_parse_flow_sequence_entry_mapping_key(parser, event)
+	case yamlParseFlowSequenceEntryMappingKeyState:
+		return yamlParserParseFlowSequenceEntryMappingKey(parser, event)
 
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE:
-		return yaml_parser_parse_flow_sequence_entry_mapping_value(parser, event)
+	case yamlParseFlowSequenceEntryMappingValueState:
+		return yamlParserParseFlowSequenceEntryMappingValue(parser, event)
 
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE:
-		return yaml_parser_parse_flow_sequence_entry_mapping_end(parser, event)
+	case yamlParseFlowSequenceEntryMappingEndState:
+		return yamlParserParseFlowSequenceEntryMappingEnd(parser, event)
 
-	case yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE:
-		return yaml_parser_parse_flow_mapping_key(parser, event, true)
+	case yamlParseFlowMappingFirstKeyState:
+		return yamlParserParseFlowMappingKey(parser, event, true)
 
-	case yaml_PARSE_FLOW_MAPPING_KEY_STATE:
-		return yaml_parser_parse_flow_mapping_key(parser, event, false)
+	case yamlParseFlowMappingKeyState:
+		return yamlParserParseFlowMappingKey(parser, event, false)
 
-	case yaml_PARSE_FLOW_MAPPING_VALUE_STATE:
-		return yaml_parser_parse_flow_mapping_value(parser, event, false)
+	case yamlParseFlowMappingValueState:
+		return yamlParserParseFlowMappingValue(parser, event, false)
 
-	case yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE:
-		return yaml_parser_parse_flow_mapping_value(parser, event, true)
+	case yamlParseFlowMappingEmptyValueState:
+		return yamlParserParseFlowMappingValue(parser, event, true)
 
 	default:
 		panic("invalid parser state")
@@ -171,22 +174,22 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 // Parse the production:
 // stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
 //              ************
-func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseStreamStart(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	if token.typ != yaml_STREAM_START_TOKEN {
-		return yaml_parser_set_parser_error(parser, "did not find expected <stream-start>", token.start_mark)
+	if token.typ != yamlStreamStartToken {
+		return yamlParserSetParserError(parser, "did not find expected <stream-start>", token.startMark)
 	}
-	parser.state = yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE
-	*event = yaml_event_t{
-		typ:        yaml_STREAM_START_EVENT,
-		start_mark: token.start_mark,
-		end_mark:   token.end_mark,
-		encoding:   token.encoding,
+	parser.state = yamlParseImplicitDocumentStartState
+	*event = yamlEventT{
+		typ:       yamlStreamStartEvent,
+		startMark: token.startMark,
+		endMark:   token.endMark,
+		encoding:  token.encoding,
 	}
-	skip_token(parser)
+	skipToken(parser)
 	return true
 }
 
@@ -195,81 +198,81 @@ func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) 
 //                          *
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //                          *************************
-func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t, implicit bool) bool {
+func yamlParserParseDocumentStart(parser *yamlParserT, event *yamlEventT, implicit bool) bool {
 
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
 	// Parse extra document end indicators.
 	if !implicit {
-		for token.typ == yaml_DOCUMENT_END_TOKEN {
-			skip_token(parser)
-			token = peek_token(parser)
+		for token.typ == yamlDocumentEndToken {
+			skipToken(parser)
+			token = peekToken(parser)
 			if token == nil {
 				return false
 			}
 		}
 	}
 
-	if implicit && token.typ != yaml_VERSION_DIRECTIVE_TOKEN &&
-		token.typ != yaml_TAG_DIRECTIVE_TOKEN &&
-		token.typ != yaml_DOCUMENT_START_TOKEN &&
-		token.typ != yaml_STREAM_END_TOKEN {
+	if implicit && token.typ != yamlVersionDirectiveToken &&
+		token.typ != yamlTagDirectiveToken &&
+		token.typ != yamlDocumentStartToken &&
+		token.typ != yamlStreamEndToken {
 		// Parse an implicit document.
-		if !yaml_parser_process_directives(parser, nil, nil) {
+		if !yamlParserProcessDirectives(parser, nil, nil) {
 			return false
 		}
-		parser.states = append(parser.states, yaml_PARSE_DOCUMENT_END_STATE)
-		parser.state = yaml_PARSE_BLOCK_NODE_STATE
+		parser.states = append(parser.states, yamlParseDocumentEndState)
+		parser.state = yamlParseBlockNodeState
 
-		*event = yaml_event_t{
-			typ:        yaml_DOCUMENT_START_EVENT,
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+		*event = yamlEventT{
+			typ:       yamlDocumentStartEvent,
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
 
-	} else if token.typ != yaml_STREAM_END_TOKEN {
+	} else if token.typ != yamlStreamEndToken {
 		// Parse an explicit document.
-		var version_directive *yaml_version_directive_t
-		var tag_directives []yaml_tag_directive_t
-		start_mark := token.start_mark
-		if !yaml_parser_process_directives(parser, &version_directive, &tag_directives) {
+		var versionDirective *yamlVersionDirectiveT
+		var tagDirectives []yamlTagDirectiveT
+		startMark := token.startMark
+		if !yamlParserProcessDirectives(parser, &versionDirective, &tagDirectives) {
 			return false
 		}
-		token = peek_token(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_DOCUMENT_START_TOKEN {
-			yaml_parser_set_parser_error(parser,
-				"did not find expected <document start>", token.start_mark)
+		if token.typ != yamlDocumentStartToken {
+			yamlParserSetParserError(parser,
+				"did not find expected <document start>", token.startMark)
 			return false
 		}
-		parser.states = append(parser.states, yaml_PARSE_DOCUMENT_END_STATE)
-		parser.state = yaml_PARSE_DOCUMENT_CONTENT_STATE
-		end_mark := token.end_mark
+		parser.states = append(parser.states, yamlParseDocumentEndState)
+		parser.state = yamlParseDocumentContentState
+		endMark := token.endMark
 
-		*event = yaml_event_t{
-			typ:               yaml_DOCUMENT_START_EVENT,
-			start_mark:        start_mark,
-			end_mark:          end_mark,
-			version_directive: version_directive,
-			tag_directives:    tag_directives,
-			implicit:          false,
+		*event = yamlEventT{
+			typ:              yamlDocumentStartEvent,
+			startMark:        startMark,
+			endMark:          endMark,
+			versionDirective: versionDirective,
+			tagDirectives:    tagDirectives,
+			implicit:         false,
 		}
-		skip_token(parser)
+		skipToken(parser)
 
 	} else {
 		// Parse the stream end.
-		parser.state = yaml_PARSE_END_STATE
-		*event = yaml_event_t{
-			typ:        yaml_STREAM_END_EVENT,
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+		parser.state = yamlParseEndState
+		*event = yamlEventT{
+			typ:       yamlStreamEndEvent,
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
-		skip_token(parser)
+		skipToken(parser)
 	}
 
 	return true
@@ -279,22 +282,22 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //                                                    ***********
 //
-func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseDocumentContent(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	if token.typ == yaml_VERSION_DIRECTIVE_TOKEN ||
-		token.typ == yaml_TAG_DIRECTIVE_TOKEN ||
-		token.typ == yaml_DOCUMENT_START_TOKEN ||
-		token.typ == yaml_DOCUMENT_END_TOKEN ||
-		token.typ == yaml_STREAM_END_TOKEN {
+	if token.typ == yamlVersionDirectiveToken ||
+		token.typ == yamlTagDirectiveToken ||
+		token.typ == yamlDocumentStartToken ||
+		token.typ == yamlDocumentEndToken ||
+		token.typ == yamlStreamEndToken {
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
-		return yaml_parser_process_empty_scalar(parser, event,
-			token.start_mark)
+		return yamlParserProcessEmptyScalar(parser, event,
+			token.startMark)
 	}
-	return yaml_parser_parse_node(parser, event, true, false)
+	return yamlParserParseNode(parser, event, true, false)
 }
 
 // Parse the productions:
@@ -302,30 +305,30 @@ func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event
 //                                     *************
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //
-func yaml_parser_parse_document_end(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseDocumentEnd(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	start_mark := token.start_mark
-	end_mark := token.start_mark
+	startMark := token.startMark
+	endMark := token.startMark
 
 	implicit := true
-	if token.typ == yaml_DOCUMENT_END_TOKEN {
-		end_mark = token.end_mark
-		skip_token(parser)
+	if token.typ == yamlDocumentEndToken {
+		endMark = token.endMark
+		skipToken(parser)
 		implicit = false
 	}
 
-	parser.tag_directives = parser.tag_directives[:0]
+	parser.tagDirectives = parser.tagDirectives[:0]
 
-	parser.state = yaml_PARSE_DOCUMENT_START_STATE
-	*event = yaml_event_t{
-		typ:        yaml_DOCUMENT_END_EVENT,
-		start_mark: start_mark,
-		end_mark:   end_mark,
-		implicit:   implicit,
+	parser.state = yamlParseDocumentStartState
+	*event = yamlEventT{
+		typ:       yamlDocumentEndEvent,
+		startMark: startMark,
+		endMark:   endMark,
+		implicit:  implicit,
 	}
 	return true
 }
@@ -356,71 +359,71 @@ func yaml_parser_parse_document_end(parser *yaml_parser_t, event *yaml_event_t) 
 //                                                               ******
 // flow_content         ::= flow_collection | SCALAR
 //                                            ******
-func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, indentless_sequence bool) bool {
+func yamlParserParseNode(parser *yamlParserT, event *yamlEventT, block, indentlessSequence bool) bool {
 	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
 
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	if token.typ == yaml_ALIAS_TOKEN {
+	if token.typ == yamlAliasToken {
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
-		*event = yaml_event_t{
-			typ:        yaml_ALIAS_EVENT,
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
-			anchor:     token.value,
+		*event = yamlEventT{
+			typ:       yamlAliasEvent,
+			startMark: token.startMark,
+			endMark:   token.endMark,
+			anchor:    token.value,
 		}
-		skip_token(parser)
+		skipToken(parser)
 		return true
 	}
 
-	start_mark := token.start_mark
-	end_mark := token.start_mark
+	startMark := token.startMark
+	endMark := token.startMark
 
-	var tag_token bool
-	var tag_handle, tag_suffix, anchor []byte
-	var tag_mark yaml_mark_t
-	if token.typ == yaml_ANCHOR_TOKEN {
+	var tagToken bool
+	var tagHandle, tagSuffix, anchor []byte
+	var tagMark yamlMarkT
+	if token.typ == yamlAnchorToken {
 		anchor = token.value
-		start_mark = token.start_mark
-		end_mark = token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		startMark = token.startMark
+		endMark = token.endMark
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ == yaml_TAG_TOKEN {
-			tag_token = true
-			tag_handle = token.value
-			tag_suffix = token.suffix
-			tag_mark = token.start_mark
-			end_mark = token.end_mark
-			skip_token(parser)
-			token = peek_token(parser)
+		if token.typ == yamlTagToken {
+			tagToken = true
+			tagHandle = token.value
+			tagSuffix = token.suffix
+			tagMark = token.startMark
+			endMark = token.endMark
+			skipToken(parser)
+			token = peekToken(parser)
 			if token == nil {
 				return false
 			}
 		}
-	} else if token.typ == yaml_TAG_TOKEN {
-		tag_token = true
-		tag_handle = token.value
-		tag_suffix = token.suffix
-		start_mark = token.start_mark
-		tag_mark = token.start_mark
-		end_mark = token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+	} else if token.typ == yamlTagToken {
+		tagToken = true
+		tagHandle = token.value
+		tagSuffix = token.suffix
+		startMark = token.startMark
+		tagMark = token.startMark
+		endMark = token.endMark
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ == yaml_ANCHOR_TOKEN {
+		if token.typ == yamlAnchorToken {
 			anchor = token.value
-			end_mark = token.end_mark
-			skip_token(parser)
-			token = peek_token(parser)
+			endMark = token.endMark
+			skipToken(parser)
+			token = peekToken(parser)
 			if token == nil {
 				return false
 			}
@@ -428,121 +431,121 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 	}
 
 	var tag []byte
-	if tag_token {
-		if len(tag_handle) == 0 {
-			tag = tag_suffix
-			tag_suffix = nil
+	if tagToken {
+		if len(tagHandle) == 0 {
+			tag = tagSuffix
+			tagSuffix = nil
 		} else {
-			for i := range parser.tag_directives {
-				if bytes.Equal(parser.tag_directives[i].handle, tag_handle) {
-					tag = append([]byte(nil), parser.tag_directives[i].prefix...)
-					tag = append(tag, tag_suffix...)
+			for i := range parser.tagDirectives {
+				if bytes.Equal(parser.tagDirectives[i].handle, tagHandle) {
+					tag = append([]byte(nil), parser.tagDirectives[i].prefix...)
+					tag = append(tag, tagSuffix...)
 					break
 				}
 			}
 			if len(tag) == 0 {
-				yaml_parser_set_parser_error_context(parser,
-					"while parsing a node", start_mark,
-					"found undefined tag handle", tag_mark)
+				yamlParserSetParserErrorContext(parser,
+					"while parsing a node", startMark,
+					"found undefined tag handle", tagMark)
 				return false
 			}
 		}
 	}
 
 	implicit := len(tag) == 0
-	if indentless_sequence && token.typ == yaml_BLOCK_ENTRY_TOKEN {
-		end_mark = token.end_mark
-		parser.state = yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE
-		*event = yaml_event_t{
-			typ:        yaml_SEQUENCE_START_EVENT,
-			start_mark: start_mark,
-			end_mark:   end_mark,
-			anchor:     anchor,
-			tag:        tag,
-			implicit:   implicit,
-			style:      yaml_style_t(yaml_BLOCK_SEQUENCE_STYLE),
+	if indentlessSequence && token.typ == yamlBlockEntryToken {
+		endMark = token.endMark
+		parser.state = yamlParseIndentlessSequenceEntryState
+		*event = yamlEventT{
+			typ:       yamlSequenceStartEvent,
+			startMark: startMark,
+			endMark:   endMark,
+			anchor:    anchor,
+			tag:       tag,
+			implicit:  implicit,
+			style:     yamlStyleT(yamlBlockSequenceStyle),
 		}
 		return true
 	}
-	if token.typ == yaml_SCALAR_TOKEN {
-		var plain_implicit, quoted_implicit bool
-		end_mark = token.end_mark
-		if (len(tag) == 0 && token.style == yaml_PLAIN_SCALAR_STYLE) || (len(tag) == 1 && tag[0] == '!') {
-			plain_implicit = true
+	if token.typ == yamlScalarToken {
+		var plainImplicit, quotedImplicit bool
+		endMark = token.endMark
+		if (len(tag) == 0 && token.style == yamlPlainScalarStyle) || (len(tag) == 1 && tag[0] == '!') {
+			plainImplicit = true
 		} else if len(tag) == 0 {
-			quoted_implicit = true
+			quotedImplicit = true
 		}
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
 
-		*event = yaml_event_t{
-			typ:             yaml_SCALAR_EVENT,
-			start_mark:      start_mark,
-			end_mark:        end_mark,
-			anchor:          anchor,
-			tag:             tag,
-			value:           token.value,
-			implicit:        plain_implicit,
-			quoted_implicit: quoted_implicit,
-			style:           yaml_style_t(token.style),
+		*event = yamlEventT{
+			typ:            yamlScalarEvent,
+			startMark:      startMark,
+			endMark:        endMark,
+			anchor:         anchor,
+			tag:            tag,
+			value:          token.value,
+			implicit:       plainImplicit,
+			quotedImplicit: quotedImplicit,
+			style:          yamlStyleT(token.style),
 		}
-		skip_token(parser)
+		skipToken(parser)
 		return true
 	}
-	if token.typ == yaml_FLOW_SEQUENCE_START_TOKEN {
+	if token.typ == yamlFlowSequenceStartToken {
 		// [Go] Some of the events below can be merged as they differ only on style.
-		end_mark = token.end_mark
-		parser.state = yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE
-		*event = yaml_event_t{
-			typ:        yaml_SEQUENCE_START_EVENT,
-			start_mark: start_mark,
-			end_mark:   end_mark,
-			anchor:     anchor,
-			tag:        tag,
-			implicit:   implicit,
-			style:      yaml_style_t(yaml_FLOW_SEQUENCE_STYLE),
+		endMark = token.endMark
+		parser.state = yamlParseFlowSequenceFirstEntryState
+		*event = yamlEventT{
+			typ:       yamlSequenceStartEvent,
+			startMark: startMark,
+			endMark:   endMark,
+			anchor:    anchor,
+			tag:       tag,
+			implicit:  implicit,
+			style:     yamlStyleT(yamlFlowSequenceStyle),
 		}
 		return true
 	}
-	if token.typ == yaml_FLOW_MAPPING_START_TOKEN {
-		end_mark = token.end_mark
-		parser.state = yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE
-		*event = yaml_event_t{
-			typ:        yaml_MAPPING_START_EVENT,
-			start_mark: start_mark,
-			end_mark:   end_mark,
-			anchor:     anchor,
-			tag:        tag,
-			implicit:   implicit,
-			style:      yaml_style_t(yaml_FLOW_MAPPING_STYLE),
+	if token.typ == yamlFlowMappingStartToken {
+		endMark = token.endMark
+		parser.state = yamlParseFlowMappingFirstKeyState
+		*event = yamlEventT{
+			typ:       yamlMappingStartEvent,
+			startMark: startMark,
+			endMark:   endMark,
+			anchor:    anchor,
+			tag:       tag,
+			implicit:  implicit,
+			style:     yamlStyleT(yamlFlowMappingStyle),
 		}
 		return true
 	}
-	if block && token.typ == yaml_BLOCK_SEQUENCE_START_TOKEN {
-		end_mark = token.end_mark
-		parser.state = yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE
-		*event = yaml_event_t{
-			typ:        yaml_SEQUENCE_START_EVENT,
-			start_mark: start_mark,
-			end_mark:   end_mark,
-			anchor:     anchor,
-			tag:        tag,
-			implicit:   implicit,
-			style:      yaml_style_t(yaml_BLOCK_SEQUENCE_STYLE),
+	if block && token.typ == yamlBlockSequenceStartToken {
+		endMark = token.endMark
+		parser.state = yamlParseBlockSequenceFirstEntryState
+		*event = yamlEventT{
+			typ:       yamlSequenceStartEvent,
+			startMark: startMark,
+			endMark:   endMark,
+			anchor:    anchor,
+			tag:       tag,
+			implicit:  implicit,
+			style:     yamlStyleT(yamlBlockSequenceStyle),
 		}
 		return true
 	}
-	if block && token.typ == yaml_BLOCK_MAPPING_START_TOKEN {
-		end_mark = token.end_mark
-		parser.state = yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE
-		*event = yaml_event_t{
-			typ:        yaml_MAPPING_START_EVENT,
-			start_mark: start_mark,
-			end_mark:   end_mark,
-			anchor:     anchor,
-			tag:        tag,
-			implicit:   implicit,
-			style:      yaml_style_t(yaml_BLOCK_MAPPING_STYLE),
+	if block && token.typ == yamlBlockMappingStartToken {
+		endMark = token.endMark
+		parser.state = yamlParseBlockMappingFirstKeyState
+		*event = yamlEventT{
+			typ:       yamlMappingStartEvent,
+			startMark: startMark,
+			endMark:   endMark,
+			anchor:    anchor,
+			tag:       tag,
+			implicit:  implicit,
+			style:     yamlStyleT(yamlBlockMappingStyle),
 		}
 		return true
 	}
@@ -550,15 +553,15 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
 
-		*event = yaml_event_t{
-			typ:             yaml_SCALAR_EVENT,
-			start_mark:      start_mark,
-			end_mark:        end_mark,
-			anchor:          anchor,
-			tag:             tag,
-			implicit:        implicit,
-			quoted_implicit: false,
-			style:           yaml_style_t(yaml_PLAIN_SCALAR_STYLE),
+		*event = yamlEventT{
+			typ:            yamlScalarEvent,
+			startMark:      startMark,
+			endMark:        endMark,
+			anchor:         anchor,
+			tag:            tag,
+			implicit:       implicit,
+			quotedImplicit: false,
+			style:          yamlStyleT(yamlPlainScalarStyle),
 		}
 		return true
 	}
@@ -567,8 +570,8 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 	if block {
 		context = "while parsing a block node"
 	}
-	yaml_parser_set_parser_error_context(parser, context, start_mark,
-		"did not find expected node content", token.start_mark)
+	yamlParserSetParserErrorContext(parser, context, startMark,
+		"did not find expected node content", token.startMark)
 	return false
 }
 
@@ -576,96 +579,95 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 // block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
 //                    ********************  *********** *             *********
 //
-func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+func yamlParserParseBlockSequenceEntry(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
-		token := peek_token(parser)
-		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		token := peekToken(parser)
+		parser.marks = append(parser.marks, token.startMark)
+		skipToken(parser)
 	}
 
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
-		parser.pendingSeqItemEvent = &yaml_event_t{
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+	if token.typ == yamlBlockEntryToken {
+		parser.pendingSeqItemEvent = &yamlEventT{
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
-		mark := token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		mark := token.endMark
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_BLOCK_ENTRY_TOKEN && token.typ != yaml_BLOCK_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE)
-			return yaml_parser_parse_node(parser, event, true, false)
-		} else {
-			parser.state = yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE
-			return yaml_parser_process_empty_scalar(parser, event, mark)
+		if token.typ != yamlBlockEntryToken && token.typ != yamlBlockEndToken {
+			parser.states = append(parser.states, yamlParseBlockSequenceEntryState)
+			return yamlParserParseNode(parser, event, true, false)
 		}
+		parser.state = yamlParseBlockSequenceEntryState
+		return yamlParserProcessEmptyScalar(parser, event, mark)
 	}
-	if token.typ == yaml_BLOCK_END_TOKEN {
+	if token.typ == yamlBlockEndToken {
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
 		parser.marks = parser.marks[:len(parser.marks)-1]
 
-		*event = yaml_event_t{
-			typ:        yaml_SEQUENCE_END_EVENT,
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+		*event = yamlEventT{
+			typ:       yamlSequenceEndEvent,
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
 
-		skip_token(parser)
+		skipToken(parser)
 		return true
 	}
 
-	context_mark := parser.marks[len(parser.marks)-1]
+	contextMark := parser.marks[len(parser.marks)-1]
 	parser.marks = parser.marks[:len(parser.marks)-1]
-	return yaml_parser_set_parser_error_context(parser,
-		"while parsing a block collection", context_mark,
-		"did not find expected '-' indicator", token.start_mark)
+	return yamlParserSetParserErrorContext(parser,
+		"while parsing a block collection", contextMark,
+		"did not find expected '-' indicator", token.startMark)
 }
 
 // Parse the productions:
 // indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
 //                           *********** *
-func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseIndentlessSequenceEntry(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	if token.typ == yaml_BLOCK_ENTRY_TOKEN {
-		parser.pendingSeqItemEvent = &yaml_event_t{
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+	if token.typ == yamlBlockEntryToken {
+		parser.pendingSeqItemEvent = &yamlEventT{
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
-		mark := token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+		mark := token.endMark
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_BLOCK_ENTRY_TOKEN &&
-			token.typ != yaml_KEY_TOKEN &&
-			token.typ != yaml_VALUE_TOKEN &&
-			token.typ != yaml_BLOCK_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE)
-			return yaml_parser_parse_node(parser, event, true, false)
+		if token.typ != yamlBlockEntryToken &&
+			token.typ != yamlKeyToken &&
+			token.typ != yamlValueToken &&
+			token.typ != yamlBlockEndToken {
+			parser.states = append(parser.states, yamlParseIndentlessSequenceEntryState)
+			return yamlParserParseNode(parser, event, true, false)
 		}
-		parser.state = yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE
-		return yaml_parser_process_empty_scalar(parser, event, mark)
+		parser.state = yamlParseIndentlessSequenceEntryState
+		return yamlParserProcessEmptyScalar(parser, event, mark)
 	}
 	parser.state = parser.states[len(parser.states)-1]
 	parser.states = parser.states[:len(parser.states)-1]
 
-	*event = yaml_event_t{
-		typ:        yaml_SEQUENCE_END_EVENT,
-		start_mark: token.start_mark,
-		end_mark:   token.start_mark, // [Go] Shouldn't this be token.end_mark?
+	*event = yamlEventT{
+		typ:       yamlSequenceEndEvent,
+		startMark: token.startMark,
+		endMark:   token.startMark, // [Go] Shouldn't this be token.end_mark?
 	}
 	return true
 }
@@ -680,52 +682,51 @@ func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *y
 //                          BLOCK-END
 //                          *********
 //
-func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+func yamlParserParseBlockMappingKey(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
-		token := peek_token(parser)
-		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		token := peekToken(parser)
+		parser.marks = append(parser.marks, token.startMark)
+		skipToken(parser)
 	}
 
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	if token.typ == yaml_KEY_TOKEN {
-		mark := token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+	if token.typ == yamlKeyToken {
+		mark := token.endMark
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_KEY_TOKEN &&
-			token.typ != yaml_VALUE_TOKEN &&
-			token.typ != yaml_BLOCK_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_BLOCK_MAPPING_VALUE_STATE)
-			return yaml_parser_parse_node(parser, event, true, true)
-		} else {
-			parser.state = yaml_PARSE_BLOCK_MAPPING_VALUE_STATE
-			return yaml_parser_process_empty_scalar(parser, event, mark)
+		if token.typ != yamlKeyToken &&
+			token.typ != yamlValueToken &&
+			token.typ != yamlBlockEndToken {
+			parser.states = append(parser.states, yamlParseBlockMappingValueState)
+			return yamlParserParseNode(parser, event, true, true)
 		}
-	} else if token.typ == yaml_BLOCK_END_TOKEN {
+		parser.state = yamlParseBlockMappingValueState
+		return yamlParserProcessEmptyScalar(parser, event, mark)
+	} else if token.typ == yamlBlockEndToken {
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
 		parser.marks = parser.marks[:len(parser.marks)-1]
-		*event = yaml_event_t{
-			typ:        yaml_MAPPING_END_EVENT,
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+		*event = yamlEventT{
+			typ:       yamlMappingEndEvent,
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
-		skip_token(parser)
+		skipToken(parser)
 		return true
 	}
 
-	context_mark := parser.marks[len(parser.marks)-1]
+	contextMark := parser.marks[len(parser.marks)-1]
 	parser.marks = parser.marks[:len(parser.marks)-1]
-	return yaml_parser_set_parser_error_context(parser,
-		"while parsing a block mapping", context_mark,
-		"did not find expected key", token.start_mark)
+	return yamlParserSetParserErrorContext(parser,
+		"while parsing a block mapping", contextMark,
+		"did not find expected key", token.startMark)
 }
 
 // Parse the productions:
@@ -738,29 +739,29 @@ func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_even
 //                          BLOCK-END
 //
 //
-func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseBlockMappingValue(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	if token.typ == yaml_VALUE_TOKEN {
-		mark := token.end_mark
-		skip_token(parser)
-		token = peek_token(parser)
+	if token.typ == yamlValueToken {
+		mark := token.endMark
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_KEY_TOKEN &&
-			token.typ != yaml_VALUE_TOKEN &&
-			token.typ != yaml_BLOCK_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_BLOCK_MAPPING_KEY_STATE)
-			return yaml_parser_parse_node(parser, event, true, true)
+		if token.typ != yamlKeyToken &&
+			token.typ != yamlValueToken &&
+			token.typ != yamlBlockEndToken {
+			parser.states = append(parser.states, yamlParseBlockMappingKeyState)
+			return yamlParserParseNode(parser, event, true, true)
 		}
-		parser.state = yaml_PARSE_BLOCK_MAPPING_KEY_STATE
-		return yaml_parser_process_empty_scalar(parser, event, mark)
+		parser.state = yamlParseBlockMappingKeyState
+		return yamlParserProcessEmptyScalar(parser, event, mark)
 	}
-	parser.state = yaml_PARSE_BLOCK_MAPPING_KEY_STATE
-	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	parser.state = yamlParseBlockMappingKeyState
+	return yamlParserProcessEmptyScalar(parser, event, token.startMark)
 }
 
 // Parse the productions:
@@ -775,55 +776,55 @@ func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_ev
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //                          *
 //
-func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+func yamlParserParseFlowSequenceEntry(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
-		token := peek_token(parser)
-		parser.pendingSeqItemEvent = &yaml_event_t{
-			start_mark: token.start_mark,
-			end_mark:   token.end_mark,
+		token := peekToken(parser)
+		parser.pendingSeqItemEvent = &yamlEventT{
+			startMark: token.startMark,
+			endMark:   token.endMark,
 		}
-		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		parser.marks = append(parser.marks, token.startMark)
+		skipToken(parser)
 	}
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	if token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
+	if token.typ != yamlFlowSequenceEndToken {
 		if !first {
-			if token.typ == yaml_FLOW_ENTRY_TOKEN {
-				parser.pendingSeqItemEvent = &yaml_event_t{
-					start_mark: token.start_mark,
-					end_mark:   token.end_mark,
+			if token.typ == yamlFlowEntryToken {
+				parser.pendingSeqItemEvent = &yamlEventT{
+					startMark: token.startMark,
+					endMark:   token.endMark,
 				}
-				skip_token(parser)
-				token = peek_token(parser)
+				skipToken(parser)
+				token = peekToken(parser)
 				if token == nil {
 					return false
 				}
 			} else {
-				context_mark := parser.marks[len(parser.marks)-1]
+				contextMark := parser.marks[len(parser.marks)-1]
 				parser.marks = parser.marks[:len(parser.marks)-1]
-				return yaml_parser_set_parser_error_context(parser,
-					"while parsing a flow sequence", context_mark,
-					"did not find expected ',' or ']'", token.start_mark)
+				return yamlParserSetParserErrorContext(parser,
+					"while parsing a flow sequence", contextMark,
+					"did not find expected ',' or ']'", token.startMark)
 			}
 		}
 
-		if token.typ == yaml_KEY_TOKEN {
-			parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE
-			*event = yaml_event_t{
-				typ:        yaml_MAPPING_START_EVENT,
-				start_mark: token.start_mark,
-				end_mark:   token.end_mark,
-				implicit:   true,
-				style:      yaml_style_t(yaml_FLOW_MAPPING_STYLE),
+		if token.typ == yamlKeyToken {
+			parser.state = yamlParseFlowSequenceEntryMappingKeyState
+			*event = yamlEventT{
+				typ:       yamlMappingStartEvent,
+				startMark: token.startMark,
+				endMark:   token.endMark,
+				implicit:  true,
+				style:     yamlStyleT(yamlFlowMappingStyle),
 			}
-			skip_token(parser)
+			skipToken(parser)
 			return true
-		} else if token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+		} else if token.typ != yamlFlowSequenceEndToken {
+			parser.states = append(parser.states, yamlParseFlowSequenceEntryState)
+			return yamlParserParseNode(parser, event, false, false)
 		}
 	}
 
@@ -831,13 +832,13 @@ func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_ev
 	parser.states = parser.states[:len(parser.states)-1]
 	parser.marks = parser.marks[:len(parser.marks)-1]
 
-	*event = yaml_event_t{
-		typ:        yaml_SEQUENCE_END_EVENT,
-		start_mark: token.start_mark,
-		end_mark:   token.end_mark,
+	*event = yamlEventT{
+		typ:       yamlSequenceEndEvent,
+		startMark: token.startMark,
+		endMark:   token.endMark,
 	}
 
-	skip_token(parser)
+	skipToken(parser)
 	return true
 }
 
@@ -846,61 +847,61 @@ func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_ev
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //                                      *** *
 //
-func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseFlowSequenceEntryMappingKey(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	if token.typ != yaml_VALUE_TOKEN &&
-		token.typ != yaml_FLOW_ENTRY_TOKEN &&
-		token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
-		parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE)
-		return yaml_parser_parse_node(parser, event, false, false)
+	if token.typ != yamlValueToken &&
+		token.typ != yamlFlowEntryToken &&
+		token.typ != yamlFlowSequenceEndToken {
+		parser.states = append(parser.states, yamlParseFlowSequenceEntryMappingValueState)
+		return yamlParserParseNode(parser, event, false, false)
 	}
-	mark := token.end_mark
-	skip_token(parser)
-	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE
-	return yaml_parser_process_empty_scalar(parser, event, mark)
+	mark := token.endMark
+	skipToken(parser)
+	parser.state = yamlParseFlowSequenceEntryMappingValueState
+	return yamlParserProcessEmptyScalar(parser, event, mark)
 }
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //                                                      ***** *
 //
-func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseFlowSequenceEntryMappingValue(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	if token.typ == yaml_VALUE_TOKEN {
-		skip_token(parser)
-		token := peek_token(parser)
+	if token.typ == yamlValueToken {
+		skipToken(parser)
+		token := peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_FLOW_ENTRY_TOKEN && token.typ != yaml_FLOW_SEQUENCE_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+		if token.typ != yamlFlowEntryToken && token.typ != yamlFlowSequenceEndToken {
+			parser.states = append(parser.states, yamlParseFlowSequenceEntryMappingEndState)
+			return yamlParserParseNode(parser, event, false, false)
 		}
 	}
-	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE
-	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	parser.state = yamlParseFlowSequenceEntryMappingEndState
+	return yamlParserProcessEmptyScalar(parser, event, token.startMark)
 }
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //                                                                      *
 //
-func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, event *yaml_event_t) bool {
-	token := peek_token(parser)
+func yamlParserParseFlowSequenceEntryMappingEnd(parser *yamlParserT, event *yamlEventT) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
-	parser.state = yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE
-	*event = yaml_event_t{
-		typ:        yaml_MAPPING_END_EVENT,
-		start_mark: token.start_mark,
-		end_mark:   token.start_mark, // [Go] Shouldn't this be end_mark?
+	parser.state = yamlParseFlowSequenceEntryState
+	*event = yamlEventT{
+		typ:       yamlMappingEndEvent,
+		startMark: token.startMark,
+		endMark:   token.startMark, // [Go] Shouldn't this be end_mark?
 	}
 	return true
 }
@@ -917,65 +918,64 @@ func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, ev
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //                          *           *** *
 //
-func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
+func yamlParserParseFlowMappingKey(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
-		token := peek_token(parser)
-		parser.marks = append(parser.marks, token.start_mark)
-		skip_token(parser)
+		token := peekToken(parser)
+		parser.marks = append(parser.marks, token.startMark)
+		skipToken(parser)
 	}
 
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	if token.typ != yaml_FLOW_MAPPING_END_TOKEN {
+	if token.typ != yamlFlowMappingEndToken {
 		if !first {
-			if token.typ == yaml_FLOW_ENTRY_TOKEN {
-				skip_token(parser)
-				token = peek_token(parser)
+			if token.typ == yamlFlowEntryToken {
+				skipToken(parser)
+				token = peekToken(parser)
 				if token == nil {
 					return false
 				}
 			} else {
-				context_mark := parser.marks[len(parser.marks)-1]
+				contextMark := parser.marks[len(parser.marks)-1]
 				parser.marks = parser.marks[:len(parser.marks)-1]
-				return yaml_parser_set_parser_error_context(parser,
-					"while parsing a flow mapping", context_mark,
-					"did not find expected ',' or '}'", token.start_mark)
+				return yamlParserSetParserErrorContext(parser,
+					"while parsing a flow mapping", contextMark,
+					"did not find expected ',' or '}'", token.startMark)
 			}
 		}
 
-		if token.typ == yaml_KEY_TOKEN {
-			skip_token(parser)
-			token = peek_token(parser)
+		if token.typ == yamlKeyToken {
+			skipToken(parser)
+			token = peekToken(parser)
 			if token == nil {
 				return false
 			}
-			if token.typ != yaml_VALUE_TOKEN &&
-				token.typ != yaml_FLOW_ENTRY_TOKEN &&
-				token.typ != yaml_FLOW_MAPPING_END_TOKEN {
-				parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_VALUE_STATE)
-				return yaml_parser_parse_node(parser, event, false, false)
-			} else {
-				parser.state = yaml_PARSE_FLOW_MAPPING_VALUE_STATE
-				return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+			if token.typ != yamlValueToken &&
+				token.typ != yamlFlowEntryToken &&
+				token.typ != yamlFlowMappingEndToken {
+				parser.states = append(parser.states, yamlParseFlowMappingValueState)
+				return yamlParserParseNode(parser, event, false, false)
 			}
-		} else if token.typ != yaml_FLOW_MAPPING_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+			parser.state = yamlParseFlowMappingValueState
+			return yamlParserProcessEmptyScalar(parser, event, token.startMark)
+		} else if token.typ != yamlFlowMappingEndToken {
+			parser.states = append(parser.states, yamlParseFlowMappingEmptyValueState)
+			return yamlParserParseNode(parser, event, false, false)
 		}
 	}
 
 	parser.state = parser.states[len(parser.states)-1]
 	parser.states = parser.states[:len(parser.states)-1]
 	parser.marks = parser.marks[:len(parser.marks)-1]
-	*event = yaml_event_t{
-		typ:        yaml_MAPPING_END_EVENT,
-		start_mark: token.start_mark,
-		end_mark:   token.end_mark,
+	*event = yamlEventT{
+		typ:       yamlMappingEndEvent,
+		startMark: token.startMark,
+		endMark:   token.endMark,
 	}
-	skip_token(parser)
+	skipToken(parser)
 	return true
 }
 
@@ -983,129 +983,129 @@ func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
 //                                   *                  ***** *
 //
-func yaml_parser_parse_flow_mapping_value(parser *yaml_parser_t, event *yaml_event_t, empty bool) bool {
-	token := peek_token(parser)
+func yamlParserParseFlowMappingValue(parser *yamlParserT, event *yamlEventT, empty bool) bool {
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 	if empty {
-		parser.state = yaml_PARSE_FLOW_MAPPING_KEY_STATE
-		return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+		parser.state = yamlParseFlowMappingKeyState
+		return yamlParserProcessEmptyScalar(parser, event, token.startMark)
 	}
-	if token.typ == yaml_VALUE_TOKEN {
-		skip_token(parser)
-		token = peek_token(parser)
+	if token.typ == yamlValueToken {
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
-		if token.typ != yaml_FLOW_ENTRY_TOKEN && token.typ != yaml_FLOW_MAPPING_END_TOKEN {
-			parser.states = append(parser.states, yaml_PARSE_FLOW_MAPPING_KEY_STATE)
-			return yaml_parser_parse_node(parser, event, false, false)
+		if token.typ != yamlFlowEntryToken && token.typ != yamlFlowMappingEndToken {
+			parser.states = append(parser.states, yamlParseFlowMappingKeyState)
+			return yamlParserParseNode(parser, event, false, false)
 		}
 	}
-	parser.state = yaml_PARSE_FLOW_MAPPING_KEY_STATE
-	return yaml_parser_process_empty_scalar(parser, event, token.start_mark)
+	parser.state = yamlParseFlowMappingKeyState
+	return yamlParserProcessEmptyScalar(parser, event, token.startMark)
 }
 
 // Generate an empty scalar event.
-func yaml_parser_process_empty_scalar(parser *yaml_parser_t, event *yaml_event_t, mark yaml_mark_t) bool {
-	*event = yaml_event_t{
-		typ:        yaml_SCALAR_EVENT,
-		start_mark: mark,
-		end_mark:   mark,
-		value:      nil, // Empty
-		implicit:   true,
-		style:      yaml_style_t(yaml_PLAIN_SCALAR_STYLE),
+func yamlParserProcessEmptyScalar(parser *yamlParserT, event *yamlEventT, mark yamlMarkT) bool {
+	*event = yamlEventT{
+		typ:       yamlScalarEvent,
+		startMark: mark,
+		endMark:   mark,
+		value:     nil, // Empty
+		implicit:  true,
+		style:     yamlStyleT(yamlPlainScalarStyle),
 	}
 	return true
 }
 
-var default_tag_directives = []yaml_tag_directive_t{
+var defaultTagDirectives = []yamlTagDirectiveT{
 	{[]byte("!"), []byte("!")},
 	{[]byte("!!"), []byte("tag:yaml.org,2002:")},
 }
 
 // Parse directives.
-func yaml_parser_process_directives(parser *yaml_parser_t,
-	version_directive_ref **yaml_version_directive_t,
-	tag_directives_ref *[]yaml_tag_directive_t) bool {
+func yamlParserProcessDirectives(parser *yamlParserT,
+	versionDirectiveRef **yamlVersionDirectiveT,
+	tagDirectivesRef *[]yamlTagDirectiveT) bool {
 
-	var version_directive *yaml_version_directive_t
-	var tag_directives []yaml_tag_directive_t
+	var versionDirective *yamlVersionDirectiveT
+	var tagDirectives []yamlTagDirectiveT
 
-	token := peek_token(parser)
+	token := peekToken(parser)
 	if token == nil {
 		return false
 	}
 
-	for token.typ == yaml_VERSION_DIRECTIVE_TOKEN || token.typ == yaml_TAG_DIRECTIVE_TOKEN {
-		if token.typ == yaml_VERSION_DIRECTIVE_TOKEN {
-			if version_directive != nil {
-				yaml_parser_set_parser_error(parser,
-					"found duplicate %YAML directive", token.start_mark)
+	for token.typ == yamlVersionDirectiveToken || token.typ == yamlTagDirectiveToken {
+		if token.typ == yamlVersionDirectiveToken {
+			if versionDirective != nil {
+				yamlParserSetParserError(parser,
+					"found duplicate %YAML directive", token.startMark)
 				return false
 			}
 			if token.major != 1 || token.minor != 1 {
-				yaml_parser_set_parser_error(parser,
-					"found incompatible YAML document", token.start_mark)
+				yamlParserSetParserError(parser,
+					"found incompatible YAML document", token.startMark)
 				return false
 			}
-			version_directive = &yaml_version_directive_t{
+			versionDirective = &yamlVersionDirectiveT{
 				major: token.major,
 				minor: token.minor,
 			}
-		} else if token.typ == yaml_TAG_DIRECTIVE_TOKEN {
-			value := yaml_tag_directive_t{
+		} else if token.typ == yamlTagDirectiveToken {
+			value := yamlTagDirectiveT{
 				handle: token.value,
 				prefix: token.prefix,
 			}
-			if !yaml_parser_append_tag_directive(parser, value, false, token.start_mark) {
+			if !yamlParserAppendTagDirective(parser, value, false, token.startMark) {
 				return false
 			}
-			tag_directives = append(tag_directives, value)
+			tagDirectives = append(tagDirectives, value)
 		}
 
-		skip_token(parser)
-		token = peek_token(parser)
+		skipToken(parser)
+		token = peekToken(parser)
 		if token == nil {
 			return false
 		}
 	}
 
-	for i := range default_tag_directives {
-		if !yaml_parser_append_tag_directive(parser, default_tag_directives[i], true, token.start_mark) {
+	for i := range defaultTagDirectives {
+		if !yamlParserAppendTagDirective(parser, defaultTagDirectives[i], true, token.startMark) {
 			return false
 		}
 	}
 
-	if version_directive_ref != nil {
-		*version_directive_ref = version_directive
+	if versionDirectiveRef != nil {
+		*versionDirectiveRef = versionDirective
 	}
-	if tag_directives_ref != nil {
-		*tag_directives_ref = tag_directives
+	if tagDirectivesRef != nil {
+		*tagDirectivesRef = tagDirectives
 	}
 	return true
 }
 
 // Append a tag directive to the directives stack.
-func yaml_parser_append_tag_directive(parser *yaml_parser_t, value yaml_tag_directive_t, allow_duplicates bool, mark yaml_mark_t) bool {
-	for i := range parser.tag_directives {
-		if bytes.Equal(value.handle, parser.tag_directives[i].handle) {
-			if allow_duplicates {
+func yamlParserAppendTagDirective(parser *yamlParserT, value yamlTagDirectiveT, allowDuplicates bool, mark yamlMarkT) bool {
+	for i := range parser.tagDirectives {
+		if bytes.Equal(value.handle, parser.tagDirectives[i].handle) {
+			if allowDuplicates {
 				return true
 			}
-			return yaml_parser_set_parser_error(parser, "found duplicate %TAG directive", mark)
+			return yamlParserSetParserError(parser, "found duplicate %TAG directive", mark)
 		}
 	}
 
 	// [Go] I suspect the copy is unnecessary. This was likely done
 	// because there was no way to track ownership of the data.
-	value_copy := yaml_tag_directive_t{
+	valueCopy := yamlTagDirectiveT{
 		handle: make([]byte, len(value.handle)),
 		prefix: make([]byte, len(value.prefix)),
 	}
-	copy(value_copy.handle, value.handle)
-	copy(value_copy.prefix, value.prefix)
-	parser.tag_directives = append(parser.tag_directives, value_copy)
+	copy(valueCopy.handle, value.handle)
+	copy(valueCopy.prefix, value.prefix)
+	parser.tagDirectives = append(parser.tagDirectives, valueCopy)
 	return true
 }

--- a/pkg/yamlmeta/internal/yaml.v2/sorter.go
+++ b/pkg/yamlmeta/internal/yaml.v2/sorter.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml
 
 import (

--- a/pkg/yamlmeta/internal/yaml.v2/strict_scalar_resolve.go
+++ b/pkg/yamlmeta/internal/yaml.v2/strict_scalar_resolve.go
@@ -46,11 +46,11 @@ func strictScalarResolve(tag, in string) (string, interface{}) {
 func strictScalarResolveConservative(in string) (string, interface{}) {
 	switch in {
 	case "":
-		return yaml_NULL_TAG, nil
+		return yamlNullTag, nil
 	case "true":
-		return yaml_BOOL_TAG, true
+		return yamlBoolTag, true
 	case "false":
-		return yaml_BOOL_TAG, false
+		return yamlBoolTag, false
 
 	default:
 		switch {
@@ -59,16 +59,16 @@ func strictScalarResolveConservative(in string) (string, interface{}) {
 			if err != nil {
 				uintv, err := strconv.ParseUint(in, 0, 64)
 				if err == nil {
-					return yaml_INT_TAG, uintv
+					return yamlIntTag, uintv
 				}
 
 				failf("Strict parsing: Parsing int '%s': %s", in, err)
 				panic("Unreachable")
 			}
 			if intv == int64(int(intv)) {
-				return yaml_INT_TAG, int(intv)
+				return yamlIntTag, int(intv)
 			}
-			return yaml_INT_TAG, intv
+			return yamlIntTag, intv
 
 		case strictStyleFloat.MatchString(in):
 			floatv, err := strconv.ParseFloat(in, 64)
@@ -76,7 +76,7 @@ func strictScalarResolveConservative(in string) (string, interface{}) {
 				failf("Strict parsing: Parsing float '%s': %s", in, err)
 				panic("Unreachable")
 			}
-			return yaml_FLOAT_TAG, floatv
+			return yamlFloatTag, floatv
 
 		case strings.IndexFunc(in, unicode.IsSpace) != -1:
 			failf("Strict parsing: Strings with whitespace must be explicitly quoted: '%s'", in)
@@ -92,7 +92,7 @@ func strictScalarResolveConservative(in string) (string, interface{}) {
 			panic("Unreachable")
 
 		default:
-			return yaml_STR_TAG, in
+			return yamlStrTag, in
 		}
 	}
 }

--- a/pkg/yamlmeta/internal/yaml.v2/suite_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/suite_test.go
@@ -1,8 +1,12 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml_test
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }

--- a/pkg/yamlmeta/internal/yaml.v2/writerc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/writerc.go
@@ -1,26 +1,29 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml
 
 // Set the writer error and return false.
-func yaml_emitter_set_writer_error(emitter *yaml_emitter_t, problem string) bool {
-	emitter.error = yaml_WRITER_ERROR
+func yamlEmitterSetWriterError(emitter *yamlEmitterT, problem string) bool {
+	emitter.error = yamlWriterError
 	emitter.problem = problem
 	return false
 }
 
 // Flush the output buffer.
-func yaml_emitter_flush(emitter *yaml_emitter_t) bool {
-	if emitter.write_handler == nil {
+func yamlEmitterFlush(emitter *yamlEmitterT) bool {
+	if emitter.writeHandler == nil {
 		panic("write handler not set")
 	}
 
 	// Check if the buffer is empty.
-	if emitter.buffer_pos == 0 {
+	if emitter.bufferPos == 0 {
 		return true
 	}
 
-	if err := emitter.write_handler(emitter, emitter.buffer[:emitter.buffer_pos]); err != nil {
-		return yaml_emitter_set_writer_error(emitter, "write error: "+err.Error())
+	if err := emitter.writeHandler(emitter, emitter.buffer[:emitter.bufferPos]); err != nil {
+		return yamlEmitterSetWriterError(emitter, "write error: "+err.Error())
 	}
-	emitter.buffer_pos = 0
+	emitter.bufferPos = 0
 	return true
 }

--- a/pkg/yamlmeta/internal/yaml.v2/yaml.go
+++ b/pkg/yamlmeta/internal/yaml.v2/yaml.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package yaml implements YAML support for the Go language.
 //
 // Source code and other details for the project are available at GitHub:
@@ -177,7 +180,7 @@ func (dec *Decoder) DocumentStartLine() int {
 func (dec *Decoder) Comments() []Comment {
 	var comments []Comment
 	for _, c := range dec.parser.parser.comments {
-		comments = append(comments, Comment{Data: string(c.value), Line: c.start_mark.line})
+		comments = append(comments, Comment{Data: string(c.value), Line: c.startMark.line})
 	}
 	return comments
 }
@@ -204,7 +207,7 @@ func unmarshal(in []byte, out interface{}, strict bool) (comments []Comment, err
 		return nil, &TypeError{d.terrors}
 	}
 	for _, c := range p.parser.comments {
-		comments = append(comments, Comment{Data: string(c.value), Line: c.start_mark.line})
+		comments = append(comments, Comment{Data: string(c.value), Line: c.startMark.line})
 	}
 	return comments, nil
 }
@@ -354,7 +357,7 @@ type fieldInfo struct {
 	Flow      bool
 	// Id holds the unique field identifier, so we can cheaply
 	// check for field duplicates without maintaining an extra map.
-	Id int
+	ID int
 
 	// Inline holds the field index if the field is part of an inlined struct.
 	Inline []int
@@ -403,7 +406,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 				case "inline":
 					inline = true
 				default:
-					return nil, errors.New(fmt.Sprintf("Unsupported flag %q in tag %q of type %s", flag, tag, st))
+					return nil, fmt.Errorf("Unsupported flag %q in tag %q of type %s", flag, tag, st)
 				}
 			}
 			tag = fields[0]
@@ -434,7 +437,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					} else {
 						finfo.Inline = append([]int{i}, finfo.Inline...)
 					}
-					finfo.Id = len(fieldsList)
+					finfo.ID = len(fieldsList)
 					fieldsMap[finfo.Key] = finfo
 					fieldsList = append(fieldsList, finfo)
 				}
@@ -456,7 +459,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 			return nil, errors.New(msg)
 		}
 
-		info.Id = len(fieldsList)
+		info.ID = len(fieldsList)
 		fieldsList = append(fieldsList, info)
 		fieldsMap[info.Key] = info
 	}

--- a/pkg/yamlmeta/internal/yaml.v2/yamlh.go
+++ b/pkg/yamlmeta/internal/yaml.v2/yamlh.go
@@ -1,3 +1,6 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml
 
 import (
@@ -6,59 +9,59 @@ import (
 )
 
 // The version directive data.
-type yaml_version_directive_t struct {
+type yamlVersionDirectiveT struct {
 	major int8 // The major version number.
 	minor int8 // The minor version number.
 }
 
 // The tag directive data.
-type yaml_tag_directive_t struct {
+type yamlTagDirectiveT struct {
 	handle []byte // The tag handle.
 	prefix []byte // The tag prefix.
 }
 
-type yaml_encoding_t int
+type yamlEncodingT int
 
 // The stream encoding.
 const (
 	// Let the parser choose the encoding.
-	yaml_ANY_ENCODING yaml_encoding_t = iota
+	yamlAnyEncoding yamlEncodingT = iota
 
-	yaml_UTF8_ENCODING    // The default UTF-8 encoding.
-	yaml_UTF16LE_ENCODING // The UTF-16-LE encoding with BOM.
-	yaml_UTF16BE_ENCODING // The UTF-16-BE encoding with BOM.
+	yamlUtf8Encoding    // The default UTF-8 encoding.
+	yamlUtf16leEncoding // The UTF-16-LE encoding with BOM.
+	yamlUtf16beEncoding // The UTF-16-BE encoding with BOM.
 )
 
-type yaml_break_t int
+type yamlBreakT int
 
 // Line break types.
 const (
 	// Let the parser choose the break type.
-	yaml_ANY_BREAK yaml_break_t = iota
+	yamlAnyBreak yamlBreakT = iota
 
-	yaml_CR_BREAK   // Use CR for line breaks (Mac style).
-	yaml_LN_BREAK   // Use LN for line breaks (Unix style).
-	yaml_CRLN_BREAK // Use CR LN for line breaks (DOS style).
+	yamlCrBreak   // Use CR for line breaks (Mac style).
+	yamlLnBreak   // Use LN for line breaks (Unix style).
+	yamlCrlnBreak // Use CR LN for line breaks (DOS style).
 )
 
-type yaml_error_type_t int
+type yamlErrorTypeT int
 
 // Many bad things could happen with the parser and emitter.
 const (
 	// No error is produced.
-	yaml_NO_ERROR yaml_error_type_t = iota
+	yamlNoError yamlErrorTypeT = iota
 
-	yaml_MEMORY_ERROR   // Cannot allocate or reallocate a block of memory.
-	yaml_READER_ERROR   // Cannot read or decode the input stream.
-	yaml_SCANNER_ERROR  // Cannot scan the input stream.
-	yaml_PARSER_ERROR   // Cannot parse the input stream.
-	yaml_COMPOSER_ERROR // Cannot compose a YAML document.
-	yaml_WRITER_ERROR   // Cannot write to the output stream.
-	yaml_EMITTER_ERROR  // Cannot emit a YAML stream.
+	yamlMemoryError   // Cannot allocate or reallocate a block of memory.
+	yamlReaderError   // Cannot read or decode the input stream.
+	yamlScannerError  // Cannot scan the input stream.
+	yamlParserError   // Cannot parse the input stream.
+	yamlComposerError // Cannot compose a YAML document.
+	yamlWriterError   // Cannot write to the output stream.
+	yamlEmitterError  // Cannot emit a YAML stream.
 )
 
 // The pointer position.
-type yaml_mark_t struct {
+type yamlMarkT struct {
 	index  int // The position index.
 	line   int // The position line.
 	column int // The position column.
@@ -66,144 +69,144 @@ type yaml_mark_t struct {
 
 // Node Styles
 
-type yaml_style_t int8
+type yamlStyleT int8
 
-type yaml_scalar_style_t yaml_style_t
+type yamlScalarStyleT yamlStyleT
 
 // Scalar styles.
 const (
 	// Let the emitter choose the style.
-	yaml_ANY_SCALAR_STYLE yaml_scalar_style_t = iota
+	yamlAnyScalarStyle yamlScalarStyleT = iota
 
-	yaml_PLAIN_SCALAR_STYLE         // The plain scalar style.
-	yaml_SINGLE_QUOTED_SCALAR_STYLE // The single-quoted scalar style.
-	yaml_DOUBLE_QUOTED_SCALAR_STYLE // The double-quoted scalar style.
-	yaml_LITERAL_SCALAR_STYLE       // The literal scalar style.
-	yaml_FOLDED_SCALAR_STYLE        // The folded scalar style.
+	yamlPlainScalarStyle        // The plain scalar style.
+	yamlSingleQuotedScalarStyle // The single-quoted scalar style.
+	yamlDoubleQuotedScalarStyle // The double-quoted scalar style.
+	yamlLiteralScalarStyle      // The literal scalar style.
+	yamlFoldedScalarStyle       // The folded scalar style.
 )
 
-type yaml_sequence_style_t yaml_style_t
+type yamlSequenceStyleT yamlStyleT
 
 // Sequence styles.
 const (
 	// Let the emitter choose the style.
-	yaml_ANY_SEQUENCE_STYLE yaml_sequence_style_t = iota
+	yamlAnySequenceStyle yamlSequenceStyleT = iota
 
-	yaml_BLOCK_SEQUENCE_STYLE // The block sequence style.
-	yaml_FLOW_SEQUENCE_STYLE  // The flow sequence style.
+	yamlBlockSequenceStyle // The block sequence style.
+	yamlFlowSequenceStyle  // The flow sequence style.
 )
 
-type yaml_mapping_style_t yaml_style_t
+type yamlMappingStyleT yamlStyleT
 
 // Mapping styles.
 const (
 	// Let the emitter choose the style.
-	yaml_ANY_MAPPING_STYLE yaml_mapping_style_t = iota
+	yamlAnyMappingStyle yamlMappingStyleT = iota
 
-	yaml_BLOCK_MAPPING_STYLE // The block mapping style.
-	yaml_FLOW_MAPPING_STYLE  // The flow mapping style.
+	yamlBlockMappingStyle // The block mapping style.
+	yamlFlowMappingStyle  // The flow mapping style.
 )
 
 // Tokens
 
-type yaml_token_type_t int
+type yamlTokenTypeT int
 
 // Token types.
 const (
 	// An empty token.
-	yaml_NO_TOKEN yaml_token_type_t = iota
+	yamlNoToken yamlTokenTypeT = iota
 
-	yaml_STREAM_START_TOKEN // A STREAM-START token.
-	yaml_STREAM_END_TOKEN   // A STREAM-END token.
+	yamlStreamStartToken // A STREAM-START token.
+	yamlStreamEndToken   // A STREAM-END token.
 
-	yaml_VERSION_DIRECTIVE_TOKEN // A VERSION-DIRECTIVE token.
-	yaml_TAG_DIRECTIVE_TOKEN     // A TAG-DIRECTIVE token.
-	yaml_DOCUMENT_START_TOKEN    // A DOCUMENT-START token.
-	yaml_DOCUMENT_END_TOKEN      // A DOCUMENT-END token.
+	yamlVersionDirectiveToken // A VERSION-DIRECTIVE token.
+	yamlTagDirectiveToken     // A TAG-DIRECTIVE token.
+	yamlDocumentStartToken    // A DOCUMENT-START token.
+	yamlDocumentEndToken      // A DOCUMENT-END token.
 
-	yaml_BLOCK_SEQUENCE_START_TOKEN // A BLOCK-SEQUENCE-START token.
-	yaml_BLOCK_MAPPING_START_TOKEN  // A BLOCK-SEQUENCE-END token.
-	yaml_BLOCK_END_TOKEN            // A BLOCK-END token.
+	yamlBlockSequenceStartToken // A BLOCK-SEQUENCE-START token.
+	yamlBlockMappingStartToken  // A BLOCK-SEQUENCE-END token.
+	yamlBlockEndToken           // A BLOCK-END token.
 
-	yaml_FLOW_SEQUENCE_START_TOKEN // A FLOW-SEQUENCE-START token.
-	yaml_FLOW_SEQUENCE_END_TOKEN   // A FLOW-SEQUENCE-END token.
-	yaml_FLOW_MAPPING_START_TOKEN  // A FLOW-MAPPING-START token.
-	yaml_FLOW_MAPPING_END_TOKEN    // A FLOW-MAPPING-END token.
+	yamlFlowSequenceStartToken // A FLOW-SEQUENCE-START token.
+	yamlFlowSequenceEndToken   // A FLOW-SEQUENCE-END token.
+	yamlFlowMappingStartToken  // A FLOW-MAPPING-START token.
+	yamlFlowMappingEndToken    // A FLOW-MAPPING-END token.
 
-	yaml_BLOCK_ENTRY_TOKEN // A BLOCK-ENTRY token.
-	yaml_FLOW_ENTRY_TOKEN  // A FLOW-ENTRY token.
-	yaml_KEY_TOKEN         // A KEY token.
-	yaml_VALUE_TOKEN       // A VALUE token.
+	yamlBlockEntryToken // A BLOCK-ENTRY token.
+	yamlFlowEntryToken  // A FLOW-ENTRY token.
+	yamlKeyToken        // A KEY token.
+	yamlValueToken      // A VALUE token.
 
-	yaml_ALIAS_TOKEN  // An ALIAS token.
-	yaml_ANCHOR_TOKEN // An ANCHOR token.
-	yaml_TAG_TOKEN    // A TAG token.
-	yaml_SCALAR_TOKEN // A SCALAR token.
-	yaml_COMMENT_TOKEN
+	yamlAliasToken  // An ALIAS token.
+	yamlAnchorToken // An ANCHOR token.
+	yamlTagToken    // A TAG token.
+	yamlScalarToken // A SCALAR token.
+	yamlCommentToken
 )
 
-func (tt yaml_token_type_t) String() string {
+func (tt yamlTokenTypeT) String() string {
 	switch tt {
-	case yaml_NO_TOKEN:
+	case yamlNoToken:
 		return "yaml_NO_TOKEN"
-	case yaml_STREAM_START_TOKEN:
+	case yamlStreamStartToken:
 		return "yaml_STREAM_START_TOKEN"
-	case yaml_STREAM_END_TOKEN:
+	case yamlStreamEndToken:
 		return "yaml_STREAM_END_TOKEN"
-	case yaml_VERSION_DIRECTIVE_TOKEN:
+	case yamlVersionDirectiveToken:
 		return "yaml_VERSION_DIRECTIVE_TOKEN"
-	case yaml_TAG_DIRECTIVE_TOKEN:
+	case yamlTagDirectiveToken:
 		return "yaml_TAG_DIRECTIVE_TOKEN"
-	case yaml_DOCUMENT_START_TOKEN:
+	case yamlDocumentStartToken:
 		return "yaml_DOCUMENT_START_TOKEN"
-	case yaml_DOCUMENT_END_TOKEN:
+	case yamlDocumentEndToken:
 		return "yaml_DOCUMENT_END_TOKEN"
-	case yaml_BLOCK_SEQUENCE_START_TOKEN:
+	case yamlBlockSequenceStartToken:
 		return "yaml_BLOCK_SEQUENCE_START_TOKEN"
-	case yaml_BLOCK_MAPPING_START_TOKEN:
+	case yamlBlockMappingStartToken:
 		return "yaml_BLOCK_MAPPING_START_TOKEN"
-	case yaml_BLOCK_END_TOKEN:
+	case yamlBlockEndToken:
 		return "yaml_BLOCK_END_TOKEN"
-	case yaml_FLOW_SEQUENCE_START_TOKEN:
+	case yamlFlowSequenceStartToken:
 		return "yaml_FLOW_SEQUENCE_START_TOKEN"
-	case yaml_FLOW_SEQUENCE_END_TOKEN:
+	case yamlFlowSequenceEndToken:
 		return "yaml_FLOW_SEQUENCE_END_TOKEN"
-	case yaml_FLOW_MAPPING_START_TOKEN:
+	case yamlFlowMappingStartToken:
 		return "yaml_FLOW_MAPPING_START_TOKEN"
-	case yaml_FLOW_MAPPING_END_TOKEN:
+	case yamlFlowMappingEndToken:
 		return "yaml_FLOW_MAPPING_END_TOKEN"
-	case yaml_BLOCK_ENTRY_TOKEN:
+	case yamlBlockEntryToken:
 		return "yaml_BLOCK_ENTRY_TOKEN"
-	case yaml_FLOW_ENTRY_TOKEN:
+	case yamlFlowEntryToken:
 		return "yaml_FLOW_ENTRY_TOKEN"
-	case yaml_KEY_TOKEN:
+	case yamlKeyToken:
 		return "yaml_KEY_TOKEN"
-	case yaml_VALUE_TOKEN:
+	case yamlValueToken:
 		return "yaml_VALUE_TOKEN"
-	case yaml_ALIAS_TOKEN:
+	case yamlAliasToken:
 		return "yaml_ALIAS_TOKEN"
-	case yaml_ANCHOR_TOKEN:
+	case yamlAnchorToken:
 		return "yaml_ANCHOR_TOKEN"
-	case yaml_TAG_TOKEN:
+	case yamlTagToken:
 		return "yaml_TAG_TOKEN"
-	case yaml_SCALAR_TOKEN:
+	case yamlScalarToken:
 		return "yaml_SCALAR_TOKEN"
-	case yaml_COMMENT_TOKEN:
+	case yamlCommentToken:
 		return "yaml_COMMENT_TOKEN"
 	}
 	return "<unknown token>"
 }
 
 // The token structure.
-type yaml_token_t struct {
+type yamlTokenT struct {
 	// The token type.
-	typ yaml_token_type_t
+	typ yamlTokenTypeT
 
 	// The start/end of the token.
-	start_mark, end_mark yaml_mark_t
+	startMark, endMark yamlMarkT
 
 	// The stream encoding (for yaml_STREAM_START_TOKEN).
-	encoding yaml_encoding_t
+	encoding yamlEncodingT
 
 	// The alias/anchor/scalar value or tag/tag directive handle
 	// (for yaml_ALIAS_TOKEN, yaml_ANCHOR_TOKEN, yaml_SCALAR_TOKEN, yaml_TAG_TOKEN, yaml_TAG_DIRECTIVE_TOKEN).
@@ -216,52 +219,52 @@ type yaml_token_t struct {
 	prefix []byte
 
 	// The scalar style (for yaml_SCALAR_TOKEN).
-	style yaml_scalar_style_t
+	style yamlScalarStyleT
 
 	// The version directive major/minor (for yaml_VERSION_DIRECTIVE_TOKEN).
 	major, minor int8
 }
 
-func (t *yaml_token_t) String() string {
+func (t *yamlTokenT) String() string {
 	return fmt.Sprintf("Token(typ=%s, value=%s)", t.typ.String(), string(t.value))
 }
 
 // Events
 
-type yaml_event_type_t int8
+type yamlEventTypeT int8
 
 // Event types.
 const (
 	// An empty event.
-	yaml_NO_EVENT yaml_event_type_t = iota
+	yamlNoEvent yamlEventTypeT = iota
 
-	yaml_STREAM_START_EVENT   // A STREAM-START event.
-	yaml_STREAM_END_EVENT     // A STREAM-END event.
-	yaml_DOCUMENT_START_EVENT // A DOCUMENT-START event.
-	yaml_DOCUMENT_END_EVENT   // A DOCUMENT-END event.
-	yaml_ALIAS_EVENT          // An ALIAS event.
-	yaml_SCALAR_EVENT         // A SCALAR event.
-	yaml_SEQUENCE_START_EVENT // A SEQUENCE-START event.
-	yaml_SEQUENCE_END_EVENT   // A SEQUENCE-END event.
-	yaml_MAPPING_START_EVENT  // A MAPPING-START event.
-	yaml_MAPPING_END_EVENT    // A MAPPING-END event.
+	yamlStreamStartEvent   // A STREAM-START event.
+	yamlStreamEndEvent     // A STREAM-END event.
+	yamlDocumentStartEvent // A DOCUMENT-START event.
+	yamlDocumentEndEvent   // A DOCUMENT-END event.
+	yamlAliasEvent         // An ALIAS event.
+	yamlScalarEvent        // A SCALAR event.
+	yamlSequenceStartEvent // A SEQUENCE-START event.
+	yamlSequenceEndEvent   // A SEQUENCE-END event.
+	yamlMappingStartEvent  // A MAPPING-START event.
+	yamlMappingEndEvent    // A MAPPING-END event.
 )
 
 var eventStrings = []string{
-	yaml_NO_EVENT:             "none",
-	yaml_STREAM_START_EVENT:   "stream start",
-	yaml_STREAM_END_EVENT:     "stream end",
-	yaml_DOCUMENT_START_EVENT: "document start",
-	yaml_DOCUMENT_END_EVENT:   "document end",
-	yaml_ALIAS_EVENT:          "alias",
-	yaml_SCALAR_EVENT:         "scalar",
-	yaml_SEQUENCE_START_EVENT: "sequence start",
-	yaml_SEQUENCE_END_EVENT:   "sequence end",
-	yaml_MAPPING_START_EVENT:  "mapping start",
-	yaml_MAPPING_END_EVENT:    "mapping end",
+	yamlNoEvent:            "none",
+	yamlStreamStartEvent:   "stream start",
+	yamlStreamEndEvent:     "stream end",
+	yamlDocumentStartEvent: "document start",
+	yamlDocumentEndEvent:   "document end",
+	yamlAliasEvent:         "alias",
+	yamlScalarEvent:        "scalar",
+	yamlSequenceStartEvent: "sequence start",
+	yamlSequenceEndEvent:   "sequence end",
+	yamlMappingStartEvent:  "mapping start",
+	yamlMappingEndEvent:    "mapping end",
 }
 
-func (e yaml_event_type_t) String() string {
+func (e yamlEventTypeT) String() string {
 	if e < 0 || int(e) >= len(eventStrings) {
 		return fmt.Sprintf("unknown event %d", e)
 	}
@@ -269,22 +272,22 @@ func (e yaml_event_type_t) String() string {
 }
 
 // The event structure.
-type yaml_event_t struct {
+type yamlEventT struct {
 
 	// The event type.
-	typ yaml_event_type_t
+	typ yamlEventTypeT
 
 	// The start and end of the event.
-	start_mark, end_mark yaml_mark_t
+	startMark, endMark yamlMarkT
 
 	// The document encoding (for yaml_STREAM_START_EVENT).
-	encoding yaml_encoding_t
+	encoding yamlEncodingT
 
 	// The version directive (for yaml_DOCUMENT_START_EVENT).
-	version_directive *yaml_version_directive_t
+	versionDirective *yamlVersionDirectiveT
 
 	// The list of tag directives (for yaml_DOCUMENT_START_EVENT).
-	tag_directives []yaml_tag_directive_t
+	tagDirectives []yamlTagDirectiveT
 
 	// The anchor (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT, yaml_ALIAS_EVENT).
 	anchor []byte
@@ -300,112 +303,112 @@ type yaml_event_t struct {
 	implicit bool
 
 	// Is the tag optional for any non-plain style? (for yaml_SCALAR_EVENT).
-	quoted_implicit bool
+	quotedImplicit bool
 
 	// The style (for yaml_SCALAR_EVENT, yaml_SEQUENCE_START_EVENT, yaml_MAPPING_START_EVENT).
-	style yaml_style_t
+	style yamlStyleT
 }
 
-func (e *yaml_event_t) scalar_style() yaml_scalar_style_t     { return yaml_scalar_style_t(e.style) }
-func (e *yaml_event_t) sequence_style() yaml_sequence_style_t { return yaml_sequence_style_t(e.style) }
-func (e *yaml_event_t) mapping_style() yaml_mapping_style_t   { return yaml_mapping_style_t(e.style) }
+func (e *yamlEventT) scalarStyle() yamlScalarStyleT     { return yamlScalarStyleT(e.style) }
+func (e *yamlEventT) sequenceStyle() yamlSequenceStyleT { return yamlSequenceStyleT(e.style) }
+func (e *yamlEventT) mappingStyle() yamlMappingStyleT   { return yamlMappingStyleT(e.style) }
 
 // Nodes
 
 const (
-	yaml_NULL_TAG      = "tag:yaml.org,2002:null"      // The tag !!null with the only possible value: null.
-	yaml_BOOL_TAG      = "tag:yaml.org,2002:bool"      // The tag !!bool with the values: true and false.
-	yaml_STR_TAG       = "tag:yaml.org,2002:str"       // The tag !!str for string values.
-	yaml_INT_TAG       = "tag:yaml.org,2002:int"       // The tag !!int for integer values.
-	yaml_FLOAT_TAG     = "tag:yaml.org,2002:float"     // The tag !!float for float values.
-	yaml_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp" // The tag !!timestamp for date and time values.
+	yamlNullTag      = "tag:yaml.org,2002:null"      // The tag !!null with the only possible value: null.
+	yamlBoolTag      = "tag:yaml.org,2002:bool"      // The tag !!bool with the values: true and false.
+	yamlStrTag       = "tag:yaml.org,2002:str"       // The tag !!str for string values.
+	yamlIntTag       = "tag:yaml.org,2002:int"       // The tag !!int for integer values.
+	yamlFloatTag     = "tag:yaml.org,2002:float"     // The tag !!float for float values.
+	yamlTimestampTag = "tag:yaml.org,2002:timestamp" // The tag !!timestamp for date and time values.
 
-	yaml_SEQ_TAG = "tag:yaml.org,2002:seq" // The tag !!seq is used to denote sequences.
-	yaml_MAP_TAG = "tag:yaml.org,2002:map" // The tag !!map is used to denote mapping.
+	yamlSeqTag = "tag:yaml.org,2002:seq" // The tag !!seq is used to denote sequences.
+	yamlMapTag = "tag:yaml.org,2002:map" // The tag !!map is used to denote mapping.
 
 	// Not in original libyaml.
-	yaml_BINARY_TAG = "tag:yaml.org,2002:binary"
-	yaml_MERGE_TAG  = "tag:yaml.org,2002:merge"
+	yamlBinaryTag = "tag:yaml.org,2002:binary"
+	yamlMergeTag  = "tag:yaml.org,2002:merge"
 
-	yaml_DEFAULT_SCALAR_TAG   = yaml_STR_TAG // The default scalar tag is !!str.
-	yaml_DEFAULT_SEQUENCE_TAG = yaml_SEQ_TAG // The default sequence tag is !!seq.
-	yaml_DEFAULT_MAPPING_TAG  = yaml_MAP_TAG // The default mapping tag is !!map.
+	yamlDefaultScalarTag   = yamlStrTag // The default scalar tag is !!str.
+	yamlDefaultSequenceTag = yamlSeqTag // The default sequence tag is !!seq.
+	yamlDefaultMappingTag  = yamlMapTag // The default mapping tag is !!map.
 )
 
-type yaml_node_type_t int
+type yamlNodeTypeT int
 
 // Node types.
 const (
 	// An empty node.
-	yaml_NO_NODE yaml_node_type_t = iota
+	yamlNoNode yamlNodeTypeT = iota
 
-	yaml_SCALAR_NODE   // A scalar node.
-	yaml_SEQUENCE_NODE // A sequence node.
-	yaml_MAPPING_NODE  // A mapping node.
+	yamlScalarNode   // A scalar node.
+	yamlSequenceNode // A sequence node.
+	yamlMappingNode  // A mapping node.
 )
 
 // An element of a sequence node.
-type yaml_node_item_t int
+type yamlNodeItemT int
 
 // An element of a mapping node.
-type yaml_node_pair_t struct {
+type yamlNodePairT struct {
 	key   int // The key of the element.
 	value int // The value of the element.
 }
 
 // The node structure.
-type yaml_node_t struct {
-	typ yaml_node_type_t // The node type.
-	tag []byte           // The node tag.
+type yamlNodeT struct {
+	typ yamlNodeTypeT // The node type.
+	tag []byte        // The node tag.
 
 	// The node data.
 
 	// The scalar parameters (for yaml_SCALAR_NODE).
 	scalar struct {
-		value  []byte              // The scalar value.
-		length int                 // The length of the scalar value.
-		style  yaml_scalar_style_t // The scalar style.
+		value  []byte           // The scalar value.
+		length int              // The length of the scalar value.
+		style  yamlScalarStyleT // The scalar style.
 	}
 
 	// The sequence parameters (for YAML_SEQUENCE_NODE).
 	sequence struct {
-		items_data []yaml_node_item_t    // The stack of sequence items.
-		style      yaml_sequence_style_t // The sequence style.
+		itemsData []yamlNodeItemT    // The stack of sequence items.
+		style     yamlSequenceStyleT // The sequence style.
 	}
 
 	// The mapping parameters (for yaml_MAPPING_NODE).
 	mapping struct {
-		pairs_data  []yaml_node_pair_t   // The stack of mapping pairs (key, value).
-		pairs_start *yaml_node_pair_t    // The beginning of the stack.
-		pairs_end   *yaml_node_pair_t    // The end of the stack.
-		pairs_top   *yaml_node_pair_t    // The top of the stack.
-		style       yaml_mapping_style_t // The mapping style.
+		pairsData  []yamlNodePairT   // The stack of mapping pairs (key, value).
+		pairsStart *yamlNodePairT    // The beginning of the stack.
+		pairsEnd   *yamlNodePairT    // The end of the stack.
+		pairsTop   *yamlNodePairT    // The top of the stack.
+		style      yamlMappingStyleT // The mapping style.
 	}
 
-	start_mark yaml_mark_t // The beginning of the node.
-	end_mark   yaml_mark_t // The end of the node.
+	startMark yamlMarkT // The beginning of the node.
+	endMark   yamlMarkT // The end of the node.
 
 }
 
 // The document structure.
-type yaml_document_t struct {
+type yamlDocumentT struct {
 
 	// The document nodes.
-	nodes []yaml_node_t
+	nodes []yamlNodeT
 
 	// The version directive.
-	version_directive *yaml_version_directive_t
+	versionDirective *yamlVersionDirectiveT
 
 	// The list of tag directives.
-	tag_directives_data  []yaml_tag_directive_t
-	tag_directives_start int // The beginning of the tag directives list.
-	tag_directives_end   int // The end of the tag directives list.
+	tagDirectivesData  []yamlTagDirectiveT
+	tagDirectivesStart int // The beginning of the tag directives list.
+	tagDirectivesEnd   int // The end of the tag directives list.
 
-	start_implicit int // Is the document start indicator implicit?
-	end_implicit   int // Is the document end indicator implicit?
+	startImplicit int // Is the document start indicator implicit?
+	endImplicit   int // Is the document end indicator implicit?
 
 	// The start/end of the document.
-	start_mark, end_mark yaml_mark_t
+	startMark, endMark yamlMarkT
 }
 
 // The prototype of a read handler.
@@ -423,185 +426,185 @@ type yaml_document_t struct {
 // On success, the handler should return 1.  If the handler failed,
 // the returned value should be 0. On EOF, the handler should set the
 // size_read to 0 and return 1.
-type yaml_read_handler_t func(parser *yaml_parser_t, buffer []byte) (n int, err error)
+type yamlReadHandlerT func(parser *yamlParserT, buffer []byte) (n int, err error)
 
 // This structure holds information about a potential simple key.
-type yaml_simple_key_t struct {
-	possible     bool        // Is a simple key possible?
-	required     bool        // Is a simple key required?
-	token_number int         // The number of the token.
-	mark         yaml_mark_t // The position mark.
+type yamlSimpleKeyT struct {
+	possible    bool      // Is a simple key possible?
+	required    bool      // Is a simple key required?
+	tokenNumber int       // The number of the token.
+	mark        yamlMarkT // The position mark.
 }
 
 // The states of the parser.
-type yaml_parser_state_t int
+type yamlParserStateT int
 
 const (
-	yaml_PARSE_STREAM_START_STATE yaml_parser_state_t = iota
+	yamlParseStreamStartState yamlParserStateT = iota
 
-	yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE           // Expect the beginning of an implicit document.
-	yaml_PARSE_DOCUMENT_START_STATE                    // Expect DOCUMENT-START.
-	yaml_PARSE_DOCUMENT_CONTENT_STATE                  // Expect the content of a document.
-	yaml_PARSE_DOCUMENT_END_STATE                      // Expect DOCUMENT-END.
-	yaml_PARSE_BLOCK_NODE_STATE                        // Expect a block node.
-	yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE // Expect a block node or indentless sequence.
-	yaml_PARSE_FLOW_NODE_STATE                         // Expect a flow node.
-	yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE        // Expect the first entry of a block sequence.
-	yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE              // Expect an entry of a block sequence.
-	yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE         // Expect an entry of an indentless sequence.
-	yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE           // Expect the first key of a block mapping.
-	yaml_PARSE_BLOCK_MAPPING_KEY_STATE                 // Expect a block mapping key.
-	yaml_PARSE_BLOCK_MAPPING_VALUE_STATE               // Expect a block mapping value.
-	yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE         // Expect the first entry of a flow sequence.
-	yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE               // Expect an entry of a flow sequence.
-	yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE   // Expect a key of an ordered mapping.
-	yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE // Expect a value of an ordered mapping.
-	yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE   // Expect the and of an ordered mapping entry.
-	yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE            // Expect the first key of a flow mapping.
-	yaml_PARSE_FLOW_MAPPING_KEY_STATE                  // Expect a key of a flow mapping.
-	yaml_PARSE_FLOW_MAPPING_VALUE_STATE                // Expect a value of a flow mapping.
-	yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE          // Expect an empty value of a flow mapping.
-	yaml_PARSE_END_STATE                               // Expect nothing.
+	yamlParseImplicitDocumentStartState         // Expect the beginning of an implicit document.
+	yamlParseDocumentStartState                 // Expect DOCUMENT-START.
+	yamlParseDocumentContentState               // Expect the content of a document.
+	yamlParseDocumentEndState                   // Expect DOCUMENT-END.
+	yamlParseBlockNodeState                     // Expect a block node.
+	yamlParseBlockNodeOrIndentlessSequenceState // Expect a block node or indentless sequence.
+	yamlParseFlowNodeState                      // Expect a flow node.
+	yamlParseBlockSequenceFirstEntryState       // Expect the first entry of a block sequence.
+	yamlParseBlockSequenceEntryState            // Expect an entry of a block sequence.
+	yamlParseIndentlessSequenceEntryState       // Expect an entry of an indentless sequence.
+	yamlParseBlockMappingFirstKeyState          // Expect the first key of a block mapping.
+	yamlParseBlockMappingKeyState               // Expect a block mapping key.
+	yamlParseBlockMappingValueState             // Expect a block mapping value.
+	yamlParseFlowSequenceFirstEntryState        // Expect the first entry of a flow sequence.
+	yamlParseFlowSequenceEntryState             // Expect an entry of a flow sequence.
+	yamlParseFlowSequenceEntryMappingKeyState   // Expect a key of an ordered mapping.
+	yamlParseFlowSequenceEntryMappingValueState // Expect a value of an ordered mapping.
+	yamlParseFlowSequenceEntryMappingEndState   // Expect the and of an ordered mapping entry.
+	yamlParseFlowMappingFirstKeyState           // Expect the first key of a flow mapping.
+	yamlParseFlowMappingKeyState                // Expect a key of a flow mapping.
+	yamlParseFlowMappingValueState              // Expect a value of a flow mapping.
+	yamlParseFlowMappingEmptyValueState         // Expect an empty value of a flow mapping.
+	yamlParseEndState                           // Expect nothing.
 )
 
-func (ps yaml_parser_state_t) String() string {
+func (ps yamlParserStateT) String() string {
 	switch ps {
-	case yaml_PARSE_STREAM_START_STATE:
+	case yamlParseStreamStartState:
 		return "yaml_PARSE_STREAM_START_STATE"
-	case yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE:
+	case yamlParseImplicitDocumentStartState:
 		return "yaml_PARSE_IMPLICIT_DOCUMENT_START_STATE"
-	case yaml_PARSE_DOCUMENT_START_STATE:
+	case yamlParseDocumentStartState:
 		return "yaml_PARSE_DOCUMENT_START_STATE"
-	case yaml_PARSE_DOCUMENT_CONTENT_STATE:
+	case yamlParseDocumentContentState:
 		return "yaml_PARSE_DOCUMENT_CONTENT_STATE"
-	case yaml_PARSE_DOCUMENT_END_STATE:
+	case yamlParseDocumentEndState:
 		return "yaml_PARSE_DOCUMENT_END_STATE"
-	case yaml_PARSE_BLOCK_NODE_STATE:
+	case yamlParseBlockNodeState:
 		return "yaml_PARSE_BLOCK_NODE_STATE"
-	case yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE:
+	case yamlParseBlockNodeOrIndentlessSequenceState:
 		return "yaml_PARSE_BLOCK_NODE_OR_INDENTLESS_SEQUENCE_STATE"
-	case yaml_PARSE_FLOW_NODE_STATE:
+	case yamlParseFlowNodeState:
 		return "yaml_PARSE_FLOW_NODE_STATE"
-	case yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE:
+	case yamlParseBlockSequenceFirstEntryState:
 		return "yaml_PARSE_BLOCK_SEQUENCE_FIRST_ENTRY_STATE"
-	case yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE:
+	case yamlParseBlockSequenceEntryState:
 		return "yaml_PARSE_BLOCK_SEQUENCE_ENTRY_STATE"
-	case yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE:
+	case yamlParseIndentlessSequenceEntryState:
 		return "yaml_PARSE_INDENTLESS_SEQUENCE_ENTRY_STATE"
-	case yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE:
+	case yamlParseBlockMappingFirstKeyState:
 		return "yaml_PARSE_BLOCK_MAPPING_FIRST_KEY_STATE"
-	case yaml_PARSE_BLOCK_MAPPING_KEY_STATE:
+	case yamlParseBlockMappingKeyState:
 		return "yaml_PARSE_BLOCK_MAPPING_KEY_STATE"
-	case yaml_PARSE_BLOCK_MAPPING_VALUE_STATE:
+	case yamlParseBlockMappingValueState:
 		return "yaml_PARSE_BLOCK_MAPPING_VALUE_STATE"
-	case yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE:
+	case yamlParseFlowSequenceFirstEntryState:
 		return "yaml_PARSE_FLOW_SEQUENCE_FIRST_ENTRY_STATE"
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE:
+	case yamlParseFlowSequenceEntryState:
 		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_STATE"
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE:
+	case yamlParseFlowSequenceEntryMappingKeyState:
 		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_KEY_STATE"
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE:
+	case yamlParseFlowSequenceEntryMappingValueState:
 		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE_STATE"
-	case yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE:
+	case yamlParseFlowSequenceEntryMappingEndState:
 		return "yaml_PARSE_FLOW_SEQUENCE_ENTRY_MAPPING_END_STATE"
-	case yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE:
+	case yamlParseFlowMappingFirstKeyState:
 		return "yaml_PARSE_FLOW_MAPPING_FIRST_KEY_STATE"
-	case yaml_PARSE_FLOW_MAPPING_KEY_STATE:
+	case yamlParseFlowMappingKeyState:
 		return "yaml_PARSE_FLOW_MAPPING_KEY_STATE"
-	case yaml_PARSE_FLOW_MAPPING_VALUE_STATE:
+	case yamlParseFlowMappingValueState:
 		return "yaml_PARSE_FLOW_MAPPING_VALUE_STATE"
-	case yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE:
+	case yamlParseFlowMappingEmptyValueState:
 		return "yaml_PARSE_FLOW_MAPPING_EMPTY_VALUE_STATE"
-	case yaml_PARSE_END_STATE:
+	case yamlParseEndState:
 		return "yaml_PARSE_END_STATE"
 	}
 	return "<unknown parser state>"
 }
 
 // This structure holds aliases data.
-type yaml_alias_data_t struct {
-	anchor []byte      // The anchor.
-	index  int         // The node id.
-	mark   yaml_mark_t // The anchor mark.
+type yamlAliasDataT struct {
+	anchor []byte    // The anchor.
+	index  int       // The node id.
+	mark   yamlMarkT // The anchor mark.
 }
 
 // The parser structure.
 //
 // All members are internal. Manage the structure using the
 // yaml_parser_ family of functions.
-type yaml_parser_t struct {
+type yamlParserT struct {
 
 	// Error handling
 
-	error yaml_error_type_t // Error type.
+	error yamlErrorTypeT // Error type.
 
 	problem string // Error description.
 
 	// The byte about which the problem occurred.
-	problem_offset int
-	problem_value  int
-	problem_mark   yaml_mark_t
+	problemOffset int
+	problemValue  int
+	problemMark   yamlMarkT
 
 	// The error context.
-	context      string
-	context_mark yaml_mark_t
+	context     string
+	contextMark yamlMarkT
 
 	// Reader stuff
 
-	read_handler yaml_read_handler_t // Read handler.
+	readHandler yamlReadHandlerT // Read handler.
 
-	input_reader io.Reader // File input data.
-	input        []byte    // String input data.
-	input_pos    int
+	inputReader io.Reader // File input data.
+	input       []byte    // String input data.
+	inputPos    int
 
 	eof bool // EOF flag
 
-	buffer     []byte // The working buffer.
-	buffer_pos int    // The current position of the buffer.
+	buffer    []byte // The working buffer.
+	bufferPos int    // The current position of the buffer.
 
 	unread int // The number of unread characters in the buffer.
 
-	raw_buffer     []byte // The raw buffer.
-	raw_buffer_pos int    // The current position of the buffer.
+	rawBuffer    []byte // The raw buffer.
+	rawBufferPos int    // The current position of the buffer.
 
-	encoding yaml_encoding_t // The input encoding.
+	encoding yamlEncodingT // The input encoding.
 
-	offset int         // The offset of the current position (in bytes).
-	mark   yaml_mark_t // The mark of the current position.
+	offset int       // The offset of the current position (in bytes).
+	mark   yamlMarkT // The mark of the current position.
 
 	// Scanner stuff
 
-	stream_start_produced bool // Have we started to scan the input stream?
-	stream_end_produced   bool // Have we reached the end of the input stream?
+	streamStartProduced bool // Have we started to scan the input stream?
+	streamEndProduced   bool // Have we reached the end of the input stream?
 
-	flow_level int // The number of unclosed '[' and '{' indicators.
+	flowLevel int // The number of unclosed '[' and '{' indicators.
 
-	tokens          []yaml_token_t // The tokens queue.
-	tokens_head     int            // The head of the tokens queue.
-	tokens_parsed   int            // The number of tokens fetched from the queue.
-	token_available bool           // Does the tokens queue contain a token ready for dequeueing.
+	tokens         []yamlTokenT // The tokens queue.
+	tokensHead     int          // The head of the tokens queue.
+	tokensParsed   int          // The number of tokens fetched from the queue.
+	tokenAvailable bool         // Does the tokens queue contain a token ready for dequeueing.
 
 	indent  int   // The current indentation level.
 	indents []int // The indentation levels stack.
 
-	simple_key_allowed bool                // May a simple key occur at the current position?
-	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+	simpleKeyAllowed bool             // May a simple key occur at the current position?
+	simpleKeys       []yamlSimpleKeyT // The stack of simple keys.
 
 	// Parser stuff
 
-	state          yaml_parser_state_t    // The current parser state.
-	states         []yaml_parser_state_t  // The parser states stack.
-	marks          []yaml_mark_t          // The stack of marks.
-	tag_directives []yaml_tag_directive_t // The list of TAG directives.
+	state         yamlParserStateT    // The current parser state.
+	states        []yamlParserStateT  // The parser states stack.
+	marks         []yamlMarkT         // The stack of marks.
+	tagDirectives []yamlTagDirectiveT // The list of TAG directives.
 
 	// Dumper stuff
 
-	aliases []yaml_alias_data_t // The alias data.
+	aliases []yamlAliasDataT // The alias data.
 
-	document *yaml_document_t // The currently parsed document.
+	document *yamlDocumentT // The currently parsed document.
 
-	comments            []yaml_token_t
-	pendingSeqItemEvent *yaml_event_t
+	comments            []yamlTokenT
+	pendingSeqItemEvent *yamlEventT
 }
 
 // Emitter Definitions
@@ -620,114 +623,114 @@ type yaml_parser_t struct {
 // @returns On success, the handler should return @c 1.  If the handler failed,
 // the returned value should be @c 0.
 //
-type yaml_write_handler_t func(emitter *yaml_emitter_t, buffer []byte) error
+type yamlWriteHandlerT func(emitter *yamlEmitterT, buffer []byte) error
 
-type yaml_emitter_state_t int
+type yamlEmitterStateT int
 
 // The emitter states.
 const (
 	// Expect STREAM-START.
-	yaml_EMIT_STREAM_START_STATE yaml_emitter_state_t = iota
+	yamlEmitStreamStartState yamlEmitterStateT = iota
 
-	yaml_EMIT_FIRST_DOCUMENT_START_STATE       // Expect the first DOCUMENT-START or STREAM-END.
-	yaml_EMIT_DOCUMENT_START_STATE             // Expect DOCUMENT-START or STREAM-END.
-	yaml_EMIT_DOCUMENT_CONTENT_STATE           // Expect the content of a document.
-	yaml_EMIT_DOCUMENT_END_STATE               // Expect DOCUMENT-END.
-	yaml_EMIT_FLOW_SEQUENCE_FIRST_ITEM_STATE   // Expect the first item of a flow sequence.
-	yaml_EMIT_FLOW_SEQUENCE_ITEM_STATE         // Expect an item of a flow sequence.
-	yaml_EMIT_FLOW_MAPPING_FIRST_KEY_STATE     // Expect the first key of a flow mapping.
-	yaml_EMIT_FLOW_MAPPING_KEY_STATE           // Expect a key of a flow mapping.
-	yaml_EMIT_FLOW_MAPPING_SIMPLE_VALUE_STATE  // Expect a value for a simple key of a flow mapping.
-	yaml_EMIT_FLOW_MAPPING_VALUE_STATE         // Expect a value of a flow mapping.
-	yaml_EMIT_BLOCK_SEQUENCE_FIRST_ITEM_STATE  // Expect the first item of a block sequence.
-	yaml_EMIT_BLOCK_SEQUENCE_ITEM_STATE        // Expect an item of a block sequence.
-	yaml_EMIT_BLOCK_MAPPING_FIRST_KEY_STATE    // Expect the first key of a block mapping.
-	yaml_EMIT_BLOCK_MAPPING_KEY_STATE          // Expect the key of a block mapping.
-	yaml_EMIT_BLOCK_MAPPING_SIMPLE_VALUE_STATE // Expect a value for a simple key of a block mapping.
-	yaml_EMIT_BLOCK_MAPPING_VALUE_STATE        // Expect a value of a block mapping.
-	yaml_EMIT_END_STATE                        // Expect nothing.
+	yamlEmitFirstDocumentStartState      // Expect the first DOCUMENT-START or STREAM-END.
+	yamlEmitDocumentStartState           // Expect DOCUMENT-START or STREAM-END.
+	yamlEmitDocumentContentState         // Expect the content of a document.
+	yamlEmitDocumentEndState             // Expect DOCUMENT-END.
+	yamlEmitFlowSequenceFirstItemState   // Expect the first item of a flow sequence.
+	yamlEmitFlowSequenceItemState        // Expect an item of a flow sequence.
+	yamlEmitFlowMappingFirstKeyState     // Expect the first key of a flow mapping.
+	yamlEmitFlowMappingKeyState          // Expect a key of a flow mapping.
+	yamlEmitFlowMappingSimpleValueState  // Expect a value for a simple key of a flow mapping.
+	yamlEmitFlowMappingValueState        // Expect a value of a flow mapping.
+	yamlEmitBlockSequenceFirstItemState  // Expect the first item of a block sequence.
+	yamlEmitBlockSequenceItemState       // Expect an item of a block sequence.
+	yamlEmitBlockMappingFirstKeyState    // Expect the first key of a block mapping.
+	yamlEmitBlockMappingKeyState         // Expect the key of a block mapping.
+	yamlEmitBlockMappingSimpleValueState // Expect a value for a simple key of a block mapping.
+	yamlEmitBlockMappingValueState       // Expect a value of a block mapping.
+	yamlEmitEndState                     // Expect nothing.
 )
 
 // The emitter structure.
 //
 // All members are internal.  Manage the structure using the @c yaml_emitter_
 // family of functions.
-type yaml_emitter_t struct {
+type yamlEmitterT struct {
 
 	// Error handling
 
-	error   yaml_error_type_t // Error type.
-	problem string            // Error description.
+	error   yamlErrorTypeT // Error type.
+	problem string         // Error description.
 
 	// Writer stuff
 
-	write_handler yaml_write_handler_t // Write handler.
+	writeHandler yamlWriteHandlerT // Write handler.
 
-	output_buffer *[]byte   // String output data.
-	output_writer io.Writer // File output data.
+	outputBuffer *[]byte   // String output data.
+	outputWriter io.Writer // File output data.
 
-	buffer     []byte // The working buffer.
-	buffer_pos int    // The current position of the buffer.
+	buffer    []byte // The working buffer.
+	bufferPos int    // The current position of the buffer.
 
-	raw_buffer     []byte // The raw buffer.
-	raw_buffer_pos int    // The current position of the buffer.
+	rawBuffer    []byte // The raw buffer.
+	rawBufferPos int    // The current position of the buffer.
 
-	encoding yaml_encoding_t // The stream encoding.
+	encoding yamlEncodingT // The stream encoding.
 
 	// Emitter stuff
 
-	canonical   bool         // If the output is in the canonical style?
-	best_indent int          // The number of indentation spaces.
-	best_width  int          // The preferred width of the output lines.
-	unicode     bool         // Allow unescaped non-ASCII characters?
-	line_break  yaml_break_t // The preferred line break.
+	canonical  bool       // If the output is in the canonical style?
+	bestIndent int        // The number of indentation spaces.
+	bestWidth  int        // The preferred width of the output lines.
+	unicode    bool       // Allow unescaped non-ASCII characters?
+	lineBreak  yamlBreakT // The preferred line break.
 
-	state  yaml_emitter_state_t   // The current emitter state.
-	states []yaml_emitter_state_t // The stack of states.
+	state  yamlEmitterStateT   // The current emitter state.
+	states []yamlEmitterStateT // The stack of states.
 
-	events      []yaml_event_t // The event queue.
-	events_head int            // The head of the event queue.
+	events     []yamlEventT // The event queue.
+	eventsHead int          // The head of the event queue.
 
 	indents []int // The stack of indentation levels.
 
-	tag_directives []yaml_tag_directive_t // The list of tag directives.
+	tagDirectives []yamlTagDirectiveT // The list of tag directives.
 
 	indent int // The current indentation level.
 
-	flow_level int // The current flow level.
+	flowLevel int // The current flow level.
 
-	root_context       bool // Is it the document root context?
-	sequence_context   bool // Is it a sequence context?
-	mapping_context    bool // Is it a mapping context?
-	simple_key_context bool // Is it a simple mapping key context?
+	rootContext      bool // Is it the document root context?
+	sequenceContext  bool // Is it a sequence context?
+	mappingContext   bool // Is it a mapping context?
+	simpleKeyContext bool // Is it a simple mapping key context?
 
 	line       int  // The current line.
 	column     int  // The current column.
 	whitespace bool // If the last character was a whitespace?
 	indention  bool // If the last character was an indentation character (' ', '-', '?', ':')?
-	open_ended bool // If an explicit document end is required?
+	openEnded  bool // If an explicit document end is required?
 
 	// Anchor analysis.
-	anchor_data struct {
+	anchorData struct {
 		anchor []byte // The anchor value.
 		alias  bool   // Is it an alias?
 	}
 
 	// Tag analysis.
-	tag_data struct {
+	tagData struct {
 		handle []byte // The tag handle.
 		suffix []byte // The tag suffix.
 	}
 
 	// Scalar analysis.
-	scalar_data struct {
-		value                 []byte              // The scalar value.
-		multiline             bool                // Does the scalar contain line breaks?
-		flow_plain_allowed    bool                // Can the scalar be expessed in the flow plain style?
-		block_plain_allowed   bool                // Can the scalar be expressed in the block plain style?
-		single_quoted_allowed bool                // Can the scalar be expressed in the single quoted style?
-		block_allowed         bool                // Can the scalar be expressed in the literal or folded styles?
-		style                 yaml_scalar_style_t // The output style.
+	scalarData struct {
+		value               []byte           // The scalar value.
+		multiline           bool             // Does the scalar contain line breaks?
+		flowPlainAllowed    bool             // Can the scalar be expessed in the flow plain style?
+		blockPlainAllowed   bool             // Can the scalar be expressed in the block plain style?
+		singleQuotedAllowed bool             // Can the scalar be expressed in the single quoted style?
+		blockAllowed        bool             // Can the scalar be expressed in the literal or folded styles?
+		style               yamlScalarStyleT // The output style.
 	}
 
 	// Dumper stuff
@@ -742,7 +745,7 @@ type yaml_emitter_t struct {
 		serialized bool // If the node has been emitted?
 	}
 
-	last_anchor_id int // The last assigned anchor id.
+	lastAnchorID int // The last assigned anchor id.
 
-	document *yaml_document_t // The currently emitted document.
+	document *yamlDocumentT // The currently emitted document.
 }

--- a/pkg/yamlmeta/internal/yaml.v2/yamlprivateh.go
+++ b/pkg/yamlmeta/internal/yaml.v2/yamlprivateh.go
@@ -1,49 +1,52 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package yaml
 
 const (
 	// The size of the input raw buffer.
-	input_raw_buffer_size = 512
+	inputRawBufferSize = 512
 
 	// The size of the input buffer.
 	// It should be possible to decode the whole raw buffer.
-	input_buffer_size = input_raw_buffer_size * 3
+	inputBufferSize = inputRawBufferSize * 3
 
 	// The size of the output buffer.
-	output_buffer_size = 128
+	outputBufferSize = 128
 
 	// The size of the output raw buffer.
 	// It should be possible to encode the whole output buffer.
-	output_raw_buffer_size = (output_buffer_size*2 + 2)
+	outputRawBufferSize = (outputBufferSize*2 + 2)
 
 	// The size of other stacks and queues.
-	initial_stack_size  = 16
-	initial_queue_size  = 16
-	initial_string_size = 16
+	initialStackSize  = 16
+	initialQueueSize  = 16
+	initialStringSize = 16
 )
 
 // Check if the character at the specified position is an alphabetical
 // character, a digit, '_', or '-'.
-func is_alpha(b []byte, i int) bool {
+func isAlpha(b []byte, i int) bool {
 	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'Z' || b[i] >= 'a' && b[i] <= 'z' || b[i] == '_' || b[i] == '-'
 }
 
 // Check if the character at the specified position is a digit.
-func is_digit(b []byte, i int) bool {
+func isDigit(b []byte, i int) bool {
 	return b[i] >= '0' && b[i] <= '9'
 }
 
 // Get the value of a digit.
-func as_digit(b []byte, i int) int {
+func asDigit(b []byte, i int) int {
 	return int(b[i]) - '0'
 }
 
 // Check if the character at the specified position is a hex-digit.
-func is_hex(b []byte, i int) bool {
+func isHex(b []byte, i int) bool {
 	return b[i] >= '0' && b[i] <= '9' || b[i] >= 'A' && b[i] <= 'F' || b[i] >= 'a' && b[i] <= 'f'
 }
 
 // Get the value of a hex-digit.
-func as_hex(b []byte, i int) int {
+func asHex(b []byte, i int) int {
 	bi := b[i]
 	if bi >= 'A' && bi <= 'F' {
 		return int(bi) - 'A' + 10
@@ -55,12 +58,12 @@ func as_hex(b []byte, i int) int {
 }
 
 // Check if the character is ASCII.
-func is_ascii(b []byte, i int) bool {
+func isASCII(b []byte, i int) bool {
 	return b[i] <= 0x7F
 }
 
 // Check if the character at the start of the buffer can be printed unescaped.
-func is_printable(b []byte, i int) bool {
+func isPrintable(b []byte, i int) bool {
 	return ((b[i] == 0x0A) || // . == #x0A
 		(b[i] >= 0x20 && b[i] <= 0x7E) || // #x20 <= . <= #x7E
 		(b[i] == 0xC2 && b[i+1] >= 0xA0) || // #0xA0 <= . <= #xD7FF
@@ -73,33 +76,33 @@ func is_printable(b []byte, i int) bool {
 }
 
 // Check if the character at the specified position is NUL.
-func is_z(b []byte, i int) bool {
+func isZ(b []byte, i int) bool {
 	return b[i] == 0x00
 }
 
 // Check if the beginning of the buffer is a BOM.
-func is_bom(b []byte, i int) bool {
+func isBom(b []byte, i int) bool {
 	return b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF
 }
 
 // Check if the character at the specified position is space.
-func is_space(b []byte, i int) bool {
+func isSpace(b []byte, i int) bool {
 	return b[i] == ' '
 }
 
 // Check if the character at the specified position is tab.
-func is_tab(b []byte, i int) bool {
+func isTab(b []byte, i int) bool {
 	return b[i] == '\t'
 }
 
 // Check if the character at the specified position is blank (space or tab).
-func is_blank(b []byte, i int) bool {
+func isBlank(b []byte, i int) bool {
 	//return is_space(b, i) || is_tab(b, i)
 	return b[i] == ' ' || b[i] == '\t'
 }
 
 // Check if the character at the specified position is a line break.
-func is_break(b []byte, i int) bool {
+func isBreak(b []byte, i int) bool {
 	return (b[i] == '\r' || // CR (#xD)
 		b[i] == '\n' || // LF (#xA)
 		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
@@ -107,12 +110,12 @@ func is_break(b []byte, i int) bool {
 		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9) // PS (#x2029)
 }
 
-func is_crlf(b []byte, i int) bool {
+func isCrlf(b []byte, i int) bool {
 	return b[i] == '\r' && b[i+1] == '\n'
 }
 
 // Check if the character is a line break or NUL.
-func is_breakz(b []byte, i int) bool {
+func isBreakz(b []byte, i int) bool {
 	//return is_break(b, i) || is_z(b, i)
 	return (        // is_break:
 	b[i] == '\r' || // CR (#xD)
@@ -125,7 +128,7 @@ func is_breakz(b []byte, i int) bool {
 }
 
 // Check if the character is a line break, space, or NUL.
-func is_spacez(b []byte, i int) bool {
+func isSpacez(b []byte, i int) bool {
 	//return is_space(b, i) || is_breakz(b, i)
 	return ( // is_space:
 	b[i] == ' ' ||
@@ -139,7 +142,7 @@ func is_spacez(b []byte, i int) bool {
 }
 
 // Check if the character is a line break, space, tab, or NUL.
-func is_blankz(b []byte, i int) bool {
+func isBlankz(b []byte, i int) bool {
 	//return is_blank(b, i) || is_breakz(b, i)
 	return ( // is_blank:
 	b[i] == ' ' || b[i] == '\t' ||

--- a/pkg/yamlmeta/parser.go
+++ b/pkg/yamlmeta/parser.go
@@ -248,7 +248,7 @@ func (p *Parser) buildLineLocs(val interface{}, nodeAtLines map[int][]Node) {
 
 func (p *Parser) buildLineNums(nodeAtLines map[int][]Node) []int {
 	var result []int
-	for lineNum, _ := range nodeAtLines {
+	for lineNum := range nodeAtLines {
 		result = append(result, lineNum)
 	}
 	sort.Ints(result)

--- a/pkg/yamltemplate/metas.go
+++ b/pkg/yamltemplate/metas.go
@@ -95,7 +95,7 @@ func NewMetas(node yamlmeta.Node, opts MetasOpts) (Metas, error) {
 
 				for keyword, replacementKeyword := range nodeSpecificKeywords {
 					if strings.HasPrefix(code, spacePrefix+keyword) {
-						metas.needsEnds += 1
+						metas.needsEnds++
 						code = strings.Replace(code, spacePrefix+keyword, spacePrefix+replacementKeyword, 1)
 					}
 				}

--- a/pkg/yttlibrary/overlay/api.go
+++ b/pkg/yttlibrary/overlay/api.go
@@ -48,7 +48,7 @@ func (b overlayModule) Apply(
 
 	for _, right := range typedVals[1:] {
 		var err error
-		result, err = OverlayOp{Left: result, Right: right, Thread: thread}.Apply() // left is modified
+		result, err = Op{Left: result, Right: right, Thread: thread}.Apply() // left is modified
 		if err != nil {
 			return starlark.None, err
 		}

--- a/pkg/yttlibrary/overlay/array.go
+++ b/pkg/yttlibrary/overlay/array.go
@@ -7,7 +7,7 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-func (o OverlayOp) mergeArrayItem(
+func (o Op) mergeArrayItem(
 	leftArray *yamlmeta.Array, newItem *yamlmeta.ArrayItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -46,7 +46,7 @@ func (o OverlayOp) mergeArrayItem(
 	return nil
 }
 
-func (o OverlayOp) removeArrayItem(
+func (o Op) removeArrayItem(
 	leftArray *yamlmeta.Array, newItem *yamlmeta.ArrayItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -81,7 +81,7 @@ func (o OverlayOp) removeArrayItem(
 	return nil
 }
 
-func (o OverlayOp) replaceArrayItem(
+func (o Op) replaceArrayItem(
 	leftArray *yamlmeta.Array, newItem *yamlmeta.ArrayItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -116,7 +116,7 @@ func (o OverlayOp) replaceArrayItem(
 	return nil
 }
 
-func (o OverlayOp) insertArrayItem(
+func (o Op) insertArrayItem(
 	leftArray *yamlmeta.Array, newItem *yamlmeta.ArrayItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -165,7 +165,7 @@ func (o OverlayOp) insertArrayItem(
 	return nil
 }
 
-func (o OverlayOp) appendArrayItem(
+func (o Op) appendArrayItem(
 	leftArray *yamlmeta.Array, newItem *yamlmeta.ArrayItem) error {
 
 	// No need to traverse further
@@ -173,7 +173,7 @@ func (o OverlayOp) appendArrayItem(
 	return nil
 }
 
-func (o OverlayOp) assertArrayItem(
+func (o Op) assertArrayItem(
 	leftArray *yamlmeta.Array, newItem *yamlmeta.ArrayItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 

--- a/pkg/yttlibrary/overlay/document.go
+++ b/pkg/yttlibrary/overlay/document.go
@@ -7,7 +7,7 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-func (o OverlayOp) mergeDocument(
+func (o Op) mergeDocument(
 	leftDocSets []*yamlmeta.DocumentSet, newDoc *yamlmeta.Document,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -42,7 +42,7 @@ func (o OverlayOp) mergeDocument(
 	return nil
 }
 
-func (o OverlayOp) removeDocument(
+func (o Op) removeDocument(
 	leftDocSets []*yamlmeta.DocumentSet, newDoc *yamlmeta.Document,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -79,7 +79,7 @@ func (o OverlayOp) removeDocument(
 	return nil
 }
 
-func (o OverlayOp) replaceDocument(
+func (o Op) replaceDocument(
 	leftDocSets []*yamlmeta.DocumentSet, newDoc *yamlmeta.Document,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -114,7 +114,7 @@ func (o OverlayOp) replaceDocument(
 	return nil
 }
 
-func (o OverlayOp) insertDocument(
+func (o Op) insertDocument(
 	leftDocSets []*yamlmeta.DocumentSet, newDoc *yamlmeta.Document,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
@@ -165,7 +165,7 @@ func (o OverlayOp) insertDocument(
 	return nil
 }
 
-func (o OverlayOp) appendDocument(
+func (o Op) appendDocument(
 	leftDocSets []*yamlmeta.DocumentSet, newDoc *yamlmeta.Document) error {
 
 	// No need to traverse further
@@ -173,7 +173,7 @@ func (o OverlayOp) appendDocument(
 	return nil
 }
 
-func (o OverlayOp) assertDocument(
+func (o Op) assertDocument(
 	leftDocSets []*yamlmeta.DocumentSet, newDoc *yamlmeta.Document,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 

--- a/pkg/yttlibrary/overlay/document_match_annotation.go
+++ b/pkg/yttlibrary/overlay/document_match_annotation.go
@@ -114,7 +114,7 @@ func (a DocumentMatchAnnotation) MatchNodes(leftDocSets []*yamlmeta.DocumentSet)
 					matches = append(matches, item.Position)
 				}
 
-				combinedIdx += 1
+				combinedIdx++
 			}
 		}
 

--- a/pkg/yttlibrary/overlay/map.go
+++ b/pkg/yttlibrary/overlay/map.go
@@ -7,7 +7,7 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-func (o OverlayOp) mergeMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
+func (o Op) mergeMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
 	matchChildDefaults, err := NewMatchChildDefaultsAnnotation(newItem, parentMatchChildDefaults)
@@ -47,7 +47,7 @@ func (o OverlayOp) mergeMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem
 	return nil
 }
 
-func (o OverlayOp) removeMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
+func (o Op) removeMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
 	ann, err := NewMapItemMatchAnnotation(newItem, parentMatchChildDefaults, o.Thread)
@@ -81,7 +81,7 @@ func (o OverlayOp) removeMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapIte
 	return nil
 }
 
-func (o OverlayOp) replaceMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
+func (o Op) replaceMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
 	ann, err := NewMapItemMatchAnnotation(newItem, parentMatchChildDefaults, o.Thread)
@@ -115,7 +115,7 @@ func (o OverlayOp) replaceMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapIt
 	return nil
 }
 
-func (o OverlayOp) assertMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
+func (o Op) assertMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) error {
 
 	matchChildDefaults, err := NewMatchChildDefaultsAnnotation(newItem, parentMatchChildDefaults)

--- a/pkg/yttlibrary/overlay/op.go
+++ b/pkg/yttlibrary/overlay/op.go
@@ -12,7 +12,7 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-type OverlayOp struct {
+type Op struct {
 	Left  interface{}
 	Right interface{}
 
@@ -21,7 +21,7 @@ type OverlayOp struct {
 	ExactMatch bool
 }
 
-func (o OverlayOp) Apply() (interface{}, error) {
+func (o Op) Apply() (interface{}, error) {
 	leftObj := yamlmeta.NewASTFromInterface(o.Left)
 	rightObj := yamlmeta.NewASTFromInterface(o.Right)
 
@@ -34,7 +34,7 @@ func (o OverlayOp) Apply() (interface{}, error) {
 	return leftObj, nil
 }
 
-func (o OverlayOp) apply(left, right interface{}, parentMatchChildDefaults MatchChildDefaultsAnnotation) (bool, error) {
+func (o Op) apply(left, right interface{}, parentMatchChildDefaults MatchChildDefaultsAnnotation) (bool, error) {
 	switch typedRight := right.(type) {
 	case *yamlmeta.DocumentSet:
 		var docSetArray []*yamlmeta.DocumentSet
@@ -134,7 +134,7 @@ func (o OverlayOp) apply(left, right interface{}, parentMatchChildDefaults Match
 	return false, nil
 }
 
-func (o OverlayOp) applyDocSet(
+func (o Op) applyDocSet(
 	typedLeft []*yamlmeta.DocumentSet, typedRight *yamlmeta.DocumentSet,
 	parentMatchChildDefaults MatchChildDefaultsAnnotation) (bool, error) {
 
@@ -168,7 +168,7 @@ func (o OverlayOp) applyDocSet(
 	return false, nil
 }
 
-func (o OverlayOp) removeOverlayAnns(val interface{}) {
+func (o Op) removeOverlayAnns(val interface{}) {
 	node, ok := val.(yamlmeta.Node)
 	if !ok {
 		return

--- a/pkg/yttlibrary/template.go
+++ b/pkg/yttlibrary/template.go
@@ -9,15 +9,15 @@ import (
 	"github.com/k14s/ytt/pkg/template/core"
 )
 
-type templateModule struct {
+type TemplateModule struct {
 	replaceNodeFunc core.StarlarkFunc
 }
 
-func NewTemplateModule(replaceNodeFunc core.StarlarkFunc) templateModule {
-	return templateModule{replaceNodeFunc}
+func NewTemplateModule(replaceNodeFunc core.StarlarkFunc) TemplateModule {
+	return TemplateModule{replaceNodeFunc}
 }
 
-func (b templateModule) AsModule() starlark.StringDict {
+func (b TemplateModule) AsModule() starlark.StringDict {
 	return starlark.StringDict{
 		"template": &starlarkstruct.Module{
 			Name: "template",

--- a/pkg/yttlibrary/url.go
+++ b/pkg/yttlibrary/url.go
@@ -172,7 +172,7 @@ func (b urlModule) QueryParamsDecode(thread *starlark.Thread, f *starlark.Builti
 
 func (b urlModule) sortedKeys(vals url.Values) []string {
 	var result []string
-	for k, _ := range vals {
+	for k := range vals {
 		result = append(result, k)
 	}
 	sort.Strings(result)


### PR DESCRIPTION
Adding golangci-lint to run `golint` linter to enforce go styling conventions and `goheader` to enforce whether copyright headers are present for files. 