### PR TITLE
Set line position of data value flags

### DIFF
--- a/pkg/cmd/template/data_values_flags.go
+++ b/pkg/cmd/template/data_values_flags.go
@@ -202,7 +202,8 @@ func (s *DataValuesFlags) env(prefix string, valueFunc valueTransformFunc) ([]*w
 
 		// '__' gets translated into a '.' since periods may not be liked by shells
 		keyPieces := strings.Split(strings.TrimPrefix(pieces[0], keyPrefix+envKeyPrefix), envMapKeySep)
-		overlay := s.buildOverlay(keyPieces, val, "env var", envVar)
+		desc := fmt.Sprintf("key '%s' (env var)", strings.Join(keyPieces, dvsMapKeySep))
+		overlay := s.buildOverlay(keyPieces, val, desc, envVar)
 
 		dvs, err := workspace.NewDataValuesWithOptionalLib(overlay, libRef)
 		if err != nil {
@@ -230,8 +231,8 @@ func (s *DataValuesFlags) kv(kv string, valueFunc valueTransformFunc) (*workspac
 	if err != nil {
 		return nil, err
 	}
-
-	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), val, "kv arg", kv)
+	desc := fmt.Sprintf("key '%s' (kv arg)", key)
+	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), val, desc, kv)
 
 	return workspace.NewDataValuesWithOptionalLib(overlay, libRef)
 }
@@ -259,9 +260,8 @@ func (s *DataValuesFlags) kvFile(kv string) (*workspace.DataValues, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	line := fmt.Sprintf("%s=%s", key, string(contents))
-	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), string(contents), "key=file arg", line)
+	desc := fmt.Sprintf("key '%s' (key=file arg) %s", key, pieces[1])
+	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), string(contents), desc, string(contents))
 
 	return workspace.NewDataValuesWithOptionalLib(overlay, libRef)
 }
@@ -294,7 +294,7 @@ func (s *DataValuesFlags) buildOverlay(keyPieces []string, value interface{}, de
 	var lastMapItem *yamlmeta.MapItem
 
 	pos := filepos.NewPosition(1)
-	pos.SetFile(fmt.Sprintf("key '%s' (%s)", strings.Join(keyPieces, dvsMapKeySep), desc))
+	pos.SetFile(desc)
 	pos.SetLine(line)
 
 	for _, piece := range keyPieces {

--- a/pkg/cmd/template/data_values_flags.go
+++ b/pkg/cmd/template/data_values_flags.go
@@ -202,7 +202,7 @@ func (s *DataValuesFlags) env(prefix string, valueFunc valueTransformFunc) ([]*w
 
 		// '__' gets translated into a '.' since periods may not be liked by shells
 		keyPieces := strings.Split(strings.TrimPrefix(pieces[0], keyPrefix+envKeyPrefix), envMapKeySep)
-		overlay := s.buildOverlay(keyPieces, val, "env var")
+		overlay := s.buildOverlay(keyPieces, val, "env var", envVar)
 
 		dvs, err := workspace.NewDataValuesWithOptionalLib(overlay, libRef)
 		if err != nil {
@@ -231,7 +231,7 @@ func (s *DataValuesFlags) kv(kv string, valueFunc valueTransformFunc) (*workspac
 		return nil, err
 	}
 
-	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), val, "kv arg")
+	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), val, "kv arg", kv)
 
 	return workspace.NewDataValuesWithOptionalLib(overlay, libRef)
 }
@@ -260,7 +260,8 @@ func (s *DataValuesFlags) kvFile(kv string) (*workspace.DataValues, error) {
 		return nil, err
 	}
 
-	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), string(contents), "key=file arg")
+	line := fmt.Sprintf("%s=%s", key, string(contents))
+	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), string(contents), "key=file arg", line)
 
 	return workspace.NewDataValuesWithOptionalLib(overlay, libRef)
 }
@@ -287,13 +288,14 @@ func (DataValuesFlags) libraryRefAndKey(key string) (string, string, error) {
 	}
 }
 
-func (s *DataValuesFlags) buildOverlay(keyPieces []string, value interface{}, desc string) *yamlmeta.Document {
+func (s *DataValuesFlags) buildOverlay(keyPieces []string, value interface{}, desc string, line string) *yamlmeta.Document {
 	resultMap := &yamlmeta.Map{}
 	currMap := resultMap
 	var lastMapItem *yamlmeta.MapItem
 
 	pos := filepos.NewPosition(1)
 	pos.SetFile(fmt.Sprintf("key '%s' (%s)", strings.Join(keyPieces, dvsMapKeySep), desc))
+	pos.SetLine(line)
 
 	for _, piece := range keyPieces {
 		newMap := &yamlmeta.Map{}

--- a/pkg/cmd/template/data_values_flags.go
+++ b/pkg/cmd/template/data_values_flags.go
@@ -55,6 +55,7 @@ func (s *DataValuesFlags) Set(cmd *cobra.Command) {
 type dataValuesFlagsSource struct {
 	Values        []string
 	TransformFunc valueTransformFunc
+	Name          string
 }
 
 type valueTransformFunc func(string) (interface{}, error)
@@ -83,9 +84,9 @@ func (s *DataValuesFlags) AsOverlays(strict bool) ([]*workspace.DataValues, []*w
 
 	// Then env vars take precedence over files
 	// since env vars are specific to command execution
-	for _, src := range []dataValuesFlagsSource{{s.EnvFromStrings, plainValFunc}, {s.EnvFromYAML, yamlValFunc}} {
+	for _, src := range []dataValuesFlagsSource{{s.EnvFromStrings, plainValFunc, "data-values-env"}, {s.EnvFromYAML, yamlValFunc, "data-values-env-yaml"}} {
 		for _, envPrefix := range src.Values {
-			vals, err := s.env(envPrefix, src.TransformFunc)
+			vals, err := s.env(envPrefix, src)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Extracting data values from env under prefix '%s': %s", envPrefix, err)
 			}
@@ -94,9 +95,9 @@ func (s *DataValuesFlags) AsOverlays(strict bool) ([]*workspace.DataValues, []*w
 	}
 
 	// KVs take precedence over environment variables
-	for _, src := range []dataValuesFlagsSource{{s.KVsFromStrings, plainValFunc}, {s.KVsFromYAML, yamlValFunc}} {
+	for _, src := range []dataValuesFlagsSource{{s.KVsFromStrings, plainValFunc, "data-value"}, {s.KVsFromYAML, yamlValFunc, "data-value-yaml"}} {
 		for _, kv := range src.Values {
-			val, err := s.kv(kv, src.TransformFunc)
+			val, err := s.kv(kv, src)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Extracting data value from KV: %s", err)
 			}
@@ -167,7 +168,7 @@ func (s *DataValuesFlags) file(path string, strict bool) ([]*workspace.DataValue
 	return result, nil
 }
 
-func (s *DataValuesFlags) env(prefix string, valueFunc valueTransformFunc) ([]*workspace.DataValues, error) {
+func (s *DataValuesFlags) env(prefix string, src dataValuesFlagsSource) ([]*workspace.DataValues, error) {
 	const (
 		envKeyPrefix = "_"
 		envMapKeySep = "__"
@@ -195,14 +196,14 @@ func (s *DataValuesFlags) env(prefix string, valueFunc valueTransformFunc) ([]*w
 			continue
 		}
 
-		val, err := valueFunc(pieces[1])
+		val, err := src.TransformFunc(pieces[1])
 		if err != nil {
 			return nil, fmt.Errorf("Extracting data value from env variable '%s': %s", pieces[0], err)
 		}
 
 		// '__' gets translated into a '.' since periods may not be liked by shells
 		keyPieces := strings.Split(strings.TrimPrefix(pieces[0], keyPrefix+envKeyPrefix), envMapKeySep)
-		desc := fmt.Sprintf("key '%s' (env var)", strings.Join(keyPieces, dvsMapKeySep))
+		desc := fmt.Sprintf("(%s arg) %s", src.Name, keyPrefix)
 		overlay := s.buildOverlay(keyPieces, val, desc, envVar)
 
 		dvs, err := workspace.NewDataValuesWithOptionalLib(overlay, libRef)
@@ -216,13 +217,13 @@ func (s *DataValuesFlags) env(prefix string, valueFunc valueTransformFunc) ([]*w
 	return result, nil
 }
 
-func (s *DataValuesFlags) kv(kv string, valueFunc valueTransformFunc) (*workspace.DataValues, error) {
+func (s *DataValuesFlags) kv(kv string, src dataValuesFlagsSource) (*workspace.DataValues, error) {
 	pieces := strings.SplitN(kv, dvsKVSep, 2)
 	if len(pieces) != 2 {
 		return nil, fmt.Errorf("Expected format key=value")
 	}
 
-	val, err := valueFunc(pieces[1])
+	val, err := src.TransformFunc(pieces[1])
 	if err != nil {
 		return nil, fmt.Errorf("Deserializing value for key '%s': %s", pieces[0], err)
 	}
@@ -231,7 +232,7 @@ func (s *DataValuesFlags) kv(kv string, valueFunc valueTransformFunc) (*workspac
 	if err != nil {
 		return nil, err
 	}
-	desc := fmt.Sprintf("key '%s' (kv arg)", key)
+	desc := fmt.Sprintf("(%s arg)", src.Name)
 	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), val, desc, kv)
 
 	return workspace.NewDataValuesWithOptionalLib(overlay, libRef)
@@ -260,7 +261,7 @@ func (s *DataValuesFlags) kvFile(kv string) (*workspace.DataValues, error) {
 	if err != nil {
 		return nil, err
 	}
-	desc := fmt.Sprintf("key '%s' (key=file arg) %s", key, pieces[1])
+	desc := fmt.Sprintf("(data-value-file arg) %s=%s", key, pieces[1])
 	overlay := s.buildOverlay(strings.Split(key, dvsMapKeySep), string(contents), desc, string(contents))
 
 	return workspace.NewDataValuesWithOptionalLib(overlay, libRef)

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -527,7 +527,38 @@ rendered: #@ data.values.foo
 One or more data values were invalid
 ====================================
 
-key 'foo' (kv arg):
+(data-value arg):
+    |
+  1 | foo=not an integer
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:3)
+`
+		assertFails(t, filesToProcess, expectedErr, cmdOpts)
+	})
+	t.Run("when a data value of the wrong type is passed using --data-value-yaml", func(t *testing.T) {
+		cmdOpts := cmdtpl.NewOptions()
+		cmdOpts.SchemaEnabled = true
+		schemaYAML := `#@data/values-schema
+---
+foo: 7
+`
+		templateYAML := `#@ load("@ytt:data", "data")
+---
+rendered: #@ data.values.foo
+`
+		cmdOpts.DataValuesFlags.KVsFromYAML = []string{"foo=not an integer"}
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
+			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
+		})
+
+		expectedErr := `
+One or more data values were invalid
+====================================
+
+(data-value-yaml arg):
     |
   1 | foo=not an integer
     |
@@ -563,7 +594,42 @@ rendered: #@ data.values.foo
 One or more data values were invalid
 ====================================
 
-key 'foo' (env var):
+(data-values-env arg) DVS:
+    |
+  1 | DVS_foo=not an integer
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:3)
+`
+		assertFails(t, filesToProcess, expectedErr, cmdOpts)
+	})
+	t.Run("when a data value of the wrong type is passed using --data-value-env-yaml", func(t *testing.T) {
+		cmdOpts := cmdtpl.NewOptions()
+		cmdOpts.SchemaEnabled = true
+		schemaYAML := `#@data/values-schema
+---
+foo: 0
+`
+		templateYAML := `#@ load("@ytt:data", "data")
+---
+rendered: #@ data.values.foo
+`
+		cmdOpts.DataValuesFlags = cmdtpl.DataValuesFlags{
+			EnvFromYAML: []string{"DVS"},
+			EnvironFunc:    func() []string { return []string{"DVS_foo=not an integer"} },
+		}
+
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
+			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
+		})
+
+		expectedErr := `
+One or more data values were invalid
+====================================
+
+(data-values-env-yaml arg) DVS:
     |
   1 | DVS_foo=not an integer
     |
@@ -609,7 +675,7 @@ rendered: #@ data.values.foo
 One or more data values were invalid
 ====================================
 
-key 'foo' (key=file arg) dvs1.yml:
+(data-value-file arg) foo=dvs1.yml:
     |
   1 | not an integer
     |
@@ -1656,7 +1722,7 @@ foo: #@ data.values.foo
      One or more data values were invalid
      ====================================
      
-     key 'foo' (kv arg):
+     (data-value arg):
          |
        1 | @lib:foo=42
          |

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -506,7 +506,7 @@ One or more data values were invalid
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 
-	t.Run("when a data value is passed using --data-value, but schema expects a non string", func(t *testing.T) {
+	t.Run("when a data value of the wrong type is passed using --data-value", func(t *testing.T) {
 		cmdOpts := cmdtpl.NewOptions()
 		cmdOpts.SchemaEnabled = true
 		schemaYAML := `#@data/values-schema
@@ -517,7 +517,7 @@ foo: 7
 ---
 rendered: #@ data.values.foo
 `
-		cmdOpts.DataValuesFlags.KVsFromStrings = []string{"foo=42"}
+		cmdOpts.DataValuesFlags.KVsFromStrings = []string{"foo=not an integer"}
 		filesToProcess := files.NewSortedFiles([]*files.File{
 			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
 			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
@@ -529,7 +529,89 @@ One or more data values were invalid
 
 key 'foo' (kv arg):
     |
-  1 | 
+  1 | foo=not an integer
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:3)
+`
+		assertFails(t, filesToProcess, expectedErr, cmdOpts)
+	})
+
+	t.Run("when a data value of the wrong type is passed using --data-value-env", func(t *testing.T) {
+		cmdOpts := cmdtpl.NewOptions()
+		cmdOpts.SchemaEnabled = true
+		schemaYAML := `#@data/values-schema
+---
+foo: 0
+`
+		templateYAML := `#@ load("@ytt:data", "data")
+---
+rendered: #@ data.values.foo
+`
+		cmdOpts.DataValuesFlags = cmdtpl.DataValuesFlags{
+			EnvFromStrings: []string{"DVS"},
+			EnvironFunc:    func() []string { return []string{"DVS_foo=not an integer"} },
+		}
+
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
+			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
+		})
+
+		expectedErr := `
+One or more data values were invalid
+====================================
+
+key 'foo' (env var):
+    |
+  1 | DVS_foo=not an integer
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:3)
+`
+		assertFails(t, filesToProcess, expectedErr, cmdOpts)
+	})
+
+	t.Run("when a data value of the wrong type is passed using --data-value-file", func(t *testing.T) {
+		cmdOpts := cmdtpl.NewOptions()
+		cmdOpts.SchemaEnabled = true
+		schemaYAML := `#@data/values-schema
+---
+foo: 0
+`
+
+		dvs1 := `not an integer`
+
+		templateYAML := `#@ load("@ytt:data", "data")
+---
+rendered: #@ data.values.foo
+`
+		cmdOpts.DataValuesFlags = cmdtpl.DataValuesFlags{
+			KVsFromFiles: []string{"foo=dvs1.yml"},
+			ReadFileFunc: func(path string) ([]byte, error) {
+				switch path {
+				case "dvs1.yml":
+					return []byte(dvs1), nil
+				default:
+					return nil, fmt.Errorf("Unknown file '%s'", path)
+				}
+			},
+		}
+
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
+			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
+		})
+
+		expectedErr := `
+One or more data values were invalid
+====================================
+
+key 'foo' (key=file arg):
+    |
+  1 | foo=not an integer
     |
 
     = found: string
@@ -1530,7 +1612,7 @@ foo: #@ data.values.foo
      
      key 'foo' (kv arg):
          |
-       1 | 
+       1 | @lib:foo=42
          |
      
          = found: string


### PR DESCRIPTION
Why: In order to report better schema errors the source line is now saved

For all flags not read from a file the error is [reported](https://github.com/vmware-tanzu/carvel-ytt/pull/438/files#diff-2ab902ad23ffe96207ff6466403834df5538e509639024bfc503aed26a377cb8R562-R573) in the format `key=value`. 

Two cases I want to call out: 
### 1st case:
 When reporting an error from a data value read from a file eg: `--data-value-file foo=/path/file.yml` the line will be reported with only the file contents, and they key name and file name are reported at the top:
```
key 'foo' (key=file arg) dvs1.yml:
    |
  1 | not an integer
    |
```
Whereas other flags errors are reported exactly as they were input on the command line (eg: key=value). Please let me know if you have any feedback on this format.

### 2nd case: 
When targeting a library via `--data-value @lib:foo=4` the `@lib:` prefix is included in the error:
```
key 'foo' (kv arg):
         |
       1 | @lib:foo=42
```