### PR TITLE
Detect binary use of | and & for any type operands

### DIFF
--- a/pkg/template/compiled_template_error.go
+++ b/pkg/template/compiled_template_error.go
@@ -198,11 +198,6 @@ func (CompiledTemplateMultiError) isOperatorPresent(err CompiledTemplateError, o
 	return false
 }
 
-var (
-	unknownBinaryOpOr = regexp.MustCompile(`^unknown binary op: .+ \| .+$`)
-	unknownBinaryOpAnd = regexp.MustCompile(`^unknown binary op: .+ & .+$`)
-)
-
 func (e CompiledTemplateMultiError) hintMsg(err CompiledTemplateError) string {
 	hintMsg := ""
 	switch {
@@ -220,20 +215,20 @@ func (e CompiledTemplateMultiError) hintMsg(err CompiledTemplateError) string {
 		hintMsg = "use 'None' instead of 'none' to indicate no value"
 	case err.Msg == "unhandled index operation struct[string]":
 		hintMsg = "use getattr(...) to access struct field programmatically"
-	case unknownBinaryOpOr.MatchString(err.Msg):
-		hintMsg = "use 'or' instead of '|' for logical disjunction"
-	case unknownBinaryOpAnd.MatchString(err.Msg):
-		hintMsg = "use 'and' instead of '&' for logical conjunction"
+	case regexp.MustCompile(`^unknown binary op: .+ \| .+$`).MatchString(err.Msg):
+		hintMsg = "use 'or' instead of '|' for logical-or"
+	case regexp.MustCompile(`^unknown binary op: .+ & .+$`).MatchString(err.Msg):
+		hintMsg = "use 'and' instead of '&' for logical-and"
 	case err.Msg == "got '&', want primary expression":
 		isOpPresent := e.isOperatorPresent(err, "&&")
 		if isOpPresent {
-			hintMsg = "use 'and' instead of '&&' for logical conjunction"
+			hintMsg = "use 'and' instead of '&&' for logical-and"
 			break
 		}
 	case err.Msg == "got '|', want primary expression":
 		isOpPresent := e.isOperatorPresent(err, "||")
 		if isOpPresent {
-			hintMsg = "use 'or' instead of '||' for logical disjunction"
+			hintMsg = "use 'or' instead of '||' for logical-or"
 			break
 		}
 	}

--- a/pkg/template/compiled_template_error.go
+++ b/pkg/template/compiled_template_error.go
@@ -5,6 +5,7 @@ package template
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/k14s/starlark-go/resolve"
@@ -197,37 +198,42 @@ func (CompiledTemplateMultiError) isOperatorPresent(err CompiledTemplateError, o
 	return false
 }
 
+var (
+	unknownBinaryOpOr = regexp.MustCompile(`^unknown binary op: .+ \| .+$`)
+	unknownBinaryOpAnd = regexp.MustCompile(`^unknown binary op: .+ & .+$`)
+)
+
 func (e CompiledTemplateMultiError) hintMsg(err CompiledTemplateError) string {
 	hintMsg := ""
-	switch err.Msg {
-	case "undefined: true":
+	switch {
+	case err.Msg == "undefined: true":
 		hintMsg = "use 'True' instead of 'true' for boolean assignment"
-	case "undefined: false":
+	case err.Msg == "undefined: false":
 		hintMsg = "use 'False' instead of 'false' for boolean assignment"
-	case "got newline, want ':'":
+	case err.Msg == "got newline, want ':'":
 		hintMsg = "missing colon at the end of 'if/for/def' statement?"
-	case "undefined: null":
+	case err.Msg == "undefined: null":
 		hintMsg = "use 'None' instead of 'null' to indicate no value"
-	case "undefined: nil":
+	case err.Msg == "undefined: nil":
 		hintMsg = "use 'None' instead of 'nil' to indicate no value"
-	case "undefined: none":
+	case err.Msg == "undefined: none":
 		hintMsg = "use 'None' instead of 'none' to indicate no value"
-	case "unhandled index operation struct[string]":
+	case err.Msg == "unhandled index operation struct[string]":
 		hintMsg = "use getattr(...) to access struct field programmatically"
-	case "unknown binary op: bool | bool":
-		hintMsg = "use 'or' instead of '|' to combine boolean expressions"
-	case "unknown binary op: bool & bool":
-		hintMsg = "use 'and' instead of '&' to combine boolean expressions"
-	case "got '&', want primary expression":
+	case unknownBinaryOpOr.MatchString(err.Msg):
+		hintMsg = "use 'or' instead of '|' for logical disjunction"
+	case unknownBinaryOpAnd.MatchString(err.Msg):
+		hintMsg = "use 'and' instead of '&' for logical conjunction"
+	case err.Msg == "got '&', want primary expression":
 		isOpPresent := e.isOperatorPresent(err, "&&")
 		if isOpPresent {
-			hintMsg = "use 'and' instead of '&&' to combine boolean expressions"
+			hintMsg = "use 'and' instead of '&&' for logical conjunction"
 			break
 		}
-	case "got '|', want primary expression":
+	case err.Msg == "got '|', want primary expression":
 		isOpPresent := e.isOperatorPresent(err, "||")
 		if isOpPresent {
-			hintMsg = "use 'or' instead of '||' to combine boolean expressions"
+			hintMsg = "use 'or' instead of '||' for logical disjunction"
 			break
 		}
 	}

--- a/pkg/template/error_hints_test.go
+++ b/pkg/template/error_hints_test.go
@@ -68,7 +68,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- unknown binary op: bool & bool (hint: use 'and' instead of '&' for logical conjunction)
+- unknown binary op: bool & bool (hint: use 'and' instead of '&' for logical-and)
     in <toplevel>
       2 | if True & True:`,
 		},
@@ -77,7 +77,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- unknown binary op: bool | bool (hint: use 'or' instead of '|' for logical disjunction)
+- unknown binary op: bool | bool (hint: use 'or' instead of '|' for logical-or)
     in <toplevel>
       2 | if True | True:`,
 		},
@@ -86,7 +86,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- unknown binary op: string & int (hint: use 'and' instead of '&' for logical conjunction)
+- unknown binary op: string & int (hint: use 'and' instead of '&' for logical-and)
     in <toplevel>
       2 | if "" & 0:`,
 		},
@@ -95,7 +95,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- unknown binary op: float | bool (hint: use 'or' instead of '|' for logical disjunction)
+- unknown binary op: float | bool (hint: use 'or' instead of '|' for logical-or)
     in <toplevel>
       2 | if 0.0 | False:`,
 		},
@@ -104,7 +104,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- got '&', want primary expression (hint: use 'and' instead of '&&' for logical conjunction)
+- got '&', want primary expression (hint: use 'and' instead of '&&' for logical-and)
     2 | if True && True:`,
 		},
 		{
@@ -112,7 +112,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- got '|', want primary expression (hint: use 'or' instead of '||' for logical disjunction)
+- got '|', want primary expression (hint: use 'or' instead of '||' for logical-or)
     2 | if True || True:`,
 		},
 	}

--- a/pkg/template/error_hints_test.go
+++ b/pkg/template/error_hints_test.go
@@ -68,7 +68,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- unknown binary op: bool & bool (hint: use 'and' instead of '&' to combine boolean expressions)
+- unknown binary op: bool & bool (hint: use 'and' instead of '&' for logical conjunction)
     in <toplevel>
       2 | if True & True:`,
 		},
@@ -77,16 +77,34 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- unknown binary op: bool | bool (hint: use 'or' instead of '|' to combine boolean expressions)
+- unknown binary op: bool | bool (hint: use 'or' instead of '|' for logical disjunction)
     in <toplevel>
       2 | if True | True:`,
+		},
+		{
+			Input: `if "" & 0:
+  v = 123
+end`,
+			ErrMsg: `
+- unknown binary op: string & int (hint: use 'and' instead of '&' for logical conjunction)
+    in <toplevel>
+      2 | if "" & 0:`,
+		},
+		{
+			Input: `if 0.0 | False:
+  v = 123
+end`,
+			ErrMsg: `
+- unknown binary op: float | bool (hint: use 'or' instead of '|' for logical disjunction)
+    in <toplevel>
+      2 | if 0.0 | False:`,
 		},
 		{
 			Input: `if True && True:
   v = 123
 end`,
 			ErrMsg: `
-- got '&', want primary expression (hint: use 'and' instead of '&&' to combine boolean expressions)
+- got '&', want primary expression (hint: use 'and' instead of '&&' for logical conjunction)
     2 | if True && True:`,
 		},
 		{
@@ -94,7 +112,7 @@ end`,
   v = 123
 end`,
 			ErrMsg: `
-- got '|', want primary expression (hint: use 'or' instead of '||' to combine boolean expressions)
+- got '|', want primary expression (hint: use 'or' instead of '||' for logical disjunction)
     2 | if True || True:`,
 		},
 	}


### PR DESCRIPTION
Follow-up from #564.

Extends hints for cases where authors use `|`/`&` for logical disjunction/conjunction for non-boolean operands (e.g. for defaulting or guard expressions)