### PR TITLE
Allow plain merge of data values into a library

### DIFF
--- a/pkg/cmd/template/cmd_data_values_file_test.go
+++ b/pkg/cmd/template/cmd_data_values_file_test.go
@@ -147,5 +147,5 @@ int: 123`)
 	}
 
 	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
-	require.EqualError(t, out.Err, "Extracting data value from file: Checking data values file 'dvs1.yml': Expected to not find annotations inside data values file (hint: remove comments starting with '#@')")
+	require.EqualError(t, out.Err, "Extracting data value from file: Checking data values file 'dvs1.yml': Expected to be plain YAML, having no annotations (hint: remove comments starting with `#@`)")
 }

--- a/pkg/template/compiled_template.go
+++ b/pkg/template/compiled_template.go
@@ -5,13 +5,14 @@ package template
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
+
 	"github.com/k14s/starlark-go/resolve"
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/starlark-go/syntax"
 	"github.com/k14s/ytt/pkg/filepos"
 	tplcore "github.com/k14s/ytt/pkg/template/core"
-	"strings"
-	"unicode"
 )
 
 type EvaluationCtxDialectName string

--- a/pkg/yamlmeta/ast.go
+++ b/pkg/yamlmeta/ast.go
@@ -17,6 +17,7 @@ type Node interface {
 	ResetValue()
 
 	GetComments() []*Comment
+	SetComments([]*Comment)
 	addComments(*Comment)
 
 	GetMeta(name string) interface{}

--- a/pkg/yamlmeta/node.go
+++ b/pkg/yamlmeta/node.go
@@ -189,6 +189,24 @@ func (mi *MapItem) GetComments() []*Comment     { return mi.Comments }
 func (a *Array) GetComments() []*Comment        { return a.Comments }
 func (ai *ArrayItem) GetComments() []*Comment   { return ai.Comments }
 
+// SetComments replaces comments with "c"
+func (ds *DocumentSet) SetComments(c []*Comment) { ds.Comments = c }
+
+// SetComments replaces comments with "c"
+func (d *Document) SetComments(c []*Comment) { d.Comments = c }
+
+// SetComments replaces comments with "c"
+func (m *Map) SetComments(c []*Comment) { m.Comments = c }
+
+// SetComments replaces comments with "c"
+func (mi *MapItem) SetComments(c []*Comment) { mi.Comments = c }
+
+// SetComments replaces comments with "c"
+func (a *Array) SetComments(c []*Comment) { a.Comments = c }
+
+// SetComments replaces comments with "c"
+func (ai *ArrayItem) SetComments(c []*Comment) { ai.Comments = c }
+
 func (ds *DocumentSet) addComments(comment *Comment) { ds.Comments = append(ds.Comments, comment) }
 func (d *Document) addComments(comment *Comment)     { d.Comments = append(d.Comments, comment) }
 func (m *Map) addComments(comment *Comment) {

--- a/pkg/yamltemplate/evaluation_ctx.go
+++ b/pkg/yamltemplate/evaluation_ctx.go
@@ -22,9 +22,8 @@ type EvaluationCtx struct {
 
 var _ template.EvaluationCtxDialect = EvaluationCtx{}
 
-func (e EvaluationCtx) PrepareNode(
-	parentNode template.EvaluationNode, val template.EvaluationNode) error {
-
+// PrepareNode pre-processes the template.EvaluationNode so that the resulting AST fully reflects having been evaluated.
+func (e EvaluationCtx) PrepareNode(parentNode template.EvaluationNode, val template.EvaluationNode) error {
 	if typedMap, ok := parentNode.(*yamlmeta.Map); ok {
 		if typedMapItem, ok := val.(*yamlmeta.MapItem); ok {
 			return MapItemOverride{e.implicitMapKeyOverrides}.Apply(typedMap, typedMapItem, true)

--- a/pkg/yamltemplate/filetests/annotation.tpltest
+++ b/pkg/yamltemplate/filetests/annotation.tpltest
@@ -1,6 +1,5 @@
 #@unknown-ann
 #@unknown-ann "with-value"
-#@unknown-ann1,unknown-ann2 "with-value"
 test1: value
 
 +++

--- a/pkg/yttlibrary/overlay/plain_merge.go
+++ b/pkg/yttlibrary/overlay/plain_merge.go
@@ -1,0 +1,58 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package overlay
+
+import (
+	"fmt"
+
+	"github.com/k14s/starlark-go/starlark"
+	"github.com/k14s/ytt/pkg/template"
+	"github.com/k14s/ytt/pkg/yamlmeta"
+	"github.com/k14s/ytt/pkg/yamltemplate"
+)
+
+// AnnotateForPlainMerge configures `node` to be an overlay doing a "plain merge":
+// - allow new keys via `@overlay/match missing_ok=True`
+// - allow arrays and scalars to be replaced with given value (regardless of type) via `@overlay/replace or_add=True`
+//
+// Returns an error when `node` contains templating; `node` must be plain YAML.
+func AnnotateForPlainMerge(node yamlmeta.Node) error {
+	if yamltemplate.HasTemplating(node) {
+		return fmt.Errorf("Expected to be plain YAML, having no annotations (hint: remove comments starting with `#@`)")
+	}
+
+	addOverlayReplace(node)
+	return nil
+}
+
+func addOverlayReplace(node yamlmeta.Node) {
+	anns := template.NodeAnnotations{}
+
+	anns[AnnotationMatch] = template.NodeAnnotation{
+		Kwargs: []starlark.Tuple{{
+			starlark.String(MatchAnnotationKwargMissingOK),
+			starlark.Bool(true),
+		}},
+	}
+
+	replaceAnn := template.NodeAnnotation{
+		Kwargs: []starlark.Tuple{{
+			starlark.String(ReplaceAnnotationKwargOrAdd),
+			starlark.Bool(true),
+		}},
+	}
+
+	for _, val := range node.GetValues() {
+		switch typedVal := val.(type) {
+		case *yamlmeta.Array:
+			anns[AnnotationReplace] = replaceAnn
+		case yamlmeta.Node:
+			addOverlayReplace(typedVal)
+		default:
+			anns[AnnotationReplace] = replaceAnn
+		}
+	}
+
+	node.SetAnnotations(anns)
+}


### PR DESCRIPTION
- Add keyword argument "plain" to @ytt:library.with_data_values()
- Extract/reuse annotating method from template.DataValuesFile

Addresses #418 