### PR TITLE
Add indent with multiline to json.encode

### DIFF
--- a/pkg/template/core/args.go
+++ b/pkg/template/core/args.go
@@ -4,6 +4,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/k14s/starlark-go/starlark"
 )
 
@@ -18,4 +20,30 @@ func BoolArg(kwargs []starlark.Tuple, keyToFind string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func Int64Arg(kwargs []starlark.Tuple, keyToFind string) (int64, error) {
+	for _, arg := range kwargs {
+		key, err := NewStarlarkValue(arg.Index(0)).AsString()
+		if err != nil {
+			return 0, err
+		}
+		if key == keyToFind {
+			return NewStarlarkValue(arg.Index(1)).AsInt64()
+		}
+	}
+	return 0, nil
+}
+
+func CheckArgNames(kwargs []starlark.Tuple, validKeys map[string]struct{}) error {
+	for _, arg := range kwargs {
+		key, err := NewStarlarkValue(arg.Index(0)).AsString()
+		if err != nil {
+			return err
+		}
+		if _, ok := validKeys[key]; !ok {
+			return fmt.Errorf("invalid argument name: %s", key)
+		}
+	}
+	return nil
 }

--- a/pkg/yamltemplate/filetests/ytt-library/json.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/json.yml
@@ -7,24 +7,45 @@ fragment:
   piece1: false
 #@ end
 
-test1: #@ json.encode({"a": [1,2,3,{"c":456}], "b": "str"})
-test1a: #@ json.encode(yaml_fragment())
-test1b: #@ json.encode({"inside_map": yaml_fragment(), "inside_array": [yaml_fragment()]})
-test2: #@ json.encode({})
-test3: #@ json.decode("{}")
-test4: #@ json.decode('{"a":[1,2,3,{"c":456}],"b":"str"}')
+encode:
+  test1: #@ json.encode({})
+  test2: #@ json.encode({"a": [1,2,3,{"c":456}], "b": "str"})
+  test3: #@ json.encode(yaml_fragment())
+  test4: #@ json.encode({"inside_map": yaml_fragment(), "inside_array": [yaml_fragment()]})
+  indent:
+    test1: #@ json.encode({"a": [1,2,3,{"c":456}], "b": "str"}, indent=4)
+    test2: #@ json.encode({"a": [1,2,3,{"c":456}], "b": "str"}, indent=0)
+decode:
+  test1: #@ json.decode("{}")
+  test2: #@ json.decode('{"a":[1,2,3,{"c":456}],"b":"str"}')
 
 +++
 
-test1: '{"a":[1,2,3,{"c":456}],"b":"str"}'
-test1a: '{"fragment":["piece1",{"piece1":false,"piece2":true}]}'
-test1b: '{"inside_array":[{"fragment":["piece1",{"piece1":false,"piece2":true}]}],"inside_map":{"fragment":["piece1",{"piece1":false,"piece2":true}]}}'
-test2: '{}'
-test3: {}
-test4:
-  a:
-  - 1
-  - 2
-  - 3
-  - c: 456
-  b: str
+encode:
+  test1: '{}'
+  test2: '{"a":[1,2,3,{"c":456}],"b":"str"}'
+  test3: '{"fragment":["piece1",{"piece1":false,"piece2":true}]}'
+  test4: '{"inside_array":[{"fragment":["piece1",{"piece1":false,"piece2":true}]}],"inside_map":{"fragment":["piece1",{"piece1":false,"piece2":true}]}}'
+  indent:
+    test1: |-
+      {
+          "a": [
+              1,
+              2,
+              3,
+              {
+                  "c": 456
+              }
+          ],
+          "b": "str"
+      }
+    test2: '{"a":[1,2,3,{"c":456}],"b":"str"}'
+decode:
+  test1: {}
+  test2:
+    a:
+    - 1
+    - 2
+    - 3
+    - c: 456
+    b: str


### PR DESCRIPTION
- allow json.encode to receive an indent named argument:
  ```
  json.encode('{"a":"b"}', indent=2)
  ```
- indent greater than 0 indicates the json shall be rendered as a
  multiline string indented with the specified number of spaces
- indent=0 and omitting indent both result in a single line json string
- errors are returned if indent > 4 or if arguments other than indent
  are included

Issue #410

Co-authored-by: Tyler Schultz <tschultz@vmware.com>

> - indent=0 and omitting indent both result in a single line json string
In the issue it was proposed that indent=0 would result in multiline json with no indent. For pragmatic reasons we chose not to treat indent=0 as multiline. We think that it has little value and the implementation is simpler this way.

> - errors are returned if indent > 4 or if arguments other than indent  are included
We did not see patterns for testing validation errors. Should we leave the TODO in the yaml file? Would you like to see this covered in a particular way?

We also left a TODO in the PR for updating the docs repo. We're unclear how docs updates are preferred, in particular the timing. Should we make a PR now or after this PR is merged?

We're open to nit pick as well as design feedback on this PR.

cc @mcwumbly

