### PR TITLE
Name allowed keys and/guess on missing map key

### DIFF
--- a/pkg/cmd/template/schema_author_test.go
+++ b/pkg/cmd/template/schema_author_test.go
@@ -190,8 +190,8 @@ foo: 0
 		expectedErr := `
 Invalid schema
 ==============
-unknown @schema/type annotation keyword argument
 
+unknown @schema/type annotation keyword argument
 schema.yml:
     |
   4 | foo: 0
@@ -218,8 +218,8 @@ foo: 0
 		expectedErr := `
 Invalid schema
 ==============
-unknown @schema/type annotation keyword argument
 
+unknown @schema/type annotation keyword argument
 schema.yml:
     |
   4 | foo: 0
@@ -246,8 +246,8 @@ foo: 0
 		expectedErr := `
 Invalid schema
 ==============
-expected @schema/type annotation to have keyword argument and value
 
+expected @schema/type annotation to have keyword argument and value
 schema.yml:
     |
   4 | foo: 0
@@ -286,8 +286,8 @@ foo: 0
 		expectedErr := `
 Invalid schema
 ==============
-@schema/nullable, and @schema/type any=True are mutually exclusive
 
+@schema/nullable, and @schema/type any=True are mutually exclusive
 schema.yml:
     |
   5 | foo: 0
@@ -315,8 +315,8 @@ foo: 0
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/default annotation
 
+syntax error in @schema/default annotation
 schema.yml:
     |
   4 | foo: 0
@@ -341,8 +341,8 @@ foo: 0
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/default annotation
 
+syntax error in @schema/default annotation
 schema.yml:
     |
   4 | foo: 0
@@ -367,8 +367,8 @@ foo: 0
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/default annotation
 
+syntax error in @schema/default annotation
 schema.yml:
     |
   4 | foo: 0
@@ -485,8 +485,8 @@ key: val
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/desc annotation
 
+syntax error in @schema/desc annotation
 schema.yml:
     |
   4 | key: val
@@ -511,8 +511,8 @@ key: val
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/desc annotation
 
+syntax error in @schema/desc annotation
 schema.yml:
     |
   4 | key: val
@@ -537,8 +537,8 @@ key: val
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/desc annotation
 
+syntax error in @schema/desc annotation
 schema.yml:
     |
   4 | key: val
@@ -563,8 +563,8 @@ key: val
 			expectedErr := `
 Invalid schema
 ==============
-syntax error in @schema/desc annotation
 
+syntax error in @schema/desc annotation
 schema.yml:
     |
   4 | key: val

--- a/pkg/cmd/template/schema_consumer_test.go
+++ b/pkg/cmd/template/schema_consumer_test.go
@@ -268,6 +268,7 @@ foo:
 		expectedErrMsg := `Overlaying data values (in following order: additional data values): 
 One or more data values were invalid
 ====================================
+Given data value is not declared in schema
 
 dvs1.yml:
     |
@@ -275,8 +276,7 @@ dvs1.yml:
     |
 
     = found: wrong_key
-    = expected: (a key defined in map) (by schema.yml:3)
-    = hint: declare data values in schema and override them in a data values document
+    = expected: a map item with the key named "bar" (from schema.yml:3)
 `
 		assertFails(t, filesToProcess, expectedErrMsg, opts)
 	})
@@ -828,6 +828,7 @@ rendered: true`
 		expectedErrMsg := `Overlaying data values (in following order: additional data values): 
 One or more data values were invalid
 ====================================
+Given data value is not declared in schema
 
 dvs1.yml:
     |
@@ -835,8 +836,7 @@ dvs1.yml:
     |
 
     = found: not_in_schema
-    = expected: (a key defined in map) (by schema.yml:2)
-    = hint: declare data values in schema and override them in a data values document
+    = expected: a map item with the key named "hostname" (from schema.yml:2)
 `
 		assertFails(t, filesToProcess, expectedErrMsg, opts)
 	})

--- a/pkg/cmd/template/schema_consumer_test.go
+++ b/pkg/cmd/template/schema_consumer_test.go
@@ -268,8 +268,8 @@ foo:
 		expectedErrMsg := `Overlaying data values (in following order: additional data values): 
 One or more data values were invalid
 ====================================
-Given data value is not declared in schema
 
+Given data value is not declared in schema
 dvs1.yml:
     |
   3 |   wrong_key: not right key
@@ -828,8 +828,8 @@ rendered: true`
 		expectedErrMsg := `Overlaying data values (in following order: additional data values): 
 One or more data values were invalid
 ====================================
-Given data value is not declared in schema
 
+Given data value is not declared in schema
 dvs1.yml:
     |
   2 | not_in_schema: this should be the only violation reported

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -108,15 +108,15 @@ func NewUnexpectedKeyAssertionError(found *yamlmeta.MapItem, definition *filepos
 	sort.Strings(allowedKeys)
 	switch numKeys := len(allowedKeys); {
 	case numKeys == 1:
-		err.expected = fmt.Sprintf("a %s with the key named \"%s\" (from %s)", found.DisplayName(), allowedKeys[0], definition.AsCompactString())
+		err.expected = fmt.Sprintf(`a %s with the key named "%s" (from %s)`, found.DisplayName(), allowedKeys[0], definition.AsCompactString())
 	case numKeys > 1 && numKeys <= 9: // Miller's Law
 		err.expected = fmt.Sprintf("one of { %s } (from %s)", strings.Join(allowedKeys, ", "), definition.AsCompactString())
 	default:
-		err.expected = fmt.Sprintf("(a key declared in map, in schema at %s)", definition.AsCompactString())
+		err.expected = fmt.Sprintf("a key declared in map (from %s)", definition.AsCompactString())
 	}
 	mostSimilarKey := spell.Nearest(key, allowedKeys)
 	if mostSimilarKey != "" {
-		err.hints = append(err.hints, fmt.Sprintf("did you mean \"%s\"?", mostSimilarKey))
+		err.hints = append(err.hints, fmt.Sprintf(`did you mean "%s"?`, mostSimilarKey))
 	}
 	return err
 }

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -20,20 +20,17 @@ const schemaErrorReportTemplate = `
 {{- if .Summary}}
 {{.Summary}}
 {{addBreak .Summary}}
-{{- end}}
+{{ end}}
 {{- range .AssertionFailures}}
 {{- if .Description}}
 {{.Description}}
 {{- end}}
-
 {{- if .FromMemory}}
-
 {{.SourceName}}:
 {{pad "#" ""}}
 {{pad "#" ""}} {{.Source}}
 {{pad "#" ""}}
 {{- else}}
-
 {{.FileName}}:
 {{pad "|" ""}}
 {{pad "|" .FilePos}} {{.Source}}
@@ -45,8 +42,8 @@ const schemaErrorReportTemplate = `
 {{- range .Hints}}
 {{pad "=" ""}} hint: {{.}}
 {{- end}}
-{{- end}}
-{{.MiscErrorMessage}}
+{{end}}
+{{- .MiscErrorMessage}}
 `
 
 func NewSchemaError(summary string, errs ...error) error {

--- a/pkg/schema/type.go
+++ b/pkg/schema/type.go
@@ -269,7 +269,7 @@ func (m *MapType) CheckType(node yamlmeta.TypeWithValues) (chk yamlmeta.TypeChec
 	for _, item := range nodeMap.Items {
 		if !m.AllowsKey(item.Key) {
 			chk.Violations = append(chk.Violations,
-				NewUnexpectedKeyAssertionError(item, m.Position))
+				NewUnexpectedKeyAssertionError(item, m.Position, m.AllowedKeys()))
 		}
 	}
 	return
@@ -536,4 +536,15 @@ func (m *MapType) AllowsKey(key interface{}) bool {
 		}
 	}
 	return false
+}
+
+// AllowedKeys returns the set of keys (in string format) permitted in this map.
+func (m *MapType) AllowedKeys() []string {
+	var keysAsString []string
+
+	for _, item := range m.Items {
+		keysAsString = append(keysAsString, fmt.Sprintf("%s", item.Key))
+	}
+
+	return keysAsString
 }

--- a/pkg/spell/spell.go
+++ b/pkg/spell/spell.go
@@ -3,6 +3,7 @@
 
 // Package spell file defines a simple spelling checker for use in attribute errors
 // such as "no such field .foo; did you mean .food?".
+// (this source was copied from https://github.com/google/starlark-go/blob/b0039bd2cfe369fe8f2bdba0614bafd1f9402dbb/internal/spell/spell.go)
 package spell
 
 import (

--- a/pkg/spell/spell.go
+++ b/pkg/spell/spell.go
@@ -1,0 +1,115 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package spell file defines a simple spelling checker for use in attribute errors
+// such as "no such field .foo; did you mean .food?".
+package spell
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Nearest returns the element of candidates
+// nearest to x using the Levenshtein metric,
+// or "" if none were promising.
+func Nearest(x string, candidates []string) string {
+	// Ignore underscores and case when matching.
+	fold := func(s string) string {
+		return strings.Map(func(r rune) rune {
+			if r == '_' {
+				return -1
+			}
+			return unicode.ToLower(r)
+		}, s)
+	}
+
+	x = fold(x)
+
+	var best string
+	bestD := (len(x) + 1) / 2 // allow up to 50% typos
+	for _, c := range candidates {
+		d := levenshtein(x, fold(c), bestD)
+		if d < bestD {
+			bestD = d
+			best = c
+		}
+	}
+	return best
+}
+
+// levenshtein returns the non-negative Levenshtein edit distance
+// between the byte strings x and y.
+//
+// If the computed distance exceeds max,
+// the function may return early with an approximate value > max.
+func levenshtein(x, y string, max int) int {
+	// This implementation is derived from one by Laurent Le Brun in
+	// Bazel that uses the single-row space efficiency trick
+	// described at bitbucket.org/clearer/iosifovich.
+
+	// Let x be the shorter string.
+	if len(x) > len(y) {
+		x, y = y, x
+	}
+
+	// Remove common prefix.
+	for i := 0; i < len(x); i++ {
+		if x[i] != y[i] {
+			x = x[i:]
+			y = y[i:]
+			break
+		}
+	}
+	if x == "" {
+		return len(y)
+	}
+
+	if d := abs(len(x) - len(y)); d > max {
+		return d // excessive length divergence
+	}
+
+	row := make([]int, len(y)+1)
+	for i := range row {
+		row[i] = i
+	}
+
+	for i := 1; i <= len(x); i++ {
+		row[0] = i
+		best := i
+		prev := i - 1
+		for j := 1; j <= len(y); j++ {
+			a := prev + b2i(x[i-1] != y[j-1]) // substitution
+			b := 1 + row[j-1]                 // deletion
+			c := 1 + row[j]                   // insertion
+			k := min(a, min(b, c))
+			prev, row[j] = row[j], k
+			best = min(best, k)
+		}
+		if best > max {
+			return best
+		}
+	}
+	return row[len(y)]
+}
+
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func abs(x int) int {
+	if x >= 0 {
+		return x
+	}
+	return -x
+}


### PR DESCRIPTION
Replaces existing author-centered hint with some that help the consumer, instead.

Inspired by:

![image](https://user-images.githubusercontent.com/12101915/142468445-7ee5d5ce-d2db-4781-8d95-cfdf87ccbb98.png)

cc: @voor 
