### PR TITLE
return correct error for go api example

### DIFF
--- a/examples/integrating-with-ytt/internal-templating/main.go
+++ b/examples/integrating-with-ytt/internal-templating/main.go
@@ -53,7 +53,7 @@ func ytt(tpl, dvs []string) (string, error) {
 	// Evaluate the template given the configured data values...
 	output := templatingOptions.RunWithFiles(input, noopUI)
 	if output.Err != nil {
-		return "", err
+		return "", output.Err
 	}
 
 	// output.DocSet contains the full set of resulting YAML documents, in order.


### PR DESCRIPTION
Fix a small issue of the example. When I little play around with the example, I had an issue where the template output was empty without any errors. Because the wrong return value was use