### PR TITLE
Add assert.try_to

### DIFF
--- a/pkg/yamltemplate/filetests/ytt-library/assert-try-to-err-arg.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/assert-try-to-err-arg.yml
@@ -1,0 +1,11 @@
+#@ load("@ytt:assert", "assert")
+#@ load("@ytt:json", "json")
+
+test_try_to_invalid_arg: #@ assert.try_to("invalid")
+
++++
+
+ERR: 
+- assert.try_to: expected argument to be a function, but was starlark.String
+    in <toplevel>
+      stdin:4 | test_try_to_invalid_arg: #@ assert.try_to("invalid")

--- a/pkg/yamltemplate/filetests/ytt-library/assert-try-to.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/assert-try-to.yml
@@ -1,0 +1,61 @@
+#@ load("@ytt:assert", "assert")
+#@ load("@ytt:json", "json")
+
+#@ def try_to_fail_data_error():
+#@   _, err = assert.try_to(lambda: json.decode("}junk"))
+#@   return err
+#@ end
+
+#@ def bad_ref():
+#@   return (None).foo
+#@ end
+
+#@ def try_to_fail_bad_ref():
+#@   _, err = assert.try_to(bad_ref)
+#@   return err
+#@ end
+
+#@ def try_to_succeed_lambda():
+#@   decoded, err = assert.try_to(lambda: json.decode('{"ytt":"rules"}'))
+#@   if err:
+#@      return err
+#@   end
+#@   return decoded
+#@ end
+
+#@ def try_to_succeed_tuple():
+#@   tupleResult, err = assert.try_to(lambda: (1,2))
+#@   if err:
+#@      return err
+#@   end
+#@   return tupleResult
+#@ end
+
+#@ def foo():
+#@   return "foo"
+#@ end
+
+#@ def try_to_succeed_function():
+#@   functionResult, err = assert.try_to(foo)
+#@   if err:
+#@      return err
+#@   end
+#@   return functionResult
+#@ end
+
+test_try_to_fail_data_error: #@ try_to_fail_data_error()
+test_try_to_fail_bad_ref: #@ try_to_fail_bad_ref()
+test_try_to_succeed_lambda: #@ try_to_succeed_lambda()
+test_try_to_succeed_function: #@ try_to_succeed_function()
+test_try_to_succeed_tuple: #@ try_to_succeed_tuple()
+
++++
+
+test_try_to_fail_data_error: 'json.decode: invalid character ''}'' looking for beginning of value'
+test_try_to_fail_bad_ref: NoneType has no .foo field or method
+test_try_to_succeed_lambda:
+  ytt: rules
+test_try_to_succeed_function: foo
+test_try_to_succeed_tuple:
+- 1
+- 2


### PR DESCRIPTION
assert.try_to receives a callable that traps and returns failure errors.
This allows templates to handle error cases instead of fast failing and
exiting.

Co-authored-by: Christian Ang <angc@vmware.com>

This PR is a result of discussion in #433
Resolves: #475