### PR TITLE
Bug fix: Empty data values is struct instead of None

### DIFF
--- a/pkg/cmd/template/cmd_data_values_test.go
+++ b/pkg/cmd/template/cmd_data_values_test.go
@@ -13,6 +13,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEmptyDataValues(t *testing.T) {
+	yamlTplData := []byte(`
+#@ load("@ytt:data", "data")
+data_int: #@ data.values`)
+
+	expectedYAMLTplData := `data_int: {}
+`
+	filesToProcess := files.NewSortedFiles([]*files.File{
+		files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+	})
+
+	ui := ui.NewTTY(false)
+	opts := cmdtpl.NewOptions()
+
+	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+	require.NoError(t, out.Err)
+	require.Len(t, out.Files, 1, "unexpected number of output files")
+
+	file := out.Files[0]
+
+	assert.Equal(t, "tpl.yml", file.RelativePath())
+	assert.Equal(t, expectedYAMLTplData, string(file.Bytes()))
+}
+
 func TestDataValues(t *testing.T) {
 	yamlTplData := []byte(`
 #@ load("@ytt:data", "data")

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -1644,7 +1644,7 @@ foo:
     bar: 3
     ree: set from root
 ---
-root_data_values: null
+root_data_values: {}
 `
 
 		filesToProcess := files.NewSortedFiles([]*files.File{
@@ -1692,7 +1692,7 @@ foo:
     bar: 3
     ree: set from root
 ---
-root_data_values: null
+root_data_values: {}
 `
 
 		filesToProcess := files.NewSortedFiles([]*files.File{
@@ -2032,7 +2032,7 @@ system_domain: #@ data.values.system_domain
 			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
 		})
 
-		expectedErr := "NoneType has no .system_domain field or method"
+		expectedErr := "struct has no .system_domain field or method"
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 }

--- a/pkg/workspace/data_values.go
+++ b/pkg/workspace/data_values.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/k14s/ytt/pkg/filepos"
 	"github.com/k14s/ytt/pkg/template"
 	"github.com/k14s/ytt/pkg/template/core"
 	"github.com/k14s/ytt/pkg/workspace/ref"
@@ -38,7 +39,14 @@ func NewDataValues(doc *yamlmeta.Document) (*DataValues, error) {
 }
 
 func NewEmptyDataValues() *DataValues {
-	return &DataValues{Doc: &yamlmeta.Document{}}
+	return &DataValues{Doc: newEmptyDataValuesDocument()}
+}
+
+func newEmptyDataValuesDocument() *yamlmeta.Document {
+	return &yamlmeta.Document{
+		Value:    &yamlmeta.Map{},
+		Position: filepos.NewUnknownPosition(),
+	}
 }
 
 type ExtractLibRefs interface {

--- a/pkg/workspace/data_values_pre_processing.go
+++ b/pkg/workspace/data_values_pre_processing.go
@@ -161,7 +161,7 @@ func (o DataValuesPreProcessing) templateFile(fileInLib *FileInLibrary) ([]*yaml
 
 func (o DataValuesPreProcessing) newEmptyDataValuesDocument() *yamlmeta.Document {
 	return &yamlmeta.Document{
-		Value:    nil,
+		Value:    &yamlmeta.Map{},
 		Position: filepos.NewUnknownPosition(),
 	}
 }

--- a/pkg/workspace/data_values_pre_processing.go
+++ b/pkg/workspace/data_values_pre_processing.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/k14s/starlark-go/starlark"
-	"github.com/k14s/ytt/pkg/filepos"
 	"github.com/k14s/ytt/pkg/schema"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 	yttoverlay "github.com/k14s/ytt/pkg/yttlibrary/overlay"
@@ -72,7 +71,7 @@ func (o DataValuesPreProcessing) apply(files []*FileInLibrary) (*DataValues, []*
 	}
 
 	if resultDVsDoc == nil {
-		resultDVsDoc = o.newEmptyDataValuesDocument()
+		resultDVsDoc = newEmptyDataValuesDocument()
 	}
 	dataValues, err := NewDataValues(resultDVsDoc)
 	if err != nil {
@@ -157,13 +156,6 @@ func (o DataValuesPreProcessing) templateFile(fileInLib *FileInLibrary) ([]*yaml
 	}
 
 	return valuesDocs, nil
-}
-
-func (o DataValuesPreProcessing) newEmptyDataValuesDocument() *yamlmeta.Document {
-	return &yamlmeta.Document{
-		Value:    &yamlmeta.Map{},
-		Position: filepos.NewUnknownPosition(),
-	}
 }
 
 func (o DataValuesPreProcessing) overlay(dataValues, overlay *yamlmeta.Document) (*yamlmeta.Document, error) {


### PR DESCRIPTION
In v.0.31.0 we changed the type of an empty data values to be None, this PR changes it back to what it was previously: a struct.

