### PR TITLE
golangci-linter: enable godoc checks for all new commits

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.34
+          version: v1.41.1
           args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable:
     - goheader
-    - golint
+    - revive
     - deadcode
     - unused
   disable-all: true
@@ -15,6 +15,8 @@ linters-settings:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-use-default: false
+  new-from-rev: e0cbac3d0fcb3f4a5ecb55f586a0ffe269212634
 run:
   skip-dirs:
     - pkg/yamlmeta/internal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
-  new-from-rev: e0cbac3d0fcb3f4a5ecb55f586a0ffe269212634
+  new-from-rev: bd77aced0a1cd6d6f3ecd3ed04c1832e1c513ab0
 run:
   skip-dirs:
     - pkg/yamlmeta/internal


### PR DESCRIPTION
- bump golanci-lint version in the github action
- switch to revive as golint is deprecated
- change lingering nolint: golint to revive

@joe-kimmel-vmw explained:
- `fetch-depth: '0'` as otherwise the tooling will only grab a “shallow” clone from the most recent commit, and be unable to distinguish new code from old code
- `exclude-use-default: false`  iirc the godoc linter is an exclude-list by default, and this enables that linter by not using the default exclude list
- `new-from-rev: <sha>` lets you “grandfather” in all the old changes without godoc comments and only apply linter suite to new diffs (which it can distinguish bc we gave it infinite fetch-depth above).