### PR TITLE
Mismatched Type Error: include "found" portion of error message when position is unknown

### DIFF
--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -439,7 +439,7 @@ rendered: #@ data.values.foo
 		expectedErr := `? |
   |
   | TYPE MISMATCH - the value of this item is not what schema expected:
-  |      found: int64
+  |      found: integer
   |   expected: string (by schema.yml:3)`
 
 		filesToProcess := files.NewSortedFiles([]*files.File{

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -89,17 +89,19 @@ type mismatchedTypeError struct {
 }
 
 func (t mismatchedTypeError) Error() string {
-	position := t.Found.GetPosition().AsCompactString()
-	lineContent := t.Found.GetPosition().GetLine()
+	position := "?"
+	lineContent := ""
+	if t.Found.GetPosition() != nil {
+		position = t.Found.GetPosition().AsCompactString()
+		lineContent = t.Found.GetPosition().GetLine()
+	}
 
 	leftPadLength := len(position) + 1
 	msg := "\n"
 	msg += formatLine(leftPadLength, position, lineContent)
 	msg += formatLine(leftPadLength, "", "")
 	msg += formatLine(leftPadLength, "", "TYPE MISMATCH - the value of this item is not what schema expected:")
-	if t.Found.GetPosition().IsKnown() {
-		msg += formatLine(leftPadLength, "", fmt.Sprintf("     found: %s", t.Found.ValueTypeAsString()))
-	}
+	msg += formatLine(leftPadLength, "", fmt.Sprintf("     found: %s", t.Found.ValueTypeAsString()))
 
 	if t.Expected.PositionOfDefinition().IsKnown() {
 		expectedTypeString := ""

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -89,12 +89,8 @@ type mismatchedTypeError struct {
 }
 
 func (t mismatchedTypeError) Error() string {
-	position := "?"
-	lineContent := ""
-	if t.Found.GetPosition() != nil {
-		position = t.Found.GetPosition().AsCompactString()
-		lineContent = t.Found.GetPosition().GetLine()
-	}
+	position := t.Found.GetPosition().AsCompactString()
+	lineContent := t.Found.GetPosition().GetLine()
 
 	leftPadLength := len(position) + 1
 	msg := "\n"

--- a/pkg/yamltemplate/evaluation_ctx.go
+++ b/pkg/yamltemplate/evaluation_ctx.go
@@ -6,6 +6,7 @@ package yamltemplate
 import (
 	"fmt"
 
+	"github.com/k14s/ytt/pkg/filepos"
 	"github.com/k14s/ytt/pkg/orderedmap"
 	"github.com/k14s/ytt/pkg/template"
 	"github.com/k14s/ytt/pkg/yamlmeta"
@@ -114,7 +115,7 @@ func (e EvaluationCtx) convertValToDocSetItems(val interface{}) ([]*yamlmeta.Doc
 	switch typedVal := val.(type) {
 	case []interface{}:
 		for _, item := range typedVal {
-			result = append(result, &yamlmeta.Document{Value: item})
+			result = append(result, &yamlmeta.Document{Value: item, Position: filepos.NewUnknownPosition()})
 		}
 
 	case *yamlmeta.DocumentSet:
@@ -162,7 +163,7 @@ func (e EvaluationCtx) convertValToMapItems(val interface{}) ([]*yamlmeta.MapIte
 	case *orderedmap.Map:
 		result := []*yamlmeta.MapItem{}
 		typedVal.Iterate(func(k, v interface{}) {
-			result = append(result, &yamlmeta.MapItem{Key: k, Value: v})
+			result = append(result, &yamlmeta.MapItem{Key: k, Value: v, Position: filepos.NewUnknownPosition()})
 		})
 		return result, false, nil
 
@@ -199,7 +200,7 @@ func (e EvaluationCtx) convertValToArrayItems(val interface{}) ([]*yamlmeta.Arra
 	switch typedVal := val.(type) {
 	case []interface{}:
 		for _, item := range typedVal {
-			result = append(result, &yamlmeta.ArrayItem{Value: item})
+			result = append(result, &yamlmeta.ArrayItem{Value: item, Position: filepos.NewUnknownPosition()})
 		}
 
 	case *yamlmeta.Array:


### PR DESCRIPTION
"found" portion in error message is now included when position is unknown. 

In some investigation, I discovered that the position could also be `nil` if inserted using `template.replace()`. To prevent a nil dereference panic, if the inserted items are from starlark, then they are given an unknown position.