### PR TITLE
"Any" explicitly includes `nullable`

### DIFF
--- a/pkg/cmd/template/schema_inspect_test.go
+++ b/pkg/cmd/template/schema_inspect_test.go
@@ -304,6 +304,7 @@ paths: {}
 components:
   schemas:
     dataValues:
+      nullable: true
       default:
         foo:
           int_key: 0
@@ -344,6 +345,7 @@ components:
       additionalProperties: false
       properties:
         foo:
+          nullable: true
           default:
             int_key: 0
             array_of_scalars: []
@@ -392,6 +394,7 @@ components:
             array_of_scalars:
               type: array
               items:
+                nullable: true
                 default: ""
               default: []
             array_of_maps:

--- a/pkg/schema/openapi.go
+++ b/pkg/schema/openapi.go
@@ -81,6 +81,7 @@ func (o *OpenAPIDocument) calculateProperties(schemaVal interface{}) *yamlmeta.M
 		return properties
 	case *AnyType:
 		return &yamlmeta.Map{Items: []*yamlmeta.MapItem{
+			{Key: "nullable", Value: true},
 			{Key: "default", Value: typedValue.GetDefaultValue()},
 		}}
 	default:


### PR DESCRIPTION
- by specification, `nullable` can be interpreted as implied.
- however, there is at least one implementation in the wild that would
  mark a `null` input as invalid.
- for other implementations, this property/keyword would be ignored.

(in response to analysis: https://github.com/vmware-tanzu/carvel-ytt/issues/365#issuecomment-959660526)