### PR TITLE
(refactor) extract type names as constants

### DIFF
--- a/pkg/yamltemplate/filetests/ytt-library/url/url-user-wont-encode-err.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/url/url-user-wont-encode-err.yml
@@ -6,6 +6,6 @@ url_value:
 +++
 
 ERR: 
-- __ytt_tplXXX_set_node: Unable to convert value: URLUser does not automatically encode (hint: use .string())
+- __ytt_tplXXX_set_node: Unable to convert value: @ytt:url.user does not automatically encode (hint: use .string())
     in <toplevel>
       stdin:4 |   user: #@ url.parse("http://alice:secret@example.com").user

--- a/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-dict-value.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-dict-value.yml
@@ -5,6 +5,6 @@ url_value: #@ {"key": url.parse("http://example.com")}
 +++
 
 ERR: 
-- __ytt_tplXXX_set_node: Unable to convert value: URLValue does not automatically encode (hint: use .string())
+- __ytt_tplXXX_set_node: Unable to convert value: @ytt:url.value does not automatically encode (hint: use .string())
     in <toplevel>
       stdin:3 | url_value: #@ {"key": url.parse("http://example.com")}

--- a/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-iterable-value.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-iterable-value.yml
@@ -5,6 +5,6 @@ url_value: #@ [url.parse("http://example.com")]
 +++
 
 ERR: 
-- __ytt_tplXXX_set_node: Unable to convert value: URLValue does not automatically encode (hint: use .string())
+- __ytt_tplXXX_set_node: Unable to convert value: @ytt:url.value does not automatically encode (hint: use .string())
     in <toplevel>
       stdin:3 | url_value: #@ [url.parse("http://example.com")]

--- a/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-map-key.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-map-key.yml
@@ -5,6 +5,6 @@ url_value: #@ url.parse("http://example.com")
 +++
 
 ERR: 
-- __ytt_tplXXX_set_node: Unable to convert value: URLValue does not automatically encode (hint: use .string())
+- __ytt_tplXXX_set_node: Unable to convert value: @ytt:url.value does not automatically encode (hint: use .string())
     in <toplevel>
       stdin:3 | url_value: #@ url.parse("http://example.com")

--- a/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-node-value.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-node-value.yml
@@ -5,6 +5,6 @@ url_value: #@ url.parse("http://example.com")
 +++
 
 ERR: 
-- __ytt_tplXXX_set_node: Unable to convert value: URLValue does not automatically encode (hint: use .string())
+- __ytt_tplXXX_set_node: Unable to convert value: @ytt:url.value does not automatically encode (hint: use .string())
     in <toplevel>
       stdin:3 | url_value: #@ url.parse("http://example.com")

--- a/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-struct-value.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/url/url-value-wont-encode/as-struct-value.yml
@@ -6,6 +6,6 @@ url_value: #@ struct.make(key=url.parse("http://example.com"))
 +++
 
 ERR: 
-- __ytt_tplXXX_set_node: Unable to convert value: URLValue does not automatically encode (hint: use .string())
+- __ytt_tplXXX_set_node: Unable to convert value: @ytt:url.value does not automatically encode (hint: use .string())
     in <toplevel>
       stdin:4 | url_value: #@ struct.make(key=url.parse("http://example.com"))

--- a/pkg/yttlibrary/ip.go
+++ b/pkg/yttlibrary/ip.go
@@ -51,15 +51,17 @@ type IPAddrValue struct {
 	*core.StarlarkStruct // TODO: keep authorship of the interface by delegating instead of embedding
 }
 
+const ipAddrTypeName = "ip.addr"
+
 // Type reports the name of this type as seen from a Starlark program (i.e. via the `type()` built-in)
-func (av *IPAddrValue) Type() string { return "@ytt:ip.addr" }
+func (av *IPAddrValue) Type() string { return "@ytt:" + ipAddrTypeName }
 
 // AsStarlarkValue converts this instance into a value suitable for use in a Starlark program.
 func (av *IPAddrValue) AsStarlarkValue() starlark.Value {
 	m := orderedmap.NewMap()
-	m.Set("is_ipv4", starlark.NewBuiltin("ip.addr.is_ipv4", core.ErrWrapper(av.IsIPv4)))
-	m.Set("is_ipv6", starlark.NewBuiltin("ip.addr.is_ipv6", core.ErrWrapper(av.IsIPv6)))
-	m.Set("string", starlark.NewBuiltin("ip.addr.string", core.ErrWrapper(av.string)))
+	m.Set("is_ipv4", starlark.NewBuiltin(ipAddrTypeName+".is_ipv4", core.ErrWrapper(av.IsIPv4)))
+	m.Set("is_ipv6", starlark.NewBuiltin(ipAddrTypeName+".is_ipv6", core.ErrWrapper(av.IsIPv6)))
+	m.Set("string", starlark.NewBuiltin(ipAddrTypeName+".string", core.ErrWrapper(av.string)))
 	av.StarlarkStruct = core.NewStarlarkStruct(m)
 	return av
 }
@@ -119,14 +121,16 @@ type IPNetValue struct {
 	*core.StarlarkStruct // TODO: keep authorship of the interface by delegating instead of embedding
 }
 
+const ipNetTypeName = "ip.net"
+
 // Type reports the name of this type as seen from a Starlark program (i.e. via the `type()` built-in)
-func (inv *IPNetValue) Type() string { return "@ytt:ip.net" }
+func (inv *IPNetValue) Type() string { return "@ytt:" + ipNetTypeName }
 
 // AsStarlarkValue converts this instance into a value suitable for use in a Starlark program.
 func (inv *IPNetValue) AsStarlarkValue() starlark.Value {
 	m := orderedmap.NewMap()
-	m.Set("addr", starlark.NewBuiltin("ip.net.addr", core.ErrWrapper(inv.Addr)))
-	m.Set("string", starlark.NewBuiltin("ip.net.string", core.ErrWrapper(inv.string)))
+	m.Set("addr", starlark.NewBuiltin(ipNetTypeName+".addr", core.ErrWrapper(inv.Addr)))
+	m.Set("string", starlark.NewBuiltin(ipNetTypeName+".string", core.ErrWrapper(inv.string)))
 	inv.StarlarkStruct = core.NewStarlarkStruct(m)
 	return inv
 }

--- a/pkg/yttlibrary/url.go
+++ b/pkg/yttlibrary/url.go
@@ -214,20 +214,23 @@ func (b urlModule) ParseURL(thread *starlark.Thread, f *starlark.Builtin, args s
 	return (&URLValue{parsedURL, nil}).AsStarlarkValue(), nil
 }
 
-func (uv *URLValue) Type() string { return "@ytt:url.value" }
+const urlValueTypeName = "url.value"
+
+// Type reports the fully-qualified name of type of this custom struct.
+func (uv *URLValue) Type() string { return "@ytt:" + urlValueTypeName }
 
 func (uv *URLValue) AsStarlarkValue() starlark.Value {
 	m := orderedmap.NewMap()
 	m.Set("user", uv.User())
-	m.Set("without_user", starlark.NewBuiltin("url.without_user", core.ErrWrapper(uv.WithoutUser)))
-	m.Set("string", starlark.NewBuiltin("url.string", core.ErrWrapper(uv.string)))
-	m.Set("hostname", starlark.NewBuiltin("url.hostname", core.ErrWrapper(uv.Hostname)))
+	m.Set("without_user", starlark.NewBuiltin(urlValueTypeName+".without_user", core.ErrWrapper(uv.WithoutUser)))
+	m.Set("string", starlark.NewBuiltin(urlValueTypeName+".string", core.ErrWrapper(uv.string)))
+	m.Set("hostname", starlark.NewBuiltin(urlValueTypeName+".hostname", core.ErrWrapper(uv.Hostname)))
 	uv.StarlarkStruct = core.NewStarlarkStruct(m)
 	return uv
 }
 
 func (uv *URLValue) ConversionHint() string {
-	return "URLValue does not automatically encode (hint: use .string())"
+	return uv.Type() + " does not automatically encode (hint: use .string())"
 }
 
 func (uv *URLValue) Hostname(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -258,10 +261,13 @@ func (uv *URLValue) User() starlark.Value {
 	return uu
 }
 
-func (uu *URLUser) Type() string { return "@ytt:url.user" }
+const urlUserTypeName = "url.user"
+
+// Type reports the fully-qualified name of type of this custom struct.
+func (uu *URLUser) Type() string { return "@ytt:" + urlUserTypeName }
 
 func (uu *URLUser) ConversionHint() string {
-	return "URLUser does not automatically encode (hint: use .string())"
+	return uu.Type() + " does not automatically encode (hint: use .string())"
 }
 
 func (uu *URLUser) password() starlark.Value {


### PR DESCRIPTION
Normalizing the built-in and type namespaces within the ytt standard library.