### PR TITLE
Allow null array items

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -70,7 +70,7 @@ func NewNullSchema() *DocumentSchema {
 }
 
 func NewDocumentType(doc *yamlmeta.Document) (*DocumentType, error) {
-	typeOfValue, err := getTypeFromValueHoldingNode(doc)
+	typeOfValue, err := getType(doc)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func NewMapType(m *yamlmeta.Map) (*MapType, error) {
 }
 
 func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
-	typeOfValue, err := getTypeFromValueHoldingNode(item)
+	typeOfValue, err := getType(item)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
 }
 
 func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
-	typeOfValue, err := getTypeFromValueHoldingNode(item)
+	typeOfValue, err := getType(item)
 	if err != nil {
 		return nil, err
 	}
@@ -128,9 +128,7 @@ func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
 	return &ArrayItemType{ValueType: typeOfValue, defaultValue: typeOfValue.GetDefaultValue(), Position: item.GetPosition()}, nil
 }
 
-// getTypeFromValueHoldingNode derives the yamlmeta.Type from the given `node`.
-//    a "value-holding node" is a node that holds an actual value: Document, ArrayItem, or MapItem
-func getTypeFromValueHoldingNode(node yamlmeta.Node) (yamlmeta.Type, error) {
+func getType(node yamlmeta.ValueHoldingNode) (yamlmeta.Type, error) {
 	var typeOfValue yamlmeta.Type
 
 	anns, err := collectAnnotations(node)
@@ -140,13 +138,13 @@ func getTypeFromValueHoldingNode(node yamlmeta.Node) (yamlmeta.Type, error) {
 	typeOfValue = getTypeFromAnnotations(anns)
 
 	if typeOfValue == nil {
-		typeOfValue, err = inferTypeFromValue(node.GetValues()[0], node.GetPosition())
+		typeOfValue, err = inferTypeFromValue(node.Val(), node.GetPosition())
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	err = valueTypeAllowsItemValue(typeOfValue, node.GetValues()[0], node.GetPosition())
+	err = valueTypeAllowsItemValue(typeOfValue, node.Val(), node.GetPosition())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -70,29 +70,12 @@ func NewNullSchema() *DocumentSchema {
 }
 
 func NewDocumentType(doc *yamlmeta.Document) (*DocumentType, error) {
-	var typeOfValue yamlmeta.Type
-
-	anns, err := collectAnnotations(doc)
-	if err != nil {
-		return nil, NewSchemaError("Invalid schema", err)
-	}
-	typeOfValue = getTypeFromAnnotations(anns)
-
-	if typeOfValue == nil {
-		typeOfValue, err = inferTypeFromValue(doc.Value, doc.GetPosition())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = valueTypeAllowsItemValue(typeOfValue, doc.Value, doc.Position)
+	typeOfValue, err := getTypeFromValueHoldingNode(doc)
 	if err != nil {
 		return nil, err
 	}
 
-	defaultValue := typeOfValue.GetDefaultValue()
-
-	return &DocumentType{Source: doc, Position: doc.Position, ValueType: typeOfValue, defaultValue: defaultValue}, nil
+	return &DocumentType{Source: doc, Position: doc.Position, ValueType: typeOfValue, defaultValue: typeOfValue.GetDefaultValue()}, nil
 }
 
 func NewMapType(m *yamlmeta.Map) (*MapType, error) {
@@ -110,29 +93,12 @@ func NewMapType(m *yamlmeta.Map) (*MapType, error) {
 }
 
 func NewMapItemType(item *yamlmeta.MapItem) (*MapItemType, error) {
-	var typeOfValue yamlmeta.Type
-
-	anns, err := collectAnnotations(item)
-	if err != nil {
-		return nil, NewSchemaError("Invalid schema", err)
-	}
-	typeOfValue = getTypeFromAnnotations(anns)
-
-	if typeOfValue == nil {
-		typeOfValue, err = inferTypeFromValue(item.Value, item.GetPosition())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = valueTypeAllowsItemValue(typeOfValue, item.Value, item.Position)
+	typeOfValue, err := getTypeFromValueHoldingNode(item)
 	if err != nil {
 		return nil, err
 	}
 
-	defaultValue := typeOfValue.GetDefaultValue()
-
-	return &MapItemType{Key: item.Key, ValueType: typeOfValue, defaultValue: defaultValue, Position: item.Position}, nil
+	return &MapItemType{Key: item.Key, ValueType: typeOfValue, defaultValue: typeOfValue.GetDefaultValue(), Position: item.Position}, nil
 }
 
 func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
@@ -154,26 +120,38 @@ func NewArrayType(a *yamlmeta.Array) (*ArrayType, error) {
 }
 
 func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
-	var typeOfValue yamlmeta.Type
-
-	anns, err := collectAnnotations(item)
+	typeOfValue, err := getTypeFromValueHoldingNode(item)
 	if err != nil {
 		return nil, err
+	}
+
+	return &ArrayItemType{ValueType: typeOfValue, defaultValue: typeOfValue.GetDefaultValue(), Position: item.GetPosition()}, nil
+}
+
+// getTypeFromValueHoldingNode derives the yamlmeta.Type from the given `node`.
+//    a "value-holding node" is a node that holds an actual value: Document, ArrayItem, or MapItem
+func getTypeFromValueHoldingNode(node yamlmeta.Node) (yamlmeta.Type, error) {
+	var typeOfValue yamlmeta.Type
+
+	anns, err := collectAnnotations(node)
+	if err != nil {
+		return nil, NewSchemaError("Invalid schema", err)
 	}
 	typeOfValue = getTypeFromAnnotations(anns)
 
 	if typeOfValue == nil {
-		typeOfValue, err = inferTypeFromValue(item.Value, item.Position)
+		typeOfValue, err = inferTypeFromValue(node.GetValues()[0], node.GetPosition())
 		if err != nil {
 			return nil, err
 		}
 	}
-	err = valueTypeAllowsItemValue(typeOfValue, item.Value, item.Position)
+
+	err = valueTypeAllowsItemValue(typeOfValue, node.GetValues()[0], node.GetPosition())
 	if err != nil {
 		return nil, err
 	}
 
-	return &ArrayItemType{ValueType: typeOfValue, defaultValue: typeOfValue.GetDefaultValue(), Position: item.Position}, nil
+	return typeOfValue, nil
 }
 
 func inferTypeFromValue(value interface{}, position *filepos.Position) (yamlmeta.Type, error) {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -167,15 +167,6 @@ func NewArrayItemType(item *yamlmeta.ArrayItem) (*ArrayItemType, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		if _, ok := typeOfValue.(*NullType); ok {
-			return nil, NewSchemaError("Invalid schema - @schema/nullable is not supported on array items", schemaAssertionError{
-				position: item.Position,
-				expected: "a valid annotation",
-				found:    fmt.Sprintf("@%v", AnnotationNullable),
-				hints:    []string{"Remove the @schema/nullable annotation from array item"},
-			})
-		}
 	}
 	err = valueTypeAllowsItemValue(typeOfValue, item.Value, item.Position)
 	if err != nil {

--- a/pkg/yamlmeta/ast.go
+++ b/pkg/yamlmeta/ast.go
@@ -30,8 +30,13 @@ type Node interface {
 	sealed() // limit the concrete types of Node to map directly only to types allowed in YAML spec.
 }
 
-// Ensure: all types are — in fact — assignable to Node
-var _ = []Node{&DocumentSet{}, &Document{}, &Map{}, &MapItem{}, &Array{}, &ArrayItem{}}
+type ValueHoldingNode interface {
+	Node
+	Val() interface{}
+}
+
+var _ = []Node{&DocumentSet{}, &Map{}, &Array{}}
+var _ = []ValueHoldingNode{&Document{}, &MapItem{}, &ArrayItem{}}
 
 type DocumentSet struct {
 	Metas    []*Meta

--- a/pkg/yamlmeta/value_holding_node.go
+++ b/pkg/yamlmeta/value_holding_node.go
@@ -1,0 +1,14 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package yamlmeta
+
+func (d *Document) Val() interface{} {
+	return d.Value
+}
+func (mi *MapItem) Val() interface{} {
+	return mi.Value
+}
+func (ai *ArrayItem) Val() interface{} {
+	return ai.Value
+}


### PR DESCRIPTION
After a number of design conversations, it became clear that not allowing `@schema/nullable` on array items was an unnecessary constraint.

This PR removes that constraint (which allowed for a subsequent refactor).