### PR TITLE
Dispatch event when release is complete

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -24,3 +24,8 @@ jobs:
             echo "Versions do not match v$tool_version != $tag"
             exit 1
           fi
+      - run: |
+          curl -X POST https://api.github.com/repos/vmware-tanzu/carvel-release-scripts/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.carvel_bot_access_token }} \
+          --data '{"event_type": "ytt_released", "client_payload": { "tagName": "${{ github.event.release.tag_name }}", "repo": "${{ github.repository }}", "toolName": "ytt" }}'


### PR DESCRIPTION
Requirements for this to work:
- [x] Merge https://github.com/vmware-tanzu/carvel-release-scripts/pull/7
- [x] Create secret `carvel_bot_access_token` with token from `carvel-bot` with repo:all permissions

---

This event will update the homebrew formula and the `install.sh` scripts after the release of `ytt` is complete.