### PR TITLE
Bug fix: decode TOML array of tables

### DIFF
--- a/pkg/orderedmap/convert.go
+++ b/pkg/orderedmap/convert.go
@@ -74,7 +74,13 @@ func (c Conversion) fromUnorderedMaps(object interface{}) interface{} {
 			typedObj[i] = c.fromUnorderedMaps(item)
 		}
 		return typedObj
-
+	case []map[string]interface{}:
+		resultArray := make([]interface{}, len(typedObj))
+		for i, item := range typedObj {
+			resultMap := c.fromUnorderedMaps(item)
+			resultArray[i] = resultMap
+		}
+		return resultArray
 	default:
 		return typedObj
 	}

--- a/pkg/orderedmap/convert.go
+++ b/pkg/orderedmap/convert.go
@@ -74,11 +74,14 @@ func (c Conversion) fromUnorderedMaps(object interface{}) interface{} {
 			typedObj[i] = c.fromUnorderedMaps(item)
 		}
 		return typedObj
+
+	// some sources (e.g. toml library) yield specific type of slices.
+	// slices in Go are not covariant, so each flavor of slice must have its own case, here.
+	// process these exactly the same way we do for generic slices (prior case)
 	case []map[string]interface{}:
 		resultArray := make([]interface{}, len(typedObj))
 		for i, item := range typedObj {
-			resultMap := c.fromUnorderedMaps(item)
-			resultArray[i] = resultMap
+			resultArray[i] = c.fromUnorderedMaps(item)
 		}
 		return resultArray
 	default:

--- a/pkg/yamltemplate/filetests/ytt-library/toml.tpltest
+++ b/pkg/yamltemplate/filetests/ytt-library/toml.tpltest
@@ -5,6 +5,7 @@ fragment:
 - piece1
 - piece2
 #@ end
+#@ arrayOfTables = {"stuff": [{"a": 1},{"b": 2}]}
 
 encode:
   test1: #@ toml.encode({})
@@ -17,6 +18,7 @@ encode:
 decode:
   test1: #@ toml.decode("")
   test2: #@ toml.decode('a = [ 1, 2, 3, 456 ]\nb = "str"')
+  test3: #@ toml.decode(toml.encode(arrayOfTables))
 
 +++
 
@@ -33,6 +35,12 @@ encode:
 
     [inside_map]
       fragment = ["piece1", "piece2"]
+  test5: |
+    [[stuff]]
+      a = 1
+
+    [[stuff]]
+      b = 2
   indent:
     test1: |
       [[inside_array]]
@@ -55,3 +63,9 @@ decode:
     - 3
     - 456
     b: str
+  test3:
+    [[stuff]]
+      a = 1
+
+    [[stuff]]
+      b = 2

--- a/pkg/yamltemplate/filetests/ytt-library/toml.tpltest
+++ b/pkg/yamltemplate/filetests/ytt-library/toml.tpltest
@@ -5,7 +5,14 @@ fragment:
 - piece1
 - piece2
 #@ end
-#@ arrayOfTables = {"stuff": [{"a": 1},{"b": 2}]}
+
+#@ arrayOfTables = '''
+#@  [[stuff]]
+#@    a = 1
+#@
+#@  [[stuff]]
+#@    b = 2
+#@ '''
 
 encode:
   test1: #@ toml.encode({})
@@ -18,7 +25,7 @@ encode:
 decode:
   test1: #@ toml.decode("")
   test2: #@ toml.decode('a = [ 1, 2, 3, 456 ]\nb = "str"')
-  test3: #@ toml.decode(toml.encode(arrayOfTables))
+  test3: #@ toml.decode(arrayOfTables)
 
 +++
 
@@ -35,12 +42,6 @@ encode:
 
     [inside_map]
       fragment = ["piece1", "piece2"]
-  test5: |
-    [[stuff]]
-      a = 1
-
-    [[stuff]]
-      b = 2
   indent:
     test1: |
       [[inside_array]]
@@ -64,8 +65,6 @@ decode:
     - 456
     b: str
   test3:
-    [[stuff]]
-      a = 1
-
-    [[stuff]]
-      b = 2
+    stuff:
+    - a: 1
+    - b: 2


### PR DESCRIPTION
fixes: https://github.com/vmware-tanzu/carvel-ytt/issues/630

added `case []map[string]interface{}:` to conversion process. 