### PR TITLE
Extract document schema

### DIFF
--- a/pkg/cmd/template/cmd_library_module_test.go
+++ b/pkg/cmd/template/cmd_library_module_test.go
@@ -827,7 +827,7 @@ lib_val2: #@ data.values.lib_val2`)
 	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 
 	expectedErr := "Expected all provided library data values documents to be used " +
-		"but found unused: DataValue belonging to library '@~inst2' on line values.yml:9"
+		"but found unused: Data Value belonging to library '@~inst2' on line values.yml:9"
 	require.EqualError(t, out.Err, expectedErr)
 }
 
@@ -875,7 +875,7 @@ nested_lib_val1: override-me`)
 	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	require.Error(t, out.Err)
 	require.Contains(t, out.Err.Error(), "Expected all provided library data values documents to be used "+
-		"but found unused: DataValue belonging to library '@~inst1@~inst2' on line values.yml:4")
+		"but found unused: Data Value belonging to library '@~inst1@~inst2' on line values.yml:4")
 }
 
 func TestUnusedLibraryDataValuesWithoutLibraryEvalChild(t *testing.T) {
@@ -903,7 +903,7 @@ nested_lib_val1: new-val1`)
 	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	require.Error(t, out.Err)
 	require.Contains(t, out.Err.Error(), "Expected all provided library data values documents to be used "+
-		"but found unused: DataValue belonging to library '@with-nested-lib@lib' on line values.yml:4")
+		"but found unused: Data Value belonging to library '@with-nested-lib@lib' on line values.yml:4")
 }
 
 func TestUnusedLibraryDataValuesNestedWithoutLibraryEval(t *testing.T) {
@@ -931,7 +931,7 @@ nested_lib_val1: new-val1`)
 	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	require.Error(t, out.Err)
 	require.Contains(t, out.Err.Error(), "Expected all provided library data values documents to be used "+
-		"but found unused: DataValue belonging to library '@with-nested-lib' on line values.yml:4")
+		"but found unused: Data Value belonging to library '@with-nested-lib' on line values.yml:4")
 }
 
 func TestMalformedLibraryRefEmptyAlias(t *testing.T) {

--- a/pkg/workspace/data_values.go
+++ b/pkg/workspace/data_values.go
@@ -78,7 +78,7 @@ func (dvd *DataValues) Desc() string {
 	for _, refPiece := range dvd.originalLibRef {
 		desc = append(desc, refPiece.AsString())
 	}
-	return fmt.Sprintf("DataValue belonging to library '%s%s' on %s", dvsLibrarySep,
+	return fmt.Sprintf("Data Value belonging to library '%s%s' on %s", dvsLibrarySep,
 		strings.Join(desc, dvsLibrarySep), dvd.Doc.Position.AsString())
 }
 

--- a/pkg/workspace/library_module.go
+++ b/pkg/workspace/library_module.go
@@ -21,12 +21,12 @@ type LibraryModule struct {
 	libraryCtx              LibraryExecutionContext
 	libraryExecutionFactory *LibraryExecutionFactory
 	libraryValues           []*DataValues
-	librarySchemas          []*schema.DocumentSchema
+	librarySchemas          []*schema.DocumentSchemaEnvelope
 }
 
 func NewLibraryModule(libraryCtx LibraryExecutionContext,
 	libraryExecutionFactory *LibraryExecutionFactory,
-	libraryValues []*DataValues, librarySchemas []*schema.DocumentSchema) LibraryModule {
+	libraryValues []*DataValues, librarySchemas []*schema.DocumentSchemaEnvelope) LibraryModule {
 
 	return LibraryModule{libraryCtx, libraryExecutionFactory, libraryValues, librarySchemas}
 }
@@ -129,7 +129,7 @@ type libraryValue struct {
 	path        string
 	alias       string
 	dataValuess []*DataValues
-	schemas     []*schema.DocumentSchema
+	schemas     []*schema.DocumentSchemaEnvelope
 
 	libraryCtx              LibraryExecutionContext
 	libraryExecutionFactory *LibraryExecutionFactory
@@ -194,7 +194,7 @@ func (l *libraryValue) WithSchema(thread *starlark.Thread, f *starlark.Builtin,
 		return starlark.None, err
 	}
 
-	newDocSchema, err := schema.NewDocumentSchema(&yamlmeta.Document{
+	newDocSchema, err := schema.NewDocumentSchemaEnvelope(&yamlmeta.Document{
 		Value:    yamlmeta.NewASTFromInterface(libSchema),
 		Position: filepos.NewUnknownPosition(),
 	})
@@ -202,7 +202,7 @@ func (l *libraryValue) WithSchema(thread *starlark.Thread, f *starlark.Builtin,
 		return starlark.None, err
 	}
 
-	newLibSchemas := append([]*schema.DocumentSchema{}, l.schemas...)
+	newLibSchemas := append([]*schema.DocumentSchemaEnvelope{}, l.schemas...)
 	newLibSchemas = append(newLibSchemas, newDocSchema)
 
 	libVal := &libraryValue{l.path, l.alias, l.dataValuess, newLibSchemas, l.libraryCtx, l.libraryExecutionFactory}
@@ -348,8 +348,8 @@ func (l *libraryValue) exportArgs(args starlark.Tuple, kwargs []starlark.Tuple) 
 	return symbolName, locationPath, nil
 }
 
-func (l *libraryValue) librarySchemas(ll *LibraryLoader) (Schema, []*schema.DocumentSchema, error) {
-	var schemasForCurrentLib, schemasForChildLib []*schema.DocumentSchema
+func (l *libraryValue) librarySchemas(ll *LibraryLoader) (Schema, []*schema.DocumentSchemaEnvelope, error) {
+	var schemasForCurrentLib, schemasForChildLib []*schema.DocumentSchemaEnvelope
 
 	for _, docSchema := range l.schemas {
 		matchingSchema, usedInCurrLibrary := docSchema.UsedInLibrary(ref.LibraryRef{Path: l.path, Alias: l.alias})

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -22,7 +22,7 @@ type TemplateLoader struct {
 	ui                 ui.UI
 	values             *DataValues
 	libraryValuess     []*DataValues
-	librarySchemas     []*schema.DocumentSchema
+	librarySchemas     []*schema.DocumentSchemaEnvelope
 	opts               TemplateLoaderOpts
 	compiledTemplates  map[string]*template.CompiledTemplate
 	libraryExecFactory *LibraryExecutionFactory
@@ -41,7 +41,7 @@ type TemplateLoaderOptsOverrides struct {
 	StrictYAML              *bool
 }
 
-func NewTemplateLoader(values *DataValues, libraryValuess []*DataValues, librarySchemas []*schema.DocumentSchema, opts TemplateLoaderOpts, libraryExecFactory *LibraryExecutionFactory, ui ui.UI) *TemplateLoader {
+func NewTemplateLoader(values *DataValues, libraryValuess []*DataValues, librarySchemas []*schema.DocumentSchemaEnvelope, opts TemplateLoaderOpts, libraryExecFactory *LibraryExecutionFactory, ui ui.UI) *TemplateLoader {
 
 	if values == nil {
 		panic("Expected values to be non-nil")


### PR DESCRIPTION
- Introduces a refactor to hopefully communicate the difference between schema's used by the 'current' library and a schema intended for a 'child' library.

Or put another way:
Splitting the entity of a document schema, and the 'usage' of a document schema, in this case locating the correct library and marking it used or not by said child library.

- Slight improvement in the error message when a data value is not used. Changed "DataValue" to "Data Value"
