### PR TITLE
Data values files

### DIFF
--- a/examples/data-values/expected.txt
+++ b/examples/data-values/expected.txt
@@ -27,3 +27,9 @@ string:
 bool: true
 int: 123
 float: 123.123
+***
+nothing: something
+string: str
+bool: true
+int: 124
+float: 0

--- a/examples/data-values/run.sh
+++ b/examples/data-values/run.sh
@@ -37,3 +37,8 @@ export YAML_VAL_string=[1,2,4]
 ./ytt -f examples/data-values/config.yml -f examples/data-values/values.yml \
   --data-value-yaml nothing=[1,2,3] \
   --data-values-env-yaml YAML_VAL
+
+echo '***'
+
+./ytt -f examples/data-values/config.yml -f examples/data-values/values.yml \
+  --data-values-file examples/data-values/values-file.yml

--- a/examples/data-values/values-file.yml
+++ b/examples/data-values/values-file.yml
@@ -1,0 +1,7 @@
+nothing: "something"
+string: "str"
+bool: true
+int: 123
+new_thing: new
+---
+int: 124

--- a/pkg/cmd/template/cmd_data_values_file_test.go
+++ b/pkg/cmd/template/cmd_data_values_file_test.go
@@ -1,0 +1,151 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"fmt"
+	"testing"
+
+	cmdtpl "github.com/k14s/ytt/pkg/cmd/template"
+	"github.com/k14s/ytt/pkg/cmd/ui"
+	"github.com/k14s/ytt/pkg/files"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataValuesWithDataValuesFileFlags(t *testing.T) {
+	yamlTplData := []byte(`
+#@ load("@ytt:data", "data")
+values: #@ data.values`)
+
+	builtinDVs := []byte(`
+#@data/values
+---
+predefined: true`)
+
+	// Ensure various non-annotation YAML comments
+	// are allowed and do not affect parsed content
+	dvs1 := []byte(`
+# top comment
+int: 123
+str: str
+boolean: false
+nested:
+  #comment without space
+  # comment with space
+  value: not-str
+  ### some other unknown comment
+  nested:
+    #! ytt comment1
+    #! ytt comment2
+    subnested: true
+another:
+  nested:
+    map: {"a": 123}
+array:
+- 123
+- str
+
+# bottom comment`)
+
+	dvs2 := []byte(`
+int: 123
+str: str
+boolean: true
+nested:
+  value: not-str
+  nested: true
+another:
+  nested:
+    map: {"a": 123}
+# Multiple documents in one file
+---
+array:
+- str`)
+
+	// Ensure file with only comments (no structures) is allowed
+	dvs3 := []byte(`# value: 1
+# value: 2`)
+
+	expectedYAMLTplData := `values:
+  predefined: true
+  int: 123
+  str: str
+  boolean: true
+  nested:
+    value: not-str
+    nested: true
+  another:
+    nested:
+      map:
+        a: 123
+  array:
+  - str
+`
+
+	filesToProcess := files.NewSortedFiles([]*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+		files.MustNewFileFromSource(files.NewBytesSource("values.yml", builtinDVs)),
+	})
+
+	ui := ui.NewTTY(false)
+	opts := cmdtpl.NewOptions()
+
+	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
+		FromFiles: []string{"dvs1.yml", "dvs2.yml", "dvs3.yml"},
+		ReadFileFunc: func(path string) ([]byte, error) {
+			switch path {
+			case "dvs1.yml":
+				return dvs1, nil
+			case "dvs2.yml":
+				return dvs2, nil
+			case "dvs3.yml":
+				return dvs3, nil
+			default:
+				return nil, fmt.Errorf("Unknown file '%s'", path)
+			}
+		},
+	}
+
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+	require.NoError(t, out.Err)
+	require.Len(t, out.Files, 1, "unexpected number of output files")
+
+	file := out.Files[0]
+
+	assert.Equal(t, "tpl.yml", file.RelativePath())
+	assert.Equal(t, expectedYAMLTplData, string(file.Bytes()))
+}
+
+func TestDataValuesWithDataValuesFileFlagsForbiddenComment(t *testing.T) {
+	yamlTplData := []byte(`
+#@ load("@ytt:data", "data")
+values: #@ data.values`)
+
+	dvs1 := []byte(`
+#@ top comment
+int: 123`)
+
+	filesToProcess := files.NewSortedFiles([]*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+	})
+
+	ui := ui.NewTTY(false)
+	opts := cmdtpl.NewOptions()
+
+	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
+		FromFiles: []string{"dvs1.yml"},
+		ReadFileFunc: func(path string) ([]byte, error) {
+			switch path {
+			case "dvs1.yml":
+				return dvs1, nil
+			default:
+				return nil, fmt.Errorf("Unknown file '%s'", path)
+			}
+		},
+	}
+
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+	require.EqualError(t, out.Err, "Extracting data value from file: Checking data values file 'dvs1.yml': Expected to not find annotations inside data values file (hint: remove comments starting with '#@')")
+}

--- a/pkg/cmd/template/data_values_file.go
+++ b/pkg/cmd/template/data_values_file.go
@@ -1,0 +1,66 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"fmt"
+
+	"github.com/k14s/starlark-go/starlark"
+	"github.com/k14s/ytt/pkg/template"
+	"github.com/k14s/ytt/pkg/yamlmeta"
+	"github.com/k14s/ytt/pkg/yamltemplate"
+	yttoverlay "github.com/k14s/ytt/pkg/yttlibrary/overlay"
+)
+
+type DataValuesFile struct {
+	doc *yamlmeta.Document
+}
+
+func NewDataValuesFile(doc *yamlmeta.Document) DataValuesFile {
+	return DataValuesFile{doc.DeepCopy()}
+}
+
+func (f DataValuesFile) AsOverlay() (*yamlmeta.Document, error) {
+	doc := f.doc.DeepCopy()
+
+	if yamltemplate.HasTemplating(doc) {
+		return nil, fmt.Errorf("Expected to not find annotations inside data values file " +
+			"(hint: remove comments starting with '#@')")
+	}
+
+	f.addOverlayReplace(doc)
+
+	return doc, nil
+}
+
+func (f DataValuesFile) addOverlayReplace(node yamlmeta.Node) {
+	anns := template.NodeAnnotations{
+		yttoverlay.AnnotationMatch: template.NodeAnnotation{
+			Kwargs: []starlark.Tuple{{
+				starlark.String(yttoverlay.MatchAnnotationKwargMissingOK),
+				starlark.Bool(true),
+			}},
+		},
+	}
+
+	replaceAnn := template.NodeAnnotation{
+		Kwargs: []starlark.Tuple{{
+			starlark.String(yttoverlay.ReplaceAnnotationKwargOrAdd),
+			starlark.Bool(true),
+		}},
+	}
+
+	for _, val := range node.GetValues() {
+		switch typedVal := val.(type) {
+		case *yamlmeta.Array:
+			anns[yttoverlay.AnnotationReplace] = replaceAnn
+		case yamlmeta.Node:
+			f.addOverlayReplace(typedVal)
+		default:
+			anns[yttoverlay.AnnotationReplace] = replaceAnn
+		}
+	}
+
+	node.SetAnnotations(anns)
+}

--- a/pkg/cmd/template/data_values_flags.go
+++ b/pkg/cmd/template/data_values_flags.go
@@ -31,9 +31,12 @@ type DataValuesFlags struct {
 	KVsFromYAML    []string
 	KVsFromFiles   []string
 
+	FromFiles []string
+
 	Inspect bool
 
-	EnvironFunc func() []string
+	EnvironFunc  func() []string
+	ReadFileFunc func(string) ([]byte, error)
 }
 
 func (s *DataValuesFlags) Set(cmd *cobra.Command) {
@@ -43,6 +46,8 @@ func (s *DataValuesFlags) Set(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVarP(&s.KVsFromStrings, "data-value", "v", nil, "Set specific data value to given value, as string (format: all.key1.subkey=123) (can be specified multiple times)")
 	cmd.Flags().StringArrayVar(&s.KVsFromYAML, "data-value-yaml", nil, "Set specific data value to given value, parsed as YAML (format: all.key1.subkey=true) (can be specified multiple times)")
 	cmd.Flags().StringArrayVar(&s.KVsFromFiles, "data-value-file", nil, "Set specific data value to given file contents, as string (format: all.key1.subkey=/file/path) (can be specified multiple times)")
+
+	cmd.Flags().StringArrayVar(&s.FromFiles, "data-values-file", nil, "Set multiple data values via a YAML file (format: /file/path.yml) (can be specified multiple times)")
 
 	cmd.Flags().BoolVar(&s.Inspect, "data-values-inspect", false, "Inspect data values")
 }
@@ -67,6 +72,17 @@ func (s *DataValuesFlags) AsOverlays(strict bool) ([]*workspace.DataValues, []*w
 
 	var result []*workspace.DataValues
 
+	// Files go first
+	for _, file := range s.FromFiles {
+		vals, err := s.file(file, strict)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Extracting data value from file: %s", err)
+		}
+		result = append(result, vals...)
+	}
+
+	// Then env vars take precedence over files
+	// since env vars are specific to command execution
 	for _, src := range []dataValuesFlagsSource{{s.EnvFromStrings, plainValFunc}, {s.EnvFromYAML, yamlValFunc}} {
 		for _, envPrefix := range src.Values {
 			vals, err := s.env(envPrefix, src.TransformFunc)
@@ -77,7 +93,7 @@ func (s *DataValuesFlags) AsOverlays(strict bool) ([]*workspace.DataValues, []*w
 		}
 	}
 
-	// KVs and files take precedence over environment variables
+	// KVs take precedence over environment variables
 	for _, src := range []dataValuesFlagsSource{{s.KVsFromStrings, plainValFunc}, {s.KVsFromYAML, yamlValFunc}} {
 		for _, kv := range src.Values {
 			val, err := s.kv(kv, src.TransformFunc)
@@ -88,8 +104,10 @@ func (s *DataValuesFlags) AsOverlays(strict bool) ([]*workspace.DataValues, []*w
 		}
 	}
 
+	// Finally KV files take precedence over rest
+	// (technically should be same level as KVs, but gotta pick one)
 	for _, file := range s.KVsFromFiles {
-		val, err := s.file(file)
+		val, err := s.kvFile(file)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Extracting data value from file: %s", err)
 		}
@@ -107,6 +125,46 @@ func (s *DataValuesFlags) AsOverlays(strict bool) ([]*workspace.DataValues, []*w
 	}
 
 	return overlayValues, libraryOverlays, nil
+}
+
+func (s *DataValuesFlags) file(path string, strict bool) ([]*workspace.DataValues, error) {
+	libRef, path, err := s.libraryRefAndKey(path)
+	if err != nil {
+		return nil, err
+	}
+
+	contents, err := s.readFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Reading file '%s'", path)
+	}
+
+	docSetOpts := yamlmeta.DocSetOpts{
+		AssociatedName: path,
+		Strict:         strict,
+	}
+
+	docSet, err := yamlmeta.NewDocumentSetFromBytes(contents, docSetOpts)
+	if err != nil {
+		return nil, fmt.Errorf("Unmarshaling YAML data values file '%s': %s", path, err)
+	}
+
+	var result []*workspace.DataValues
+
+	for _, doc := range docSet.Items {
+		if doc.Value != nil {
+			dvsOverlay, err := NewDataValuesFile(doc).AsOverlay()
+			if err != nil {
+				return nil, fmt.Errorf("Checking data values file '%s': %s", path, err)
+			}
+			dvs, err := workspace.NewDataValuesWithOptionalLib(dvsOverlay, libRef)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, dvs)
+		}
+	}
+
+	return result, nil
 }
 
 func (s *DataValuesFlags) env(prefix string, valueFunc valueTransformFunc) ([]*workspace.DataValues, error) {
@@ -186,13 +244,13 @@ func (s *DataValuesFlags) parseYAML(data string, strict bool) (interface{}, erro
 	return docSet.Items[0].Value, nil
 }
 
-func (s *DataValuesFlags) file(kv string) (*workspace.DataValues, error) {
+func (s *DataValuesFlags) kvFile(kv string) (*workspace.DataValues, error) {
 	pieces := strings.SplitN(kv, dvsKVSep, 2)
 	if len(pieces) != 2 {
 		return nil, fmt.Errorf("Expected format key=/file/path")
 	}
 
-	contents, err := ioutil.ReadFile(pieces[1])
+	contents, err := s.readFile(pieces[1])
 	if err != nil {
 		return nil, fmt.Errorf("Reading file '%s'", pieces[1])
 	}
@@ -273,4 +331,11 @@ func (s *DataValuesFlags) buildOverlay(keyPieces []string, value interface{}, de
 	lastMapItem.SetAnnotations(existingAnns)
 
 	return &yamlmeta.Document{Value: resultMap, Position: pos}
+}
+
+func (s *DataValuesFlags) readFile(path string) ([]byte, error) {
+	if s.ReadFileFunc != nil {
+		return s.ReadFileFunc(path)
+	}
+	return ioutil.ReadFile(path)
 }

--- a/pkg/yamltemplate/filetests/ytt-library/overlay/replace-or-add.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/overlay/replace-or-add.yml
@@ -1,0 +1,80 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
+
+#@ def test1_left():
+key1: val1
+#@ end
+
+#@ def test1_right():
+#@overlay/match expects=0
+#@overlay/replace or_add=True
+key2: val2
+#@ end
+
+test1: #@ overlay.apply(test1_left(), test1_right())
+
+#@ def test1a_left():
+key1: val1
+#@ end
+
+#@ def test1a_right():
+#@overlay/match expects=0
+#@overlay/replace via=lambda a,b: [a, b], or_add=True
+key2: val2
+#@ end
+
+test1a: #@ overlay.apply(test1a_left(), test1a_right())
+
+---
+#@ def test2_left():
+- val1
+- val11
+#@ end
+
+#@ def test2_right():
+#@overlay/match by=overlay.not_op(overlay.all), expects=0
+#@overlay/replace or_add=True
+- val2
+#@ end
+
+---
+test2: #@ overlay.apply(test2_left(), test2_right())
+
+---
+#@ def test3_left():
+---
+val1
+---
+val11
+#@ end
+
+#@ def test3_right():
+#@overlay/match by=overlay.not_op(overlay.all), expects=0
+#@overlay/replace or_add=True
+---
+val2
+#@ end
+
+--- #@ template.replace(overlay.apply(test3_left(), test3_right()))
+
++++
+
+test1:
+  key1: val1
+  key2: val2
+test1a:
+  key1: val1
+  key2:
+  - null
+  - val2
+---
+test2:
+- val1
+- val11
+- val2
+---
+val1
+---
+val11
+---
+val2

--- a/pkg/yamltemplate/template.go
+++ b/pkg/yamltemplate/template.go
@@ -34,8 +34,8 @@ type TemplateOpts struct {
 	ImplicitMapKeyOverrides bool
 }
 
-func HasTemplating(docs *yamlmeta.DocumentSet) bool {
-	return hasTemplating(docs)
+func HasTemplating(node yamlmeta.Node) bool {
+	return hasTemplating(node)
 }
 
 func hasTemplating(val interface{}) bool {

--- a/pkg/yttlibrary/overlay/array.go
+++ b/pkg/yttlibrary/overlay/array.go
@@ -126,6 +126,19 @@ func (o Op) replaceArrayItem(
 		}
 	}
 
+	if len(leftIdxs) == 0 && replaceAnn.OrAdd() {
+		newVal, err := replaceAnn.Value(nil)
+		if err != nil {
+			return err
+		}
+
+		leftArray.Items = append(leftArray.Items, newItem.DeepCopy())
+		err = leftArray.Items[len(leftArray.Items)-1].SetValue(newVal)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/yttlibrary/overlay/document.go
+++ b/pkg/yttlibrary/overlay/document.go
@@ -117,6 +117,23 @@ func (o Op) replaceDocument(
 		}
 	}
 
+	if len(leftIdxs) == 0 && replaceAnn.OrAdd() {
+		if len(leftDocSets) == 0 {
+			panic("Internal inconsistency: Expected at least one doc set")
+		}
+
+		newVal, err := replaceAnn.Value(nil)
+		if err != nil {
+			return err
+		}
+
+		leftDocSets[0].Items = append(leftDocSets[0].Items, newDoc.DeepCopy())
+		err = leftDocSets[0].Items[len(leftDocSets[0].Items)-1].SetValue(newVal)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/yttlibrary/overlay/map.go
+++ b/pkg/yttlibrary/overlay/map.go
@@ -125,6 +125,19 @@ func (o Op) replaceMapItem(leftMap *yamlmeta.Map, newItem *yamlmeta.MapItem,
 		}
 	}
 
+	if len(leftIdxs) == 0 && replaceAnn.OrAdd() {
+		newVal, err := replaceAnn.Value(nil)
+		if err != nil {
+			return err
+		}
+
+		leftMap.Items = append(leftMap.Items, newItem.DeepCopy())
+		err = leftMap.Items[len(leftMap.Items)-1].SetValue(newVal)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
still in draft.

implements this proposal: https://github.com/vmware-tanzu/carvel-community/tree/develop/proposals/ytt/002-raw-data-values for https://github.com/vmware-tanzu/carvel-ytt/issues/381

this PR also:
- adds `or_add=True` to `@overlay/replace` so that when map key does not match, replace would fallback to just adding map item
- relaxes data values given over cmd line (--data-values-* family) to not require existing values in the data values overlays