### PR TITLE
Polish schema errors

### DIFF
--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1707,13 +1707,22 @@ vpc:
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("dataValues.yml", []byte(dataValuesYAML))),
 		})
+
 		expectedErr := `
-schema.yml:4 |   subnet_ids: []
-             |
-             | INVALID ARRAY DEFINITION IN SCHEMA - unable to determine the desired type
-             |      found: 0 array items
-             |   expected: exactly 1 array item, of the desired type
-             |   (hint: in a schema, the item of an array defines the type of its elements; its default value is an empty list)`
+Invalid schema — wrong number of items in array definition
+
+schema.yml:
+    |
+  4 |   subnet_ids: []
+    |
+
+    = found: 0 array items
+    = expected: exactly 1 array item, of the desired type
+    = hint: in schema, the one item of the array implies the type of its elements.
+    = hint: in schema, the default value for an array is always an empty list.
+    = hint: default values can be overridden via a data values overlay.
+`
+
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 	t.Run("array with more than one element", func(t *testing.T) {
@@ -1733,13 +1742,22 @@ vpc:
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("dataValues.yml", []byte(dataValuesYAML))),
 		})
+
 		expectedErr := `
-schema.yml:4 |   subnet_ids:
-             |
-             | INVALID ARRAY DEFINITION IN SCHEMA - unable to determine the desired type
-             |      found: 2 array items
-             |   expected: exactly 1 array item, of the desired type
-             |   (hint: to add elements to the default value of an array (i.e. an empty list), declare them in a @data/values document)`
+Invalid schema — wrong number of items in array definition
+
+schema.yml:
+    |
+  4 |   subnet_ids:
+    |
+
+    = found: 2 array items
+    = expected: exactly 1 array item, of the desired type
+    = hint: in schema, the one item of the array implies the type of its elements.
+    = hint: in schema, the default value for an array is always an empty list.
+    = hint: default values can be overridden via a data values overlay.
+`
+
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 	t.Run("array with a nullable annotation", func(t *testing.T) {

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1959,15 +1959,15 @@ foo: 0
 		expectedErr := `
 Invalid schema
 ==============
-expected @schema/type annotation keyword argument
+expected @schema/type annotation to have keyword argument and value
 
 schema.yml:
     |
   4 | foo: 0
     |
 
-    = found: missing keyword arg
-    = expected: valid keyword arg
+    = found: missing keyword argument and value
+    = expected: valid keyword argument and value
     = hint: Supported key-value pairs are 'any=True', 'any=False'
 `
 

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1775,7 +1775,10 @@ vpc:
 schema.yml:4 |   subnet_ids: null
              |
              | INVALID SCHEMA - null value is not allowed in schema (no type can be inferred from it)
-             |   (hint: to default to null, specify a value of the desired type and annotate with @schema/nullable)`
+             | hint: in YAML, omitting a value implies null.
+             | hint: to set the default value to null, annotate with @schema/nullable.
+             | hint: to allow any value, annotate with @schema/type any=True.
+`
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 	t.Run("when schema/type has keyword other than any", func(t *testing.T) {

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1754,10 +1754,19 @@ vpc:
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 		})
+
 		expectedErr := `
-schema.yml:6 |   - 0
-             |
-             | INVALID SCHEMA - @schema/nullable is not supported on array items`
+Invalid schema — @schema/nullable is not supported on array items
+
+schema.yml:6:
+    |
+  6 |   - 0
+    |
+
+    = found: @schema/nullable
+    = expected: a valid annotation
+    = hint: Remove the @schema/nullable annotation from array item
+`
 
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
@@ -1772,12 +1781,18 @@ vpc:
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 		})
 		expectedErr := `
-schema.yml:4 |   subnet_ids: null
-             |
-             | INVALID SCHEMA - null value is not allowed in schema (no type can be inferred from it)
-             | hint: in YAML, omitting a value implies null.
-             | hint: to set the default value to null, annotate with @schema/nullable.
-             | hint: to allow any value, annotate with @schema/type any=True.
+Invalid schema — null value not allowed here
+
+schema.yml:4:
+    |
+  4 |   subnet_ids: null
+    |
+
+    = found: null value
+    = expected: non-null value
+    = hint: in YAML, omitting a value implies null.
+    = hint: to set the default value to null, annotate with @schema/nullable.
+    = hint: to allow any value, annotate with @schema/type any=True.
 `
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
@@ -1787,10 +1802,19 @@ schema.yml:4 |   subnet_ids: null
 #@schema/type unknown_kwarg=False
 foo: 0
 `
-		expectedErr := `schema.yml:4 | foo: 0
-             |
-             | INVALID SCHEMA - unknown @schema/type annotation keyword argument 'unknown_kwarg'. Supported kwargs are 'any'
+		expectedErr := `
+Invalid schema — unknown @schema/type annotation keyword argument
+
+schema.yml:4:
+    |
+  4 | foo: 0
+    |
+
+    = found: unknown_kwarg
+    = expected: A valid kwarg
+    = hint: Supported kwargs are 'any'
 `
+
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 		})
@@ -1803,10 +1827,19 @@ foo: 0
 #@schema/type any=1
 foo: 0
 `
-		expectedErr := `schema.yml:4 | foo: 0
-             |
-             | INVALID SCHEMA - processing @schema/type 'any' argument: expected starlark.Bool, but was starlark.Int
+
+		expectedErr := `
+Invalid schema — unknown @schema/type annotation keyword argument
+
+schema.yml:4:
+    |
+  4 | foo: 0
+    |
+
+    = found: starlark.Int
+    = expected: starlark.Bool
 `
+
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 		})
@@ -1819,10 +1852,20 @@ foo: 0
 #@schema/type
 foo: 0
 `
-		expectedErr := `schema.yml:4 | foo: 0
-             |
-             | INVALID SCHEMA - expected @schema/type annotation to have keyword argument and value. Supported key-value pairs are 'any=True', 'any=False'
+
+		expectedErr := `
+Invalid schema — expected @schema/type annotation keyword argument
+
+schema.yml:4:
+    |
+  4 | foo: 0
+    |
+
+    = found: missing keyword arg
+    = expected: valid keyword arg
+    = hint: Supported key-value pairs are 'any=True', 'any=False'
 `
+
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 		})

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -289,6 +289,7 @@ db_conn:
 
 		expectedErr := `
 Schema Typecheck - Value is of wrong type
+=========================================
 
 data_values.yml:
     |
@@ -334,6 +335,7 @@ app: null
 
 		expectedErr := `
 Schema Typecheck - Value is of wrong type
+=========================================
 
 dataValues.yml:
     |
@@ -368,6 +370,7 @@ foo: #@ data.values.foo
 
 		expectedErr := `
 Schema Typecheck - Value is of wrong type
+=========================================
 
 dataValues.yml:
     |
@@ -407,6 +410,7 @@ clients:
 
 		expectedErr := `
 Schema Typecheck - Value is of wrong type
+=========================================
 
 data_values.yml:
      |
@@ -577,6 +581,7 @@ array: [ [1] ]
 
 		expectedErr := `
 Schema Typecheck - Value is of wrong type
+=========================================
 
 values.yml:
     |
@@ -607,6 +612,7 @@ array: [ {a: 1} ]
 
 		expectedErr := `
 Schema Typecheck - Value is of wrong type
+=========================================
 
 values.yml:
     |
@@ -1357,6 +1363,7 @@ foo: 42`)
 
     reason:
      Schema Typecheck - Value is of wrong type
+     =========================================
      
      values.yml:
          |
@@ -1766,6 +1773,7 @@ vpc:
 
 		expectedErr := `
 Invalid schema - wrong number of items in array definition
+==========================================================
 
 schema.yml:
     |
@@ -1801,6 +1809,7 @@ vpc:
 
 		expectedErr := `
 Invalid schema - wrong number of items in array definition
+==========================================================
 
 schema.yml:
     |
@@ -1831,6 +1840,7 @@ vpc:
 
 		expectedErr := `
 Invalid schema - @schema/nullable is not supported on array items
+=================================================================
 
 schema.yml:
     |
@@ -1856,6 +1866,7 @@ vpc:
 		})
 		expectedErr := `
 Invalid schema - null value not allowed here
+============================================
 
 schema.yml:
     |
@@ -1877,7 +1888,9 @@ schema.yml:
 foo: 0
 `
 		expectedErr := `
-Invalid schema - unknown @schema/type annotation keyword argument
+Invalid schema
+==============
+unknown @schema/type annotation keyword argument
 
 schema.yml:
     |
@@ -1903,7 +1916,9 @@ foo: 0
 `
 
 		expectedErr := `
-Invalid schema - unknown @schema/type annotation keyword argument
+Invalid schema
+==============
+unknown @schema/type annotation keyword argument
 
 schema.yml:
     |
@@ -1929,7 +1944,9 @@ foo: 0
 `
 
 		expectedErr := `
-Invalid schema - expected @schema/type annotation keyword argument
+Invalid schema
+==============
+expected @schema/type annotation keyword argument
 
 schema.yml:
     |

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1765,7 +1765,7 @@ vpc:
 		})
 
 		expectedErr := `
-Invalid schema — wrong number of items in array definition
+Invalid schema - wrong number of items in array definition
 
 schema.yml:
     |
@@ -1800,7 +1800,7 @@ vpc:
 		})
 
 		expectedErr := `
-Invalid schema — wrong number of items in array definition
+Invalid schema - wrong number of items in array definition
 
 schema.yml:
     |
@@ -1830,7 +1830,7 @@ vpc:
 		})
 
 		expectedErr := `
-Invalid schema — @schema/nullable is not supported on array items
+Invalid schema - @schema/nullable is not supported on array items
 
 schema.yml:
     |
@@ -1855,7 +1855,7 @@ vpc:
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 		})
 		expectedErr := `
-Invalid schema — null value not allowed here
+Invalid schema - null value not allowed here
 
 schema.yml:
     |
@@ -1877,7 +1877,7 @@ schema.yml:
 foo: 0
 `
 		expectedErr := `
-Invalid schema — unknown @schema/type annotation keyword argument
+Invalid schema - unknown @schema/type annotation keyword argument
 
 schema.yml:
     |
@@ -1903,7 +1903,7 @@ foo: 0
 `
 
 		expectedErr := `
-Invalid schema — unknown @schema/type annotation keyword argument
+Invalid schema - unknown @schema/type annotation keyword argument
 
 schema.yml:
     |
@@ -1912,6 +1912,7 @@ schema.yml:
 
     = found: starlark.Int
     = expected: starlark.Bool
+    = hint: Supported kwargs are 'any'
 `
 
 		filesToProcess := files.NewSortedFiles([]*files.File{
@@ -1928,7 +1929,7 @@ foo: 0
 `
 
 		expectedErr := `
-Invalid schema — expected @schema/type annotation keyword argument
+Invalid schema - expected @schema/type annotation keyword argument
 
 schema.yml:
     |

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1758,7 +1758,7 @@ vpc:
 		expectedErr := `
 Invalid schema — @schema/nullable is not supported on array items
 
-schema.yml:6:
+schema.yml:
     |
   6 |   - 0
     |
@@ -1783,7 +1783,7 @@ vpc:
 		expectedErr := `
 Invalid schema — null value not allowed here
 
-schema.yml:4:
+schema.yml:
     |
   4 |   subnet_ids: null
     |
@@ -1805,7 +1805,7 @@ foo: 0
 		expectedErr := `
 Invalid schema — unknown @schema/type annotation keyword argument
 
-schema.yml:4:
+schema.yml:
     |
   4 | foo: 0
     |
@@ -1831,7 +1831,7 @@ foo: 0
 		expectedErr := `
 Invalid schema — unknown @schema/type annotation keyword argument
 
-schema.yml:4:
+schema.yml:
     |
   4 | foo: 0
     |
@@ -1856,7 +1856,7 @@ foo: 0
 		expectedErr := `
 Invalid schema — expected @schema/type annotation keyword argument
 
-schema.yml:4:
+schema.yml:
     |
   4 | foo: 0
     |

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -286,26 +286,33 @@ db_conn:
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("data_values.yml", []byte(dataValuesYAML))),
 		})
+
 		expectedErr := `
-data_values.yml:4 |   port: localhost
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: string
-                  |   expected: integer (by schema.yml:4)
+Schema Typecheck - Value is of wrong type
 
+data_values.yml:
+    |
+  4 |   port: localhost
+    |
 
-data_values.yml:6 |     main: 123
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: integer
-                  |   expected: string (by schema.yml:6)
+    = found: string
+    = expected: integer (by schema.yml:4)
 
+data_values.yml:
+    |
+  6 |     main: 123
+    |
 
-data_values.yml:7 |   timeout: 5m
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: string
-                  |   expected: float (by schema.yml:7)
+    = found: integer
+    = expected: string (by schema.yml:6)
+
+data_values.yml:
+    |
+  7 |   timeout: 5m
+    |
+
+    = found: string
+    = expected: float (by schema.yml:7)
 `
 
 		assertFails(t, filesToProcess, expectedErr, opts)
@@ -324,13 +331,18 @@ app: null
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("dataValues.yml", []byte(dataValuesYAML))),
 		})
-		expectedErr := `
-dataValues.yml:3 | app: null
-                 |
-                 | TYPE MISMATCH - the value of this item is not what schema expected:
-                 |      found: null
-                 |   expected: integer (by schema.yml:3)`
 
+		expectedErr := `
+Schema Typecheck - Value is of wrong type
+
+dataValues.yml:
+    |
+  3 | app: null
+    |
+
+    = found: null
+    = expected: integer (by schema.yml:3)
+`
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 	t.Run("when map item's value is wrong type and schema/nullable is set", func(t *testing.T) {
@@ -355,12 +367,15 @@ foo: #@ data.values.foo
 		})
 
 		expectedErr := `
-dataValues.yml:3 | foo: "bar"
-                 |
-                 | TYPE MISMATCH - the value of this item is not what schema expected:
-                 |      found: string
-                 |   expected: integer (by schema.yml:4)
+Schema Typecheck - Value is of wrong type
 
+dataValues.yml:
+    |
+  3 | foo: "bar"
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:4)
 `
 
 		assertFails(t, filesToProcess, expectedErr, opts)
@@ -391,38 +406,47 @@ clients:
 		})
 
 		expectedErr := `
-data_values.yml:4 | - flags: secure  #! expecting an array, got a string
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: string
-                  |   expected: array (by schema.yml:4)
+Schema Typecheck - Value is of wrong type
 
+data_values.yml:
+     |
+   4 | - flags: secure  #! expecting an array, got a string
+     |
 
-data_values.yml:6 |   - secure  #! expecting a map, got a string
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: string
-                  |   expected: map (by schema.yml:5)
+     = found: string
+     = expected: array (by schema.yml:4)
 
+data_values.yml:
+     |
+   6 |   - secure  #! expecting a map, got a string
+     |
 
-data_values.yml:9 |     - one  #! expecting a float, got a string
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: string
-                  |   expected: float (by schema.yml:6)
+     = found: string
+     = expected: map (by schema.yml:5)
 
+data_values.yml:
+     |
+   9 |     - one  #! expecting a float, got a string
+     |
 
-data_values.yml:10 |     - true  #! expecting a float, got a bool
-                   |
-                   | TYPE MISMATCH - the value of this item is not what schema expected:
-                   |      found: boolean
-                   |   expected: float (by schema.yml:6)
+     = found: string
+     = expected: float (by schema.yml:6)
+
+data_values.yml:
+     |
+  10 |     - true  #! expecting a float, got a bool
+     |
+
+     = found: boolean
+     = expected: float (by schema.yml:6)
 `
-
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 
 	t.Run("when a invalid data value is passed using template replace", func(t *testing.T) {
+		//TODO: unskip this test
+		t.Skip("Figure out what to print as an error message here")
+
 		schemaYAML := `#@schema/match data_values=True
 ---
 foo: bar
@@ -451,6 +475,9 @@ rendered: #@ data.values.foo
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 	t.Run("when a data value is passed using --data-value, but schema expects a non string", func(t *testing.T) {
+		//TODO: unskip this test
+		t.Skip("Figure out what to print as an error message here")
+
 		cmdOpts := cmdtpl.NewOptions()
 		cmdOpts.SchemaEnabled = true
 		schemaYAML := `#@schema/match data_values=True
@@ -476,6 +503,8 @@ rendered: #@ data.values.foo
 	})
 
 	t.Run("when schema is null and non-empty data values is given", func(t *testing.T) {
+		//TODO: figure out how to improve this error message
+
 		schemaYAML := `#@schema/match data_values=True
 ---
 `
@@ -545,9 +574,18 @@ array: [ [1] ]
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("values.yml", []byte(dataValuesYAML))),
 		})
-		expectedErr := `TYPE MISMATCH - the value of this item is not what schema expected:
-             |      found: array
-             |   expected: boolean (by schema.yml:3)`
+
+		expectedErr := `
+Schema Typecheck - Value is of wrong type
+
+values.yml:
+    |
+  4 | array: [ [1] ]
+    |
+
+    = found: array
+    = expected: boolean (by schema.yml:3)
+`
 
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
@@ -566,10 +604,18 @@ array: [ {a: 1} ]
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("values.yml", []byte(dataValuesYAML))),
 		})
-		expectedErr := `TYPE MISMATCH - the value of this item is not what schema expected:
-             |      found: map
-             |   expected: boolean (by schema.yml:3)`
 
+		expectedErr := `
+Schema Typecheck - Value is of wrong type
+
+values.yml:
+    |
+  4 | array: [ {a: 1} ]
+    |
+
+    = found: map
+    = expected: boolean (by schema.yml:3)
+`
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 }
@@ -1310,11 +1356,15 @@ foo: 42`)
       config.yml:4 | --- #@ template.replace(library.get("lib").eval())
 
     reason:
-     values.yml:5 | foo: bar
-                  |
-                  | TYPE MISMATCH - the value of this item is not what schema expected:
-                  |      found: string
-                  |   expected: integer (by _ytt_lib/lib/schema.yml:4)
+     Schema Typecheck - Value is of wrong type
+     
+     values.yml:
+         |
+       5 | foo: bar
+         |
+     
+         = found: string
+         = expected: integer (by _ytt_lib/lib/schema.yml:4)
      
      `
 		assertFails(t, filesToProcess, expectedErr, opts)
@@ -1391,6 +1441,9 @@ cow: #@ data.values.cow
 		assertSucceeds(t, filesToProcess, expectedYAMLTplData, cmdOpts)
 	})
 	t.Run("when data value ref'ed to a library is passed using --data-value, but schema expects an int, schema violation is reported", func(t *testing.T) {
+		//TODO: unskip this test
+		t.Skip("Figure out what to print as an error message here")
+
 		cmdOpts := cmdtpl.NewOptions()
 		cmdOpts.SchemaEnabled = true
 		rootYAML := []byte(`
@@ -1635,6 +1688,9 @@ root_data_values: null
 		assertSucceeds(t, filesToProcess, expectedYAMLTplData, opts)
 	})
 	t.Run("when data values are programmatically set on a library, but library's schema expects an int, type violation is reported", func(t *testing.T) {
+		//TODO: unskip this test
+		t.Skip("Figure out what to print as an error message here")
+
 		configYAML := []byte(`
 #@ load("@ytt:template", "template")
 #@ load("@ytt:library", "library")

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -448,8 +448,6 @@ data_values.yml:
 	})
 
 	t.Run("when a invalid data value is passed using template replace", func(t *testing.T) {
-		//TODO: unskip this test
-		t.Skip("Figure out what to print as an error message here")
 
 		schemaYAML := `#@schema/match data_values=True
 ---
@@ -464,11 +462,18 @@ _: #@ template.replace({'foo':9})
 ---
 rendered: #@ data.values.foo
 `
-		expectedErr := `? |
-  |
-  | TYPE MISMATCH - the value of this item is not what schema expected:
-  |      found: integer
-  |   expected: string (by schema.yml:3)`
+		expectedErr := `
+Schema Typecheck - Value is of wrong type
+=========================================
+
+:
+    |
+  ? | 
+    |
+
+    = found: integer
+    = expected: string (by schema.yml:3)
+`
 
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
@@ -478,10 +483,8 @@ rendered: #@ data.values.foo
 
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
-	t.Run("when a data value is passed using --data-value, but schema expects a non string", func(t *testing.T) {
-		//TODO: unskip this test
-		t.Skip("Figure out what to print as an error message here")
 
+	t.Run("when a data value is passed using --data-value, but schema expects a non string", func(t *testing.T) {
 		cmdOpts := cmdtpl.NewOptions()
 		cmdOpts.SchemaEnabled = true
 		schemaYAML := `#@schema/match data_values=True
@@ -498,17 +501,22 @@ rendered: #@ data.values.foo
 			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
 		})
 
-		expectedErr := `key 'foo' (kv arg):1 |
-                     |
-                     | TYPE MISMATCH - the value of this item is not what schema expected:
-                     |      found: string
-                     |   expected: integer (by schema.yml:3)`
+		expectedErr := `
+Schema Typecheck - Value is of wrong type
+=========================================
+
+key 'foo' (kv arg):
+    |
+  1 | 
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:3)
+`
 		assertFails(t, filesToProcess, expectedErr, cmdOpts)
 	})
 
 	t.Run("when schema is null and non-empty data values is given", func(t *testing.T) {
-		//TODO: figure out how to improve this error message
-
 		schemaYAML := `#@schema/match data_values=True
 ---
 `
@@ -1448,9 +1456,6 @@ cow: #@ data.values.cow
 		assertSucceeds(t, filesToProcess, expectedYAMLTplData, cmdOpts)
 	})
 	t.Run("when data value ref'ed to a library is passed using --data-value, but schema expects an int, schema violation is reported", func(t *testing.T) {
-		//TODO: unskip this test
-		t.Skip("Figure out what to print as an error message here")
-
 		cmdOpts := cmdtpl.NewOptions()
 		cmdOpts.SchemaEnabled = true
 		rootYAML := []byte(`
@@ -1486,13 +1491,17 @@ foo: #@ data.values.foo
       root.yml:5 | --- #@ template.replace(library.get("lib").eval())
 
     reason:
-     key 'foo' (kv arg):1 |
-                          |
-                          | TYPE MISMATCH - the value of this item is not what schema expected:
-                          |      found: string
-                          |   expected: integer (by _ytt_lib/lib/schema.yml:5)
+     Schema Typecheck - Value is of wrong type
+     =========================================
      
-     `
+     key 'foo' (kv arg):
+         |
+       1 | 
+         |
+     
+         = found: string
+         = expected: integer (by _ytt_lib/lib/schema.yml:5)
+`
 		assertFails(t, filesToProcess, expectedErr, cmdOpts)
 	})
 
@@ -1695,9 +1704,6 @@ root_data_values: null
 		assertSucceeds(t, filesToProcess, expectedYAMLTplData, opts)
 	})
 	t.Run("when data values are programmatically set on a library, but library's schema expects an int, type violation is reported", func(t *testing.T) {
-		//TODO: unskip this test
-		t.Skip("Figure out what to print as an error message here")
-
 		configYAML := []byte(`
 #@ load("@ytt:template", "template")
 #@ load("@ytt:library", "library")
@@ -1708,16 +1714,23 @@ root_data_values: null
 ---
 foo: 3`)
 
-		expectedErr := `- library.eval: Evaluating library 'lib': Overlaying data values (in following order: additional data values): 
+		expectedErr := `
+- library.eval: Evaluating library 'lib': Overlaying data values (in following order: additional data values): 
     in <toplevel>
       config.yml:4 | --- #@ template.replace(library.get("lib").with_data_values({'foo':'4'}).eval())
 
     reason:
-     ? |
-       |
-       | TYPE MISMATCH - the value of this item is not what schema expected:
-       |      found: string
-       |   expected: integer (by _ytt_lib/lib/schema.yml:4)`
+     Schema Typecheck - Value is of wrong type
+     =========================================
+     
+     :
+         |
+       ? | 
+         |
+     
+         = found: string
+         = expected: integer (by _ytt_lib/lib/schema.yml:4)
+`
 
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("config.yml", configYAML)),

--- a/pkg/filepos/position.go
+++ b/pkg/filepos/position.go
@@ -50,6 +50,10 @@ func (p *Position) AsString() string {
 	return "line " + p.AsCompactString()
 }
 
+func (p *Position) GetFile() string {
+	return p.file
+}
+
 func (p *Position) AsCompactString() string {
 	filePrefix := p.file
 	if len(filePrefix) > 0 {

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -38,6 +38,7 @@ type NullableAnnotation struct {
 func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*TypeAnnotation, error) {
 	if len(ann.Kwargs) == 0 {
 		return nil, schemaAssertionError{
+			position:    pos,
 			description: "expected @schema/type annotation keyword argument",
 			expected:    "valid keyword arg",
 			found:       "missing keyword arg",
@@ -56,7 +57,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 			isAnyType, err := core.NewStarlarkValue(kwarg[1]).AsBool()
 			if err != nil {
 				return nil, schemaAssertionError{
-					error:       nil,
+					position:    pos,
 					description: "unknown @schema/type annotation keyword argument",
 					expected:    "starlark.Bool",
 					found:       fmt.Sprintf("%T", kwarg[1]),
@@ -67,7 +68,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 
 		default:
 			return nil, schemaAssertionError{
-				error:       nil,
+				position:    pos,
 				description: "unknown @schema/type annotation keyword argument",
 				expected:    "A valid kwarg",
 				found:       argName,
@@ -130,13 +131,13 @@ func processOptionalAnnotation(node yamlmeta.Node, optionalAnnotation structmeta
 			}
 			nullAnn, err := NewNullableAnnotation(ann, wrappedValueType, node.GetPosition())
 			if err != nil {
-				return nil, NewSchemaError(err, node)
+				return nil, NewSchemaError(err)
 			}
 			return nullAnn, nil
 		case AnnotationType:
 			typeAnn, err := NewTypeAnnotation(ann, node.GetPosition())
 			if err != nil {
-				return nil, NewSchemaError(err, node)
+				return nil, NewSchemaError(err)
 			}
 			return typeAnn, nil
 		}

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -39,9 +39,9 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 	if len(ann.Kwargs) == 0 {
 		return nil, schemaAssertionError{
 			position:    pos,
-			description: "expected @schema/type annotation keyword argument",
-			expected:    "valid keyword arg",
-			found:       "missing keyword arg",
+			description: fmt.Sprintf("expected @%v annotation to have keyword argument and value", AnnotationType),
+			expected:    "valid keyword argument and value",
+			found:       "missing keyword argument and value",
 			hints:       []string{fmt.Sprintf("Supported key-value pairs are '%v=True', '%v=False'", TypeAnnotationKwargAny, TypeAnnotationKwargAny)},
 		}
 	}

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -130,13 +130,13 @@ func processOptionalAnnotation(node yamlmeta.Node, optionalAnnotation structmeta
 			}
 			nullAnn, err := NewNullableAnnotation(ann, wrappedValueType, node.GetPosition())
 			if err != nil {
-				return nil, NewInvalidSchemaError(err, node)
+				return nil, NewSchemaError(err, node)
 			}
 			return nullAnn, nil
 		case AnnotationType:
 			typeAnn, err := NewTypeAnnotation(ann, node.GetPosition())
 			if err != nil {
-				return nil, NewInvalidSchemaError(err, node)
+				return nil, NewSchemaError(err, node)
 			}
 			return typeAnn, nil
 		}

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -37,7 +37,12 @@ type NullableAnnotation struct {
 
 func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*TypeAnnotation, error) {
 	if len(ann.Kwargs) == 0 {
-		return nil, fmt.Errorf("expected @%v annotation to have keyword argument and value. Supported key-value pairs are '%v=True', '%v=False'", AnnotationType, TypeAnnotationKwargAny, TypeAnnotationKwargAny)
+		return nil, schemaAssertionError{
+			description: "expected @schema/type annotation keyword argument",
+			expected:    "valid keyword arg",
+			found:       "missing keyword arg",
+			hints:       []string{fmt.Sprintf("Supported key-value pairs are '%v=True', '%v=False'", TypeAnnotationKwargAny, TypeAnnotationKwargAny)},
+		}
 	}
 	typeAnn := &TypeAnnotation{itemPosition: pos}
 	for _, kwarg := range ann.Kwargs {
@@ -50,13 +55,24 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 		case TypeAnnotationKwargAny:
 			isAnyType, err := core.NewStarlarkValue(kwarg[1]).AsBool()
 			if err != nil {
-				return nil,
-					fmt.Errorf("processing @%v '%v' argument: %s", AnnotationType, TypeAnnotationKwargAny, err)
+				return nil, schemaAssertionError{
+					error:       nil,
+					description: "unknown @schema/type annotation keyword argument",
+					expected:    "starlark.Bool",
+					found:       fmt.Sprintf("%T", kwarg[1]),
+					hints:       []string{fmt.Sprintf("Supported kwargs are '%v'", TypeAnnotationKwargAny)},
+				}
 			}
 			typeAnn.any = isAnyType
 
 		default:
-			return nil, fmt.Errorf("unknown @%v annotation keyword argument '%v'. Supported kwargs are '%v'", AnnotationType, argName, TypeAnnotationKwargAny)
+			return nil, schemaAssertionError{
+				error:       nil,
+				description: "unknown @schema/type annotation keyword argument",
+				expected:    "A valid kwarg",
+				found:       argName,
+				hints:       []string{fmt.Sprintf("Supported kwargs are '%v'", TypeAnnotationKwargAny)},
+			}
 		}
 	}
 	return typeAnn, nil
@@ -114,13 +130,13 @@ func processOptionalAnnotation(node yamlmeta.Node, optionalAnnotation structmeta
 			}
 			nullAnn, err := NewNullableAnnotation(ann, wrappedValueType, node.GetPosition())
 			if err != nil {
-				return nil, NewInvalidSchemaError(node, err.Error(), nil)
+				return nil, NewInvalidSchemaError(err, node)
 			}
 			return nullAnn, nil
 		case AnnotationType:
 			typeAnn, err := NewTypeAnnotation(ann, node.GetPosition())
 			if err != nil {
-				return nil, NewInvalidSchemaError(node, err.Error(), nil)
+				return nil, NewInvalidSchemaError(err, node)
 			}
 			return typeAnn, nil
 		}

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -39,7 +39,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 	if len(ann.Kwargs) == 0 {
 		return nil, schemaAssertionError{
 			position:    pos,
-			description: "expected @schema/type annotation keyword argument",
+			description: "Invalid schema - expected @schema/type annotation keyword argument",
 			expected:    "valid keyword arg",
 			found:       "missing keyword arg",
 			hints:       []string{fmt.Sprintf("Supported key-value pairs are '%v=True', '%v=False'", TypeAnnotationKwargAny, TypeAnnotationKwargAny)},
@@ -58,7 +58,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 			if err != nil {
 				return nil, schemaAssertionError{
 					position:    pos,
-					description: "unknown @schema/type annotation keyword argument",
+					description: "Invalid schema - unknown @schema/type annotation keyword argument",
 					expected:    "starlark.Bool",
 					found:       fmt.Sprintf("%T", kwarg[1]),
 					hints:       []string{fmt.Sprintf("Supported kwargs are '%v'", TypeAnnotationKwargAny)},
@@ -69,7 +69,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 		default:
 			return nil, schemaAssertionError{
 				position:    pos,
-				description: "unknown @schema/type annotation keyword argument",
+				description: "Invalid schema - unknown @schema/type annotation keyword argument",
 				expected:    "A valid kwarg",
 				found:       argName,
 				hints:       []string{fmt.Sprintf("Supported kwargs are '%v'", TypeAnnotationKwargAny)},
@@ -131,13 +131,13 @@ func processOptionalAnnotation(node yamlmeta.Node, optionalAnnotation structmeta
 			}
 			nullAnn, err := NewNullableAnnotation(ann, wrappedValueType, node.GetPosition())
 			if err != nil {
-				return nil, NewSchemaError(err)
+				return nil, NewSchemaError("", err)
 			}
 			return nullAnn, nil
 		case AnnotationType:
 			typeAnn, err := NewTypeAnnotation(ann, node.GetPosition())
 			if err != nil {
-				return nil, NewSchemaError(err)
+				return nil, NewSchemaError("", err)
 			}
 			return typeAnn, nil
 		}

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -114,13 +114,13 @@ func processOptionalAnnotation(node yamlmeta.Node, optionalAnnotation structmeta
 			}
 			nullAnn, err := NewNullableAnnotation(ann, wrappedValueType, node.GetPosition())
 			if err != nil {
-				return nil, NewInvalidSchemaError(node, err.Error(), "")
+				return nil, NewInvalidSchemaError(node, err.Error(), nil)
 			}
 			return nullAnn, nil
 		case AnnotationType:
 			typeAnn, err := NewTypeAnnotation(ann, node.GetPosition())
 			if err != nil {
-				return nil, NewInvalidSchemaError(node, err.Error(), "")
+				return nil, NewInvalidSchemaError(node, err.Error(), nil)
 			}
 			return typeAnn, nil
 		}

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -39,7 +39,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 	if len(ann.Kwargs) == 0 {
 		return nil, schemaAssertionError{
 			position:    pos,
-			description: "Invalid schema - expected @schema/type annotation keyword argument",
+			description: "expected @schema/type annotation keyword argument",
 			expected:    "valid keyword arg",
 			found:       "missing keyword arg",
 			hints:       []string{fmt.Sprintf("Supported key-value pairs are '%v=True', '%v=False'", TypeAnnotationKwargAny, TypeAnnotationKwargAny)},
@@ -58,7 +58,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 			if err != nil {
 				return nil, schemaAssertionError{
 					position:    pos,
-					description: "Invalid schema - unknown @schema/type annotation keyword argument",
+					description: "unknown @schema/type annotation keyword argument",
 					expected:    "starlark.Bool",
 					found:       fmt.Sprintf("%T", kwarg[1]),
 					hints:       []string{fmt.Sprintf("Supported kwargs are '%v'", TypeAnnotationKwargAny)},
@@ -69,7 +69,7 @@ func NewTypeAnnotation(ann template.NodeAnnotation, pos *filepos.Position) (*Typ
 		default:
 			return nil, schemaAssertionError{
 				position:    pos,
-				description: "Invalid schema - unknown @schema/type annotation keyword argument",
+				description: "unknown @schema/type annotation keyword argument",
 				expected:    "A valid kwarg",
 				found:       argName,
 				hints:       []string{fmt.Sprintf("Supported kwargs are '%v'", TypeAnnotationKwargAny)},
@@ -131,13 +131,13 @@ func processOptionalAnnotation(node yamlmeta.Node, optionalAnnotation structmeta
 			}
 			nullAnn, err := NewNullableAnnotation(ann, wrappedValueType, node.GetPosition())
 			if err != nil {
-				return nil, NewSchemaError("", err)
+				return nil, err
 			}
 			return nullAnn, nil
 		case AnnotationType:
 			typeAnn, err := NewTypeAnnotation(ann, node.GetPosition())
 			if err != nil {
-				return nil, NewSchemaError("", err)
+				return nil, err
 			}
 			return typeAnn, nil
 		}

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -13,16 +13,16 @@ import (
 
 func NewInvalidSchemaError(found yamlmeta.Node, message, hint string) error {
 	return &invalidSchemaError{
-		Message: message,
 		Found:   found,
-		Hint:    hint,
+		message: message,
+		hint:    hint,
 	}
 }
 
 func NewInvalidArrayDefinitionError(found yamlmeta.Node, hint string) error {
 	return &invalidArrayDefinitionError{
 		Found: found,
-		Hint:  hint,
+		hint:  hint,
 	}
 }
 
@@ -41,9 +41,9 @@ func NewUnexpectedKeyError(found *yamlmeta.MapItem, definition *filepos.Position
 }
 
 type invalidSchemaError struct {
-	Message string
 	Found   yamlmeta.Node
-	Hint    string
+	message string
+	hint    string
 }
 
 func (e invalidSchemaError) Error() string {
@@ -54,9 +54,9 @@ func (e invalidSchemaError) Error() string {
 	msg := "\n"
 	msg += formatLine(leftColumnSize, position, lineContent)
 	msg += formatLine(leftColumnSize, "", "")
-	msg += formatLine(leftColumnSize, "", "INVALID SCHEMA - "+e.Message)
-	if e.Hint != "" {
-		msg += formatLine(leftColumnSize, "", fmt.Sprintf("  (hint: %s)", e.Hint))
+	msg += formatLine(leftColumnSize, "", "INVALID SCHEMA - "+e.message)
+	if e.hint != "" {
+		msg += formatLine(leftColumnSize, "", fmt.Sprintf("  (hint: %s)", e.hint))
 	}
 
 	return msg
@@ -64,7 +64,7 @@ func (e invalidSchemaError) Error() string {
 
 type invalidArrayDefinitionError struct {
 	Found yamlmeta.Node
-	Hint  string
+	hint  string
 }
 
 func (i invalidArrayDefinitionError) Error() string {
@@ -78,7 +78,7 @@ func (i invalidArrayDefinitionError) Error() string {
 	msg += formatLine(leftColumnSize, "", "INVALID ARRAY DEFINITION IN SCHEMA - unable to determine the desired type")
 	msg += formatLine(leftColumnSize, "", fmt.Sprintf("     found: %d array items", len(i.Found.GetValues())))
 	msg += formatLine(leftColumnSize, "", "  expected: exactly 1 array item, of the desired type")
-	msg += formatLine(leftColumnSize, "", fmt.Sprintf("  (hint: %s)", i.Hint))
+	msg += formatLine(leftColumnSize, "", fmt.Sprintf("  (hint: %s)", i.hint))
 
 	return msg
 }

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"text/template"
 
 	"github.com/k14s/ytt/pkg/filepos"
@@ -16,6 +17,7 @@ import (
 const schemaErrorReportTemplate = `
 {{- if .Summary}}
 {{.Summary}}
+{{addBreak .Summary}}
 {{- end}}
 {{- range .AssertionFailures}}
 {{- if .Description}}
@@ -127,6 +129,9 @@ func (e schemaError) Error() string {
 			padding := "  "
 			rightAlignedFilePos := fmt.Sprintf("%*s", maxFilePos, filePos)
 			return padding + rightAlignedFilePos + " " + delim
+		},
+		"addBreak": func(title string) string {
+			return strings.Repeat("=", len(title))
 		},
 	}
 

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -11,11 +11,11 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-func NewInvalidSchemaError(found yamlmeta.Node, message, hint string) error {
+func NewInvalidSchemaError(found yamlmeta.Node, message string, hints []string) error {
 	return &invalidSchemaError{
 		Found:   found,
 		message: message,
-		hint:    hint,
+		hints:   hints,
 	}
 }
 
@@ -43,7 +43,7 @@ func NewUnexpectedKeyError(found *yamlmeta.MapItem, definition *filepos.Position
 type invalidSchemaError struct {
 	Found   yamlmeta.Node
 	message string
-	hint    string
+	hints   []string
 }
 
 func (e invalidSchemaError) Error() string {
@@ -55,8 +55,10 @@ func (e invalidSchemaError) Error() string {
 	msg += formatLine(leftColumnSize, position, lineContent)
 	msg += formatLine(leftColumnSize, "", "")
 	msg += formatLine(leftColumnSize, "", "INVALID SCHEMA - "+e.message)
-	if e.hint != "" {
-		msg += formatLine(leftColumnSize, "", fmt.Sprintf("  (hint: %s)", e.hint))
+	for _, hint := range e.hints {
+		if hint != "" {
+			msg += formatLine(leftColumnSize, "", fmt.Sprintf("hint: %s", hint))
+		}
 	}
 
 	return msg

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -31,7 +31,7 @@ func NewInvalidSchemaError(err error, node yamlmeta.Node) error {
 	if schemaErrorInfo, ok := err.(schemaAssertionError); ok {
 		return &invalidSchemaError{
 			Title:    fmt.Sprintf("Invalid schema — %s", schemaErrorInfo.description),
-			FileName: node.GetPosition().AsCompactString(),
+			FileName: node.GetPosition().GetFile(),
 			filePos:  node.GetPosition().AsIntString(),
 			Diff:     node.GetPosition().GetLine(),
 			Expected: schemaErrorInfo.expected,

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -14,7 +14,7 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-const invalidSchemaTemplate = `
+const schemaErrorReportTemplate = `
 {{.Title}}
 
 {{.FileName}}:
@@ -27,9 +27,9 @@ const invalidSchemaTemplate = `
 {{range .Hints}}{{pad "=" false}} hint: {{.}}
 {{end}}`
 
-func NewInvalidSchemaError(err error, node yamlmeta.Node) error {
+func NewSchemaError(err error, node yamlmeta.Node) error {
 	if schemaErrorInfo, ok := err.(schemaAssertionError); ok {
-		return &invalidSchemaError{
+		return &schemaError{
 			Title:    fmt.Sprintf("Invalid schema — %s", schemaErrorInfo.description),
 			FileName: node.GetPosition().GetFile(),
 			filePos:  node.GetPosition().AsIntString(),
@@ -40,8 +40,8 @@ func NewInvalidSchemaError(err error, node yamlmeta.Node) error {
 		}
 	}
 
-	return &invalidSchemaError{
-		Title:    "Invalid schema",
+	return &schemaError{
+		Title:    "Schema Error",
 		FileName: node.GetPosition().GetFile(),
 		filePos:  node.GetPosition().AsIntString(),
 		Diff:     node.GetPosition().GetLine(),
@@ -70,7 +70,7 @@ type schemaAssertionError struct {
 	hints       []string
 }
 
-type invalidSchemaError struct {
+type schemaError struct {
 	Title    string
 	FileName string
 	Diff     string
@@ -81,7 +81,7 @@ type invalidSchemaError struct {
 	filePos string
 }
 
-func (e invalidSchemaError) Error() string {
+func (e schemaError) Error() string {
 	funcMap := template.FuncMap{
 		"pad": func(delim string, includeLineNumber bool) string {
 			padding := "  "
@@ -92,7 +92,7 @@ func (e invalidSchemaError) Error() string {
 		},
 	}
 
-	tmpl, err := template.New("").Funcs(funcMap).Parse(invalidSchemaTemplate)
+	tmpl, err := template.New("").Funcs(funcMap).Parse(schemaErrorReportTemplate)
 	if err != nil {
 		log.Fatalf("parsing: %s", err)
 	}

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -42,16 +42,9 @@ func NewInvalidSchemaError(err error, node yamlmeta.Node) error {
 
 	return &invalidSchemaError{
 		Title:    "Invalid schema",
-		FileName: node.GetPosition().AsCompactString(),
+		FileName: node.GetPosition().GetFile(),
 		filePos:  node.GetPosition().AsIntString(),
 		Diff:     node.GetPosition().GetLine(),
-	}
-}
-
-func NewInvalidArrayDefinitionError(found yamlmeta.Node, hint string) error {
-	return &invalidArrayDefinitionError{
-		Found: found,
-		hint:  hint,
 	}
 }
 
@@ -112,27 +105,6 @@ func (e invalidSchemaError) Error() string {
 	}
 
 	return output.String()
-}
-
-type invalidArrayDefinitionError struct {
-	Found yamlmeta.Node
-	hint  string
-}
-
-func (i invalidArrayDefinitionError) Error() string {
-	position := i.Found.GetPosition().AsCompactString()
-	leftColumnSize := len(position) + 1
-	lineContent := i.Found.GetPosition().GetLine()
-
-	msg := "\n"
-	msg += formatLine(leftColumnSize, position, lineContent)
-	msg += formatLine(leftColumnSize, "", "")
-	msg += formatLine(leftColumnSize, "", "INVALID ARRAY DEFINITION IN SCHEMA - unable to determine the desired type")
-	msg += formatLine(leftColumnSize, "", fmt.Sprintf("     found: %d array items", len(i.Found.GetValues())))
-	msg += formatLine(leftColumnSize, "", "  expected: exactly 1 array item, of the desired type")
-	msg += formatLine(leftColumnSize, "", fmt.Sprintf("  (hint: %s)", i.hint))
-
-	return msg
 }
 
 type mismatchedTypeError struct {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -128,7 +128,11 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 	if valueType == nil {
 		return nil, NewInvalidSchemaError(item,
 			"null value is not allowed in schema (no type can be inferred from it)",
-			"to default to null, specify a value of the desired type and annotate with @schema/nullable")
+			[]string{
+				"in YAML, omitting a value implies null.",
+				"to set the default value to null, annotate with @schema/nullable.",
+				"to allow any value, annotate with @schema/type any=True.",
+			})
 	}
 
 	defaultValue := item.Value
@@ -168,7 +172,7 @@ func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
 	typeFromAnns := convertAnnotationsToSingleType(anns)
 	if typeFromAnns != nil {
 		if _, ok := typeFromAnns.(*NullType); ok {
-			return nil, NewInvalidSchemaError(item, fmt.Sprintf("@%s is not supported on array items", AnnotationNullable), "")
+			return nil, NewInvalidSchemaError(item, fmt.Sprintf("@%s is not supported on array items", AnnotationNullable), nil)
 		}
 		valueType = typeFromAnns
 	} else {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -127,11 +127,12 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 
 	if valueType == nil {
 		return nil, NewSchemaError(schemaAssertionError{
+			position:    item.GetPosition(),
 			description: "null value not allowed here",
 			expected:    "non-null value",
 			found:       "null value",
 			hints:       []string{"in YAML, omitting a value implies null.", "to set the default value to null, annotate with @schema/nullable.", "to allow any value, annotate with @schema/type any=True."},
-		}, item)
+		})
 	}
 
 	defaultValue := item.Value
@@ -145,11 +146,12 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
 	if len(a.Items) != 1 {
 		return nil, NewSchemaError(schemaAssertionError{
+			position:    a.Position,
 			description: "wrong number of items in array definition",
 			expected:    "exactly 1 array item, of the desired type",
 			found:       fmt.Sprintf("%d array items", len(a.Items)),
 			hints:       []string{"in schema, the one item of the array implies the type of its elements.", "in schema, the default value for an array is always an empty list.", "default values can be overridden via a data values overlay."},
-		}, a)
+		})
 	}
 
 	arrayItemType, err := NewArrayItemType(a.Items[0])
@@ -171,12 +173,12 @@ func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
 	if typeFromAnns != nil {
 		if _, ok := typeFromAnns.(*NullType); ok {
 			return nil, NewSchemaError(schemaAssertionError{
-				error:       nil,
+				position:    item.Position,
 				description: "@schema/nullable is not supported on array items",
 				expected:    "a valid annotation",
 				found:       fmt.Sprintf("@%v", AnnotationNullable),
 				hints:       []string{"Remove the @schema/nullable annotation from array item"},
-			}, item)
+			})
 		}
 		valueType = typeFromAnns
 	} else {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -126,7 +126,7 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 	}
 
 	if valueType == nil {
-		return nil, NewInvalidSchemaError(schemaAssertionError{
+		return nil, NewSchemaError(schemaAssertionError{
 			description: "null value not allowed here",
 			expected:    "non-null value",
 			found:       "null value",
@@ -144,7 +144,7 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 
 func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
 	if len(a.Items) != 1 {
-		return nil, NewInvalidSchemaError(schemaAssertionError{
+		return nil, NewSchemaError(schemaAssertionError{
 			description: "wrong number of items in array definition",
 			expected:    "exactly 1 array item, of the desired type",
 			found:       fmt.Sprintf("%d array items", len(a.Items)),
@@ -170,7 +170,7 @@ func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
 	typeFromAnns := convertAnnotationsToSingleType(anns)
 	if typeFromAnns != nil {
 		if _, ok := typeFromAnns.(*NullType); ok {
-			return nil, NewInvalidSchemaError(schemaAssertionError{
+			return nil, NewSchemaError(schemaAssertionError{
 				error:       nil,
 				description: "@schema/nullable is not supported on array items",
 				expected:    "a valid annotation",

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -113,7 +113,7 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 
 	anns, err := collectAnnotations(item)
 	if err != nil {
-		return nil, err
+		return nil, NewSchemaError("Invalid schema", err)
 	}
 	typeFromAnns := convertAnnotationsToSingleType(anns)
 	if typeFromAnns != nil {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -126,12 +126,11 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 	}
 
 	if valueType == nil {
-		return nil, NewSchemaError(schemaAssertionError{
-			position:    item.GetPosition(),
-			description: "null value not allowed here",
-			expected:    "non-null value",
-			found:       "null value",
-			hints:       []string{"in YAML, omitting a value implies null.", "to set the default value to null, annotate with @schema/nullable.", "to allow any value, annotate with @schema/type any=True."},
+		return nil, NewSchemaError("Invalid schema - null value not allowed here", schemaAssertionError{
+			position: item.GetPosition(),
+			expected: "non-null value",
+			found:    "null value",
+			hints:    []string{"in YAML, omitting a value implies null.", "to set the default value to null, annotate with @schema/nullable.", "to allow any value, annotate with @schema/type any=True."},
 		})
 	}
 
@@ -145,12 +144,11 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 
 func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
 	if len(a.Items) != 1 {
-		return nil, NewSchemaError(schemaAssertionError{
-			position:    a.Position,
-			description: "wrong number of items in array definition",
-			expected:    "exactly 1 array item, of the desired type",
-			found:       fmt.Sprintf("%d array items", len(a.Items)),
-			hints:       []string{"in schema, the one item of the array implies the type of its elements.", "in schema, the default value for an array is always an empty list.", "default values can be overridden via a data values overlay."},
+		return nil, NewSchemaError("Invalid schema - wrong number of items in array definition", schemaAssertionError{
+			position: a.Position,
+			expected: "exactly 1 array item, of the desired type",
+			found:    fmt.Sprintf("%d array items", len(a.Items)),
+			hints:    []string{"in schema, the one item of the array implies the type of its elements.", "in schema, the default value for an array is always an empty list.", "default values can be overridden via a data values overlay."},
 		})
 	}
 
@@ -172,12 +170,11 @@ func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
 	typeFromAnns := convertAnnotationsToSingleType(anns)
 	if typeFromAnns != nil {
 		if _, ok := typeFromAnns.(*NullType); ok {
-			return nil, NewSchemaError(schemaAssertionError{
-				position:    item.Position,
-				description: "@schema/nullable is not supported on array items",
-				expected:    "a valid annotation",
-				found:       fmt.Sprintf("@%v", AnnotationNullable),
-				hints:       []string{"Remove the @schema/nullable annotation from array item"},
+			return nil, NewSchemaError("Invalid schema - @schema/nullable is not supported on array items", schemaAssertionError{
+				position: item.Position,
+				expected: "a valid annotation",
+				found:    fmt.Sprintf("@%v", AnnotationNullable),
+				hints:    []string{"Remove the @schema/nullable annotation from array item"},
 			})
 		}
 		valueType = typeFromAnns

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -143,14 +143,13 @@ func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
 }
 
 func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
-	// what's most useful to hint at depends on the author's input.
-	if len(a.Items) == 0 {
-		// assumption: the user likely does not understand that the shape of the elements are dependent on this item
-		return nil, NewInvalidArrayDefinitionError(a, "in a schema, the item of an array defines the type of its elements; its default value is an empty list")
-	}
-	if len(a.Items) > 1 {
-		// assumption: the user wants to supply defaults and (incorrectly) assumed they should go in schema
-		return nil, NewInvalidArrayDefinitionError(a, "to add elements to the default value of an array (i.e. an empty list), declare them in a @data/values document")
+	if len(a.Items) != 1 {
+		return nil, NewInvalidSchemaError(schemaAssertionError{
+			description: "wrong number of items in array definition",
+			expected:    "exactly 1 array item, of the desired type",
+			found:       fmt.Sprintf("%d array items", len(a.Items)),
+			hints:       []string{"in schema, the one item of the array implies the type of its elements.", "in schema, the default value for an array is always an empty list.", "default values can be overridden via a data values overlay."},
+		}, a)
 	}
 
 	arrayItemType, err := NewArrayItemType(a.Items[0])

--- a/pkg/schema/type.go
+++ b/pkg/schema/type.go
@@ -165,7 +165,7 @@ func (m *MapType) CheckType(node yamlmeta.TypeWithValues) (chk yamlmeta.TypeChec
 	nodeMap, ok := node.(*yamlmeta.Map)
 	if !ok {
 		chk.Violations = append(chk.Violations,
-			NewMismatchedTypeError(node, m))
+			NewMismatchedTypeAssertionError(node, m))
 		return
 	}
 
@@ -192,7 +192,7 @@ func (a *ArrayType) CheckType(node yamlmeta.TypeWithValues) (chk yamlmeta.TypeCh
 	_, ok := node.(*yamlmeta.Array)
 	if !ok {
 		chk.Violations = append(chk.Violations,
-			NewMismatchedTypeError(node, a))
+			NewMismatchedTypeAssertionError(node, a))
 	}
 	return
 }
@@ -212,28 +212,28 @@ func (m *ScalarType) CheckType(node yamlmeta.TypeWithValues) (chk yamlmeta.TypeC
 	case string:
 		if _, ok := m.Value.(string); !ok {
 			chk.Violations = append(chk.Violations,
-				NewMismatchedTypeError(node, m))
+				NewMismatchedTypeAssertionError(node, m))
 		}
 	case float64:
 		if _, ok := m.Value.(float64); !ok {
 			chk.Violations = append(chk.Violations,
-				NewMismatchedTypeError(node, m))
+				NewMismatchedTypeAssertionError(node, m))
 		}
 	case int, int64, uint64:
 		if _, ok := m.Value.(int); !ok {
 			if _, ok = m.Value.(float64); !ok {
 				chk.Violations = append(chk.Violations,
-					NewMismatchedTypeError(node, m))
+					NewMismatchedTypeAssertionError(node, m))
 			}
 		}
 	case bool:
 		if _, ok := m.Value.(bool); !ok {
 			chk.Violations = append(chk.Violations,
-				NewMismatchedTypeError(node, m))
+				NewMismatchedTypeAssertionError(node, m))
 		}
 	default:
 		chk.Violations = append(chk.Violations,
-			NewMismatchedTypeError(node, m))
+			NewMismatchedTypeAssertionError(node, m))
 	}
 	return
 }
@@ -246,7 +246,7 @@ func (t *DocumentType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.Ty
 	doc, ok := typeable.(*yamlmeta.Document)
 	if !ok {
 		chk.Violations = append(chk.Violations,
-			NewMismatchedTypeError(typeable, t))
+			NewMismatchedTypeAssertionError(typeable, t))
 		return
 	}
 
@@ -284,7 +284,7 @@ func (t *DocumentType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.Ty
 func (m *MapType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
 	mapNode, ok := typeable.(*yamlmeta.Map)
 	if !ok {
-		chk.Violations = append(chk.Violations, NewMismatchedTypeError(typeable, m))
+		chk.Violations = append(chk.Violations, NewMismatchedTypeAssertionError(typeable, m))
 		return
 	}
 	var foundKeys []interface{}
@@ -350,7 +350,7 @@ func (t *MapItemType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.Typ
 func (a *ArrayType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {
 	arrayNode, ok := typeable.(*yamlmeta.Array)
 	if !ok {
-		chk.Violations = append(chk.Violations, NewMismatchedTypeError(typeable, a))
+		chk.Violations = append(chk.Violations, NewMismatchedTypeAssertionError(typeable, a))
 		return
 	}
 	typeable.SetType(a)
@@ -376,7 +376,7 @@ func (a *ArrayItemType) AssignTypeTo(typeable yamlmeta.Typeable) (chk yamlmeta.T
 }
 
 func (m *ScalarType) AssignTypeTo(typeable yamlmeta.Typeable) yamlmeta.TypeCheck {
-	return yamlmeta.TypeCheck{[]error{NewMismatchedTypeError(typeable, m)}}
+	return yamlmeta.TypeCheck{[]error{NewMismatchedTypeAssertionError(typeable, m)}}
 }
 
 func (a AnyType) AssignTypeTo(yamlmeta.Typeable) (chk yamlmeta.TypeCheck) {

--- a/pkg/schema/type.go
+++ b/pkg/schema/type.go
@@ -172,7 +172,7 @@ func (m *MapType) CheckType(node yamlmeta.TypeWithValues) (chk yamlmeta.TypeChec
 	for _, item := range nodeMap.Items {
 		if !m.AllowsKey(item.Key) {
 			chk.Violations = append(chk.Violations,
-				NewUnexpectedKeyError(item, m.Position))
+				NewUnexpectedKeyAssertionError(item, m.Position))
 		}
 	}
 	return

--- a/pkg/workspace/data_values_pre_processing.go
+++ b/pkg/workspace/data_values_pre_processing.go
@@ -67,7 +67,7 @@ func (o DataValuesPreProcessing) apply(files []*FileInLibrary) (*DataValues, []*
 		}
 		typeCheck := o.typeAndCheck(resultDVsDoc)
 		if len(typeCheck.Violations) > 0 {
-			return nil, nil, schema.NewSchemaError(typeCheck)
+			return nil, nil, schema.NewSchemaError("Schema Typecheck - Value is of wrong type", typeCheck.Violations...)
 		}
 	}
 

--- a/pkg/workspace/data_values_pre_processing.go
+++ b/pkg/workspace/data_values_pre_processing.go
@@ -67,7 +67,7 @@ func (o DataValuesPreProcessing) apply(files []*FileInLibrary) (*DataValues, []*
 		}
 		typeCheck := o.typeAndCheck(resultDVsDoc)
 		if len(typeCheck.Violations) > 0 {
-			return nil, nil, typeCheck
+			return nil, nil, schema.NewSchemaError(typeCheck)
 		}
 	}
 


### PR DESCRIPTION
fixes #396 

Introduces a `SchemaError` that accepts errors with the goal of producing a consistent error message. Kinda like a report of all the errors it knows about.

`SchemaError` will always print a 'summary' when `Error` is called.

If `SchemaError` is given an error of type `schemaAssertionError` it will report those errors in a 'diff' format. with the line, file name, and expected / actual value formatted in a nice readable way.

For all other type of errors given to `SchemaError`, it will delegate to their `Error()`  and append those messages to the end of the `SchemaError` 'report'