### PR TITLE
Use parent node's position for template.replace()

### DIFF
--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -473,16 +473,25 @@ data_values.yml:
 
 		schemaYAML := `#@data/values-schema
 ---
-foo: 0
+map:
+  nestedMap:
+    key: 1
+  otherMap: 2
+  array:
+  - 3
 `
 		dataValuesYAML := `#@ load("@ytt:template", "template")
 #@data/values
 ---
-_: #@ template.replace({'foo':'not a integer'})
+#@ def frag_func():
+key: one
+#@ end
+
+_: #@ template.replace({'map': { 'nestedMap': frag_func(), 'otherMap': 'two', 'array': ['three']}})
 `
 		templateYAML := `#@ load("@ytt:data", "data")
 ---
-rendered: #@ data.values.foo
+rendered: #@ data.values.map
 `
 		expectedErr := `
 One or more data values were invalid
@@ -490,11 +499,28 @@ One or more data values were invalid
 
 dataValues.yml:
     |
-  4 | _: #@ template.replace({'foo':'not a integer'})
+  5 | key: one
     |
 
     = found: string
-    = expected: integer (by schema.yml:3)
+    = expected: integer (by schema.yml:5)
+
+dataValues.yml:
+    |
+  8 | _: #@ template.replace({'map': { 'nestedMap': frag_func(), 'otherMap': 'two', 'array': ['three']}})
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:6)
+
+dataValues.yml:
+    |
+  8 | _: #@ template.replace({'map': { 'nestedMap': frag_func(), 'otherMap': 'two', 'array': ['three']}})
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:8)
+
 `
 
 		filesToProcess := files.NewSortedFiles([]*files.File{

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -469,7 +469,7 @@ data_values.yml:
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 
-	t.Run("when a data value of the wrong type is passed using template replace", func(t *testing.T) {
+	t.Run("when a data value map of the wrong type is passed using template replace", func(t *testing.T) {
 
 		schemaYAML := `#@data/values-schema
 ---
@@ -520,6 +520,43 @@ dataValues.yml:
 
     = found: string
     = expected: integer (by schema.yml:8)
+
+`
+
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("schema.yml", []byte(schemaYAML))),
+			files.MustNewFileFromSource(files.NewBytesSource("dataValues.yml", []byte(dataValuesYAML))),
+			files.MustNewFileFromSource(files.NewBytesSource("template.yml", []byte(templateYAML))),
+		})
+
+		assertFails(t, filesToProcess, expectedErr, opts)
+	})
+	t.Run("when a data value array of the wrong type is passed using template replace", func(t *testing.T) {
+
+		schemaYAML := `#@data/values-schema
+---
+- key: 1
+`
+		dataValuesYAML := `#@ load("@ytt:template", "template")
+#@data/values
+---
+- #@ template.replace([{'key': 'not an integer'}])
+`
+		templateYAML := `#@ load("@ytt:data", "data")
+---
+rendered: #@ data.values
+`
+		expectedErr := `
+One or more data values were invalid
+====================================
+
+dataValues.yml:
+    |
+  4 | - #@ template.replace([{'key': 'not an integer'}])
+    |
+
+    = found: string
+    = expected: integer (by schema.yml:3)
 
 `
 

--- a/pkg/cmd/template/schema_test.go
+++ b/pkg/cmd/template/schema_test.go
@@ -469,16 +469,16 @@ data_values.yml:
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
 
-	t.Run("when a invalid data value is passed using template replace", func(t *testing.T) {
+	t.Run("when a data value of the wrong type is passed using template replace", func(t *testing.T) {
 
 		schemaYAML := `#@data/values-schema
 ---
-foo: bar
+foo: 0
 `
 		dataValuesYAML := `#@ load("@ytt:template", "template")
 #@data/values
 ---
-_: #@ template.replace({'foo':9})
+_: #@ template.replace({'foo':'not a integer'})
 `
 		templateYAML := `#@ load("@ytt:data", "data")
 ---
@@ -488,13 +488,13 @@ rendered: #@ data.values.foo
 One or more data values were invalid
 ====================================
 
-:
+dataValues.yml:
     |
-  ? | 
+  4 | _: #@ template.replace({'foo':'not a integer'})
     |
 
-    = found: integer
-    = expected: string (by schema.yml:3)
+    = found: string
+    = expected: integer (by schema.yml:3)
 `
 
 		filesToProcess := files.NewSortedFiles([]*files.File{

--- a/pkg/filepos/position.go
+++ b/pkg/filepos/position.go
@@ -83,7 +83,7 @@ func (p *Position) DeepCopy() *Position {
 	if p == nil {
 		return nil
 	}
-	newPos := &Position{file: p.file, known: p.known}
+	newPos := &Position{file: p.file, known: p.known, line: p.line}
 	if p.lineNum != nil {
 		lineVal := *p.lineNum
 		newPos.lineNum = &lineVal

--- a/pkg/yamltemplate/evaluation_ctx.go
+++ b/pkg/yamltemplate/evaluation_ctx.go
@@ -131,7 +131,8 @@ func (e EvaluationCtx) convertValToDocSetItems(val interface{}) ([]*yamlmeta.Doc
 func (e EvaluationCtx) replaceItemInMap(
 	dstMap *yamlmeta.Map, placeholderItem *yamlmeta.MapItem, val interface{}) error {
 
-	insertItems, carryMeta, err := e.convertValToMapItems(val)
+	parentPos := dstMap.Items[0].Position.DeepCopy()
+	insertItems, carryMeta, err := e.convertValToMapItems(val, parentPos)
 	if err != nil {
 		return err
 	}
@@ -158,16 +159,17 @@ func (e EvaluationCtx) replaceItemInMap(
 	return fmt.Errorf("expected to find placeholder map item in map")
 }
 
-func (e EvaluationCtx) convertValToMapItems(val interface{}) ([]*yamlmeta.MapItem, bool, error) {
+func (e EvaluationCtx) convertValToMapItems(val interface{}, position *filepos.Position) ([]*yamlmeta.MapItem, bool, error) {
 	switch typedVal := val.(type) {
 	case *orderedmap.Map:
 		result := []*yamlmeta.MapItem{}
 		typedVal.Iterate(func(k, v interface{}) {
-			result = append(result, &yamlmeta.MapItem{Key: k, Value: v, Position: filepos.NewUnknownPosition()})
+			result = append(result, &yamlmeta.MapItem{Key: k, Value: v, Position: position})
 		})
 		return result, false, nil
 
 	case *yamlmeta.Map:
+		//TODO: need to set position here?
 		return typedVal.Items, true, nil
 
 	default:

--- a/pkg/yamltemplate/evaluation_ctx.go
+++ b/pkg/yamltemplate/evaluation_ctx.go
@@ -131,8 +131,7 @@ func (e EvaluationCtx) convertValToDocSetItems(val interface{}) ([]*yamlmeta.Doc
 func (e EvaluationCtx) replaceItemInMap(
 	dstMap *yamlmeta.Map, placeholderItem *yamlmeta.MapItem, val interface{}) error {
 
-	parentPos := dstMap.Items[0].Position.DeepCopy()
-	insertItems, carryMeta, err := e.convertValToMapItems(val, parentPos)
+	insertItems, carryMeta, err := e.convertValToMapItems(val, placeholderItem.Position.DeepCopy())
 	if err != nil {
 		return err
 	}
@@ -178,7 +177,7 @@ func (e EvaluationCtx) convertValToMapItems(val interface{}, position *filepos.P
 }
 
 func (e EvaluationCtx) replaceItemInArray(dstArray *yamlmeta.Array, placeholderItem *yamlmeta.ArrayItem, val interface{}) error {
-	insertItems, err := e.convertValToArrayItems(val)
+	insertItems, err := e.convertValToArrayItems(val, placeholderItem.Position.DeepCopy())
 	if err != nil {
 		return err
 	}
@@ -196,13 +195,13 @@ func (e EvaluationCtx) replaceItemInArray(dstArray *yamlmeta.Array, placeholderI
 	return fmt.Errorf("expected to find placeholder array item in array")
 }
 
-func (e EvaluationCtx) convertValToArrayItems(val interface{}) ([]*yamlmeta.ArrayItem, error) {
+func (e EvaluationCtx) convertValToArrayItems(val interface{}, position *filepos.Position) ([]*yamlmeta.ArrayItem, error) {
 	result := []*yamlmeta.ArrayItem{}
 
 	switch typedVal := val.(type) {
 	case []interface{}:
 		for _, item := range typedVal {
-			result = append(result, &yamlmeta.ArrayItem{Value: item, Position: filepos.NewUnknownPosition()})
+			result = append(result, &yamlmeta.ArrayItem{Value: yamlmeta.NewASTFromInterfaceWithPosition(item, position), Position: position})
 		}
 
 	case *yamlmeta.Array:

--- a/pkg/yamltemplate/evaluation_ctx.go
+++ b/pkg/yamltemplate/evaluation_ctx.go
@@ -164,12 +164,12 @@ func (e EvaluationCtx) convertValToMapItems(val interface{}, position *filepos.P
 	case *orderedmap.Map:
 		result := []*yamlmeta.MapItem{}
 		typedVal.Iterate(func(k, v interface{}) {
-			result = append(result, &yamlmeta.MapItem{Key: k, Value: v, Position: position})
+			item := &yamlmeta.MapItem{Key: k, Value: yamlmeta.NewASTFromInterfaceWithPosition(v, position), Position: position}
+			result = append(result, item)
 		})
 		return result, false, nil
 
 	case *yamlmeta.Map:
-		//TODO: need to set position here?
 		return typedVal.Items, true, nil
 
 	default:


### PR DESCRIPTION
This adds positions for arrays and maps used in `template.replace` so that they can be shown in schema error messages. It supports:
* Maps: `_: #@ template.replace({'map': { 'nestedMap': frag_func(), 'otherMap': 'two', 'array': ['three']}})`
* Arrays: `- #@ template.replace([{'key': 'not an integer'}])`

Does **not** support function calls (eg: `library.get("lib").with_data_values({'foo':'4'}).eval())`) that will likely be a separate PR.
