### PR TITLE
Skip tests in our copy of yaml.v2, for now

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -8,6 +8,6 @@ if [ -z "$GITHUB_ACTION" ]; then
   go clean -testcache
 fi
 
-go test -v `go list ./...|grep -v yaml.v2` "$@"
+go test ./... "$@"
 
 echo ALL SUCCESS

--- a/pkg/yamlmeta/internal/yaml.v2/decode_test.go
+++ b/pkg/yamlmeta/internal/yaml.v2/decode_test.go
@@ -739,6 +739,7 @@ type inlineC struct {
 }
 
 func (s *S) TestUnmarshal(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	for i, item := range unmarshalTests {
 		c.Logf("test %d: %q", i, item.data)
 		t := reflect.ValueOf(item.value).Type()
@@ -764,6 +765,7 @@ func (s *S) TestUnmarshalFullTimestamp(c *C) {
 }
 
 func (s *S) TestDecoderSingleDocument(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	// Test that Decoder.Decode works as expected on
 	// all the unmarshal tests.
 	for i, item := range unmarshalTests {
@@ -860,6 +862,7 @@ var unmarshalErrorTests = []struct {
 }
 
 func (s *S) TestUnmarshalErrors(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	for i, item := range unmarshalErrorTests {
 		c.Logf("test %d: %q", i, item.data)
 		var value interface{}
@@ -869,6 +872,7 @@ func (s *S) TestUnmarshalErrors(c *C) {
 }
 
 func (s *S) TestDecoderErrors(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	for _, item := range unmarshalErrorTests {
 		var value interface{}
 		err := yaml.NewDecoder(strings.NewReader(item.data)).Decode(&value)
@@ -1052,6 +1056,7 @@ func (su *sliceUnmarshaler) UnmarshalYAML(unmarshal func(interface{}) error) err
 }
 
 func (s *S) TestUnmarshalerRetry(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	var su sliceUnmarshaler
 	err := yaml.Unmarshal([]byte("[1, 2, 3]"), &su)
 	c.Assert(err, IsNil)
@@ -1119,6 +1124,7 @@ inlineSequenceMap:
 `
 
 func (s *S) TestMerge(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	var want = map[interface{}]interface{}{
 		"x":     1,
 		"y":     2,
@@ -1138,6 +1144,7 @@ func (s *S) TestMerge(c *C) {
 }
 
 func (s *S) TestMergeStruct(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	type Data struct {
 		X, Y, R int
 		Label   string
@@ -1166,6 +1173,7 @@ var unmarshalNullTests = []func() interface{}{
 }
 
 func (s *S) TestUnmarshalNull(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	for _, test := range unmarshalNullTests {
 		item := test()
 		zero := reflect.Zero(reflect.TypeOf(item).Elem()).Interface()
@@ -1180,6 +1188,7 @@ func (s *S) TestUnmarshalNull(c *C) {
 }
 
 func (s *S) TestUnmarshalSliceOnPreset(c *C) {
+	c.Skip("Until these tests have been updated with ytt enhancements")
 	// Issue #48.
 	v := struct{ A []int }{[]int{1}}
 	yaml.Unmarshal([]byte("a: [2]"), &v)


### PR DESCRIPTION
- the implementation around parsing has drifted and now some of those
  tests fail.
- long-term, we'd like to have a running suite of tests. However, we're
  currently not modifying this library right now.
- skipping these failing tests allows for _any_ tool to simply run the
  whole suite.