### PR TITLE
Ensure assert.try_to returns `None` on failure

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -91,6 +91,8 @@ When contributing to this library note:
   - **Type()** — use the format "@ytt:${module}.${type}" (e.g. IPAddrValue => "@ytt:ip.addr" )
 - **Fail fast** — users are usually better served by an error than an attempt to "guess" or "fix"; as soon as something seems ary, error out.
 - **Make Objects Immutable** — return modified copies rather than mutating the receiver: this tends to make template code that much easier to reason.
+- **built-in functions must return a valid `starlark.Value`**
+  - Note: `nil` is _not_ a valid `starlark.Value`; use `starlark.None` instead.
 
 ### Prior Efforts
 

--- a/pkg/yamltemplate/filetests/ytt-library/assert-try-to.yml
+++ b/pkg/yamltemplate/filetests/ytt-library/assert-try-to.yml
@@ -2,16 +2,12 @@
 #@ load("@ytt:json", "json")
 
 #@ def try_to_fail_data_error():
-#@   _, err = assert.try_to(lambda: json.decode("}junk"))
-#@   return err
-#@ end
-
-#@ def bad_ref():
-#@   return (None).foo
+#@   result, err = assert.try_to(lambda: json.decode("}junk"))
+#@   return (result, err)    # ensure `try_to` returns None (and not `nil`) for result; `nil` undefines the variable
 #@ end
 
 #@ def try_to_fail_bad_ref():
-#@   _, err = assert.try_to(bad_ref)
+#@   _, err = assert.try_to(lambda : (None).foo)
 #@   return err
 #@ end
 
@@ -31,12 +27,8 @@
 #@   return tupleResult
 #@ end
 
-#@ def foo():
-#@   return "foo"
-#@ end
-
 #@ def try_to_succeed_function():
-#@   functionResult, err = assert.try_to(foo)
+#@   functionResult, err = assert.try_to(lambda : "foo")
 #@   if err:
 #@      return err
 #@   end
@@ -51,7 +43,9 @@ test_try_to_succeed_tuple: #@ try_to_succeed_tuple()
 
 +++
 
-test_try_to_fail_data_error: 'json.decode: invalid character ''}'' looking for beginning of value'
+test_try_to_fail_data_error:
+- null
+- 'json.decode: invalid character ''}'' looking for beginning of value'
 test_try_to_fail_bad_ref: NoneType has no .foo field or method
 test_try_to_succeed_lambda:
   ytt: rules

--- a/pkg/yttlibrary/assert.go
+++ b/pkg/yttlibrary/assert.go
@@ -48,10 +48,9 @@ func (b assertModule) TryTo(thread *starlark.Thread, f *starlark.Builtin, args s
 		return starlark.None, fmt.Errorf("expected argument to be a function, but was %T", lambda)
 	}
 
-	var errVal starlark.Value = starlark.None
 	retVal, err := starlark.Call(thread, lambda, nil, nil)
 	if err != nil {
-		errVal = starlark.String(err.Error())
+		return starlark.Tuple{starlark.None, starlark.String(err.Error())}, nil
 	}
-	return starlark.Tuple{retVal, errVal}, nil
+	return starlark.Tuple{retVal, starlark.None}, nil
 }


### PR DESCRIPTION
... otherwise, if the wrapped function returns `nil` for the result
the variable assigned that rvalue becomes _undefined_.