### PR TITLE
Parse floats correctly and fix mistake from go-yaml/yaml#171

### DIFF
--- a/pkg/yamlmeta/internal/yaml.v2/decode_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/decode_test.go
@@ -694,13 +694,13 @@ var unmarshalTests = []struct {
 		M{"ñoño": "very yes 🟔"},
 	},
 
-	// YAML Float regex shouldn't match this
+	// This *is* in fact a float number, per the spec. #171 was a mistake.
 	{
 		"a: 123456e1\n",
-		M{"a": "123456e1"},
+		M{"a": 123456e1},
 	}, {
 		"a: 123456E1\n",
-		M{"a": "123456E1"},
+		M{"a": 123456E1},
 	},
 	// yaml-test-suite 3GZX: Spec Example 7.1. Alias Nodes
 	{

--- a/pkg/yamlmeta/internal/yaml.v2/resolve.go
+++ b/pkg/yamlmeta/internal/yaml.v2/resolve.go
@@ -84,7 +84,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {

--- a/pkg/yamlmeta/parser_test.go
+++ b/pkg/yamlmeta/parser_test.go
@@ -5,11 +5,11 @@ package yamlmeta_test
 
 import (
 	"fmt"
-	"github.com/k14s/difflib"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/k14s/difflib"
 	"github.com/k14s/ytt/pkg/filepos"
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
@@ -173,6 +173,28 @@ func TestParserRootValue(t *testing.T) {
 				Items: []*yamlmeta.Document{
 					&yamlmeta.Document{
 						Value:    1,
+						Position: filepos.NewPosition(1),
+					},
+				},
+				Position: filepos.NewUnknownPosition(),
+			},
+		},
+		{Description: "float", Data: "2000.1",
+			Expected: &yamlmeta.DocumentSet{
+				Items: []*yamlmeta.Document{
+					&yamlmeta.Document{
+						Value:    2000.1,
+						Position: filepos.NewPosition(1),
+					},
+				},
+				Position: filepos.NewUnknownPosition(),
+			},
+		},
+		{Description: "float (exponent)", Data: "9e3",
+			Expected: &yamlmeta.DocumentSet{
+				Items: []*yamlmeta.Document{
+					&yamlmeta.Document{
+						Value:    9000.0,
 						Position: filepos.NewPosition(1),
 					},
 				},


### PR DESCRIPTION
The regular expression is copy & pasted form the one in the spec.
The change suggested in go-yaml/yaml#171 and integrated was improper.

Closes go-yaml/yaml#290

(cherry-pick of go-yaml/yaml@7b8349ac747c6a24702b762d2c4fd9266cf4f1d6)

Signed-off-by: John Ryan <jtigger@infosysengr.com>