### PR TITLE
Setting buildid is no longer necessary for reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,6 @@ builds:
       - -trimpath
 
     ldflags:
-      - -buildid=
       - -X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version={{ .Version }}
 
 archives:

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -14,7 +14,7 @@ go mod tidy
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=$VERSION"
 
 ./hack/build.sh $VERSION # Used to generate website/generated.go used by ytt website
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -7,7 +7,7 @@ VERSION="${1:-$LATEST_GIT_TAG}"
 
 # makes builds reproducible
 export CGO_ENABLED=0
-LDFLAGS="-X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=$VERSION -buildid="
+LDFLAGS="-X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=$VERSION"
 
 rm -f website/generated.go
 

--- a/hack/test-windows.ps1
+++ b/hack/test-windows.ps1
@@ -2,7 +2,7 @@
 
 # makes builds reproducible
 $env:CGO_ENABLED = 0
-$repro_flags = "-ldflags=-buildid= -trimpath"
+$repro_flags = "-ldflags=-trimpath"
 
 echo Formatting
 go fmt ./cmd/... ./pkg/...


### PR DESCRIPTION
This was fixed in go 1.14 https://github.com/golang/go/commit/aa680c0c49b55722a72ad3772e590cd2f9af541d