### PR TITLE
Include default annotation position when default value is wrong type

### DIFF
--- a/pkg/cmd/template/schema_author_test.go
+++ b/pkg/cmd/template/schema_author_test.go
@@ -493,12 +493,12 @@ Invalid schema - @schema/default is wrong type
 
 schema.yml:
     |
+  3 | #@schema/default 1
   4 | foo: a string
     |
 
-    = found: integer
+    = found: integer (at schema.yml:3)
     = expected: string (by schema.yml:4)
-    = hint: is the default value set using @schema/default?
 `
 
 				filesToProcess := files.NewSortedFiles([]*files.File{
@@ -521,12 +521,12 @@ Invalid schema - @schema/default is wrong type
 
 schema.yml:
     |
+  3 | #@schema/default [{"item": 1}]
   4 | map: thing
     |
 
-    = found: array
+    = found: array (at schema.yml:3)
     = expected: string (by schema.yml:4)
-    = hint: is the default value set using @schema/default?
 `
 
 				filesToProcess := files.NewSortedFiles([]*files.File{
@@ -939,7 +939,6 @@ schema.yml:
 
     = found: integer (by schema.yml:3)
     = expected: boolean (by schema.yml:4)
-    = hint: is the default value set using @schema/default?
 `
 
 			filesToProcess := files.NewSortedFiles([]*files.File{

--- a/pkg/cmd/template/schema_consumer_test.go
+++ b/pkg/cmd/template/schema_consumer_test.go
@@ -314,7 +314,6 @@ data_values.yml:
 
     = found: string
     = expected: integer (by schema.yml:4)
-    = hint: is the default value set using @schema/default?
 
 data_values.yml:
     |
@@ -323,7 +322,6 @@ data_values.yml:
 
     = found: integer
     = expected: string (by schema.yml:6)
-    = hint: is the default value set using @schema/default?
 
 data_values.yml:
     |
@@ -332,7 +330,6 @@ data_values.yml:
 
     = found: string
     = expected: float (by schema.yml:7)
-    = hint: is the default value set using @schema/default?
 `
 
 		assertFails(t, filesToProcess, expectedErr, opts)
@@ -438,7 +435,6 @@ data_values.yml:
 
      = found: string
      = expected: array (by schema.yml:4)
-     = hint: is the default value set using @schema/default?
 
 data_values.yml:
      |
@@ -447,7 +443,6 @@ data_values.yml:
 
      = found: string
      = expected: map (by schema.yml:5)
-     = hint: is the default value set using @schema/default?
 
 data_values.yml:
      |
@@ -456,7 +451,6 @@ data_values.yml:
 
      = found: string
      = expected: float (by schema.yml:6)
-     = hint: is the default value set using @schema/default?
 
 data_values.yml:
      |
@@ -465,7 +459,6 @@ data_values.yml:
 
      = found: boolean
      = expected: float (by schema.yml:6)
-     = hint: is the default value set using @schema/default?
 `
 		assertFails(t, filesToProcess, expectedErr, opts)
 	})
@@ -505,7 +498,6 @@ dataValues.yml:
 
     = found: string
     = expected: integer (by schema.yml:5)
-    = hint: is the default value set using @schema/default?
 
 dataValues.yml:
     |
@@ -514,7 +506,6 @@ dataValues.yml:
 
     = found: string
     = expected: integer (by schema.yml:6)
-    = hint: is the default value set using @schema/default?
 
 dataValues.yml:
     |
@@ -523,7 +514,6 @@ dataValues.yml:
 
     = found: string
     = expected: integer (by schema.yml:8)
-    = hint: is the default value set using @schema/default?
 
 `
 

--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -610,7 +610,7 @@ func checkExamplesValue(ann *ExampleAnnotation, typeOfValue Type) error {
 			defaultValue := node.DeepCopyAsNode()
 			chk := typeOfValue.AssignTypeTo(defaultValue)
 			if !chk.HasViolations() {
-				chk = CheckDocument(defaultValue)
+				chk = CheckNode(defaultValue)
 			}
 			typeCheck.Violations = append(typeCheck.Violations, chk.Violations...)
 		} else {

--- a/pkg/schema/check.go
+++ b/pkg/schema/check.go
@@ -9,14 +9,14 @@ import (
 	"github.com/k14s/ytt/pkg/yamlmeta"
 )
 
-// CheckDocument attempts type check of `doc`.
+// CheckNode attempts type check of root node and its children.
 //
-// If `d` has "schema/type" metadata (typically attached using SetType()), `d` is checked against that schema, recursively.
+// If `n` has "schema/type" metadata (typically attached using SetType()), `n` is checked against that schema, recursively.
 // `chk` contains all the type violations found in the check.
-func CheckDocument(doc yamlmeta.Node) TypeCheck {
+func CheckNode(n yamlmeta.Node) TypeCheck {
 	checker := newTypeChecker()
 
-	err := yamlmeta.Walk(doc, checker)
+	err := yamlmeta.Walk(n, checker)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/schema/error.go
+++ b/pkg/schema/error.go
@@ -97,8 +97,6 @@ func NewMismatchedTypeAssertionError(foundNode yamlmeta.Node, expectedType Type)
 		position: foundNode.GetPosition(),
 		expected: fmt.Sprintf("%s (by %s)", expectedTypeString, expectedType.GetDefinitionPosition().AsCompactString()),
 		found:    nodeValueTypeAsString(foundNode),
-		// TODO: remove this hint once we can report if mistyped value came from annotation
-		hints: []string{fmt.Sprintf("is the default value set using @%v?", AnnotationDefault)},
 	}
 }
 

--- a/pkg/workspace/data_values_pre_processing.go
+++ b/pkg/workspace/data_values_pre_processing.go
@@ -111,7 +111,7 @@ func (pp DataValuesPreProcessing) typeAndCheck(dataValuesDoc *yamlmeta.Document)
 	if len(chk.Violations) > 0 {
 		return chk
 	}
-	chk = schema.CheckDocument(dataValuesDoc)
+	chk = schema.CheckNode(dataValuesDoc)
 	return chk
 }
 


### PR DESCRIPTION
- removes `hint: is the default value set with @schema/default` from type mismatch error messages
- checks the value of a default annotation during the `getValue()` operation of constructing a schema. We know that schema is build depth first, so any child that also needs to be type checked will have already been typed and processed by schema. Previously, if the default annotation had nested values, we deferred the type check to data values pre-processing, which lost all annotation position information.  

*Note:* This PR can be merged separately, but is related to #580 