### PR TITLE
Add documentation for all packages

### DIFF
--- a/pkg/cmd/doc.go
+++ b/pkg/cmd/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package cmd is home to the full set of ytt's "commands" -- instances of cobra.Command
+(not to be confused with ./cmd which contains the bootstrapping for executing ytt in various environments).
+
+A cobra.Command is the starting point of execution.
+
+For a list of commands run:
+
+   $ ytt help
+
+The default command is "template".
+*/
+package cmd

--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -15,9 +15,10 @@ import (
 	"github.com/vmware-tanzu/carvel-ytt/pkg/yamlmeta"
 )
 
-// Options both holds all settings for and implements the "template" command.
+// Options both contains the configuration for a "template" command AND the
+// top-level implementation of that command.
 //
-// For proper initialization, always use NewOptions().
+// For most intents and purposes, RunWithFiles() is the entrypoint.
 type Options struct {
 	IgnoreUnknownComments   bool
 	ImplicitMapKeyOverrides bool

--- a/pkg/cmd/template/doc.go
+++ b/pkg/cmd/template/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package template implements the "template" command (not to be confused with
+"pkg/template" home of the templating mechanism itself).
+
+Front-and-center is template.Options. This is both the host of ytt settings
+parsed from the command-line through Cobra AND the top-level logic that
+implements the command.
+*/
+package template

--- a/pkg/cmd/ui/doc.go
+++ b/pkg/cmd/ui/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package ui provides a thin abstraction over user input and output (typically,
+a tty device).
+*/
+package ui

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,0 +1,239 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package pkg is the collection of packages that make up the implementation of ytt.
+
+This codebase is intentionally organized into well-defined layers. A concerted
+effort has been sustained to keep the responsibility of each package concise and
+complete. Packages have been designed to be dependent on each other only to the
+degree absolutely required.
+
+In the inventory, below, individual packages are named alongside their coupling
+with the other packages in the codebase.
+
+    (# of dependents) => <package name> => (# of dependencies)
+
+Where "# of dependents" is the count of packages that import the named package
+and "# of dependencies" is the count of packages that this named package
+imports.
+
+This is output from the tool https://github.com/jtigger/go-orient.
+
+From top-down (http://www.catb.org/~esr/writings/taoup/html/ch04s03.html), ytt
+code is layered in this way:
+
+Entry Point
+
+ytt is built into two executable formats:
+
+    ./cmd/ytt                  // a command-line tool
+    ./cmd/ytt-lambda-website   // an AWS Lambda function
+
+ytt's contains a mini website that is the "Playground".
+
+    (1) => pkg/website => (0)
+
+Commands
+
+There are half-a-dozen commands ytt implements. The most commonly used and most
+complex is "template".
+
+    (1) => pkg/cmd => (8)
+    (2) => pkg/cmd/template => (10)
+
+The Workspace
+
+ytt processing can be thought of as a sequence of steps: schema "pre-processing",
+data values "pre-processing", template evaluation, and overlay "post-processing".
+All of these steps are executed over a collection of files we call a
+workspace.Library.
+
+    (1) => pkg/workspace => (14)
+    (2) => pkg/workspace/datavalues => (6)
+    (3) => pkg/workspace/ref => (2)
+    (4) => pkg/files => (1)
+    (10) => pkg/filepos => (0)
+
+Templating
+
+The heart of ytt's action is structural templating. There are two flavors of
+templates: templating on a YAML structure and templating on text. Each source
+template file is "compiled" into a Starlark program whose job is to build-up
+the output.
+
+    (9) => pkg/template => (2)
+    (9) => pkg/template/core => (1)
+    (3) => pkg/yamltemplate => (6)
+    (2) => pkg/texttemplate => (2)
+
+Standard Library
+
+ytt injects a collection of "standard" modules into Starlark executions.
+These modules support serialization, hashing, parsing of special kinds
+of values, and programmatic access to some of ytt's core capabilities. This
+collection is known as a library (not to be confused with the workspace.Library
+concept).
+
+    (2) => pkg/yttlibrary => (5)
+
+The implementation for ytt's other fundamental feature -- Overlays -- lives
+within this standard library. This allows for both template authors and ytt
+itself to use this powerful editing feature.
+
+    (3) => pkg/yttlibrary/overlay => (5)
+
+"Standard Library" modules that have Go dependencies are included as
+"extensions" to minimize the set of transitive dependencies that come from the
+github.com/vmware-tanzu/carvel-ytt module.
+
+    (1) => pkg/yttlibraryext => (1)
+    (1) => pkg/yttlibraryext/toml => (4)
+
+YAML Enhancements
+
+ytt can enrich a YAML structure with more fine-grained data typing and
+user-defined constraints on values.
+
+    (3) => pkg/schema => (5)
+    (1) => pkg/assertions => (5)
+
+YAML Structures
+
+At the heart of ytt is the ability to parse annotated YAML.
+
+ytt delegates parsing YAML to the de facto standard YAML library
+(https://github.com/go-yaml/yaml/tree/v2). However, ytt needs to store
+additional information about nodes (e.g. templating, type info, processing
+hints, etc.). It does this by converting the output from the standard YAML
+parser into a composite tree of its own yamlmeta.Node structure that can
+hold that metadata.
+
+    (11) => pkg/yamlmeta => (3)
+    (1) => pkg/yamlmeta/internal/yaml.v2 => (0)
+
+Utilities
+
+Finally, there is a collection of supporting features.
+
+One of which provides the implementation of the "fmt" command:
+
+    (1) => pkg/yamlfmt => (1)
+
+The remainder are domain-agnostic utilities that provide either an
+application-level capability or a specialized piece of logic.
+
+    (5) => pkg/cmd/ui => (0)
+    (5) => pkg/orderedmap => (0)
+    (2) => pkg/version => (0)
+    (2) => pkg/feature => (0)
+    (1) => pkg/spell => (0)
+
+Dependencies
+
+Each package's dependencies on other packages within this module are as follows
+(if a package is not listed, it has no dependencies on other packages within
+this module):
+
+    pkg/cmd/template:
+    - pkg/workspace
+    - pkg/workspace/datavalues
+    - pkg/schema
+    - pkg/workspace/ref
+    - pkg/yttlibrary/overlay
+    - pkg/files
+    - pkg/cmd/ui
+    - pkg/template
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/workspace:
+    - pkg/assertions
+    - pkg/texttemplate
+    - pkg/workspace/datavalues
+    - pkg/yttlibrary
+    - pkg/schema
+    - pkg/workspace/ref
+    - pkg/yamltemplate
+    - pkg/yttlibrary/overlay
+    - pkg/files
+    - pkg/cmd/ui
+    - pkg/template
+    - pkg/template/core
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/assertions:
+    - pkg/feature
+    - pkg/yamltemplate
+    - pkg/template
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/yamltemplate:
+    - pkg/texttemplate
+    - pkg/orderedmap
+    - pkg/template
+    - pkg/template/core
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/texttemplate:
+    - pkg/template
+    - pkg/filepos
+    pkg/template:
+    - pkg/template/core
+    - pkg/filepos
+    pkg/template/core:
+    - pkg/orderedmap
+    pkg/yamlmeta:
+    - pkg/yamlmeta/internal/yaml.v2
+    - pkg/orderedmap
+    - pkg/filepos
+    pkg/workspace/datavalues:
+    - pkg/schema
+    - pkg/workspace/ref
+    - pkg/template
+    - pkg/template/core
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/schema:
+    - pkg/spell
+    - pkg/template
+    - pkg/template/core
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/workspace/ref:
+    - pkg/template
+    - pkg/template/core
+    pkg/yttlibrary:
+    - pkg/version
+    - pkg/yttlibrary/overlay
+    - pkg/orderedmap
+    - pkg/template/core
+    - pkg/yamlmeta
+    pkg/yttlibrary/overlay:
+    - pkg/yamltemplate
+    - pkg/template
+    - pkg/template/core
+    - pkg/filepos
+    - pkg/yamlmeta
+    pkg/files:
+    - pkg/cmd/ui
+    pkg/cmd:
+    - pkg/website
+    - pkg/yamlfmt
+    - pkg/yttlibraryext
+    - pkg/cmd/template
+    - pkg/version
+    - pkg/files
+    - pkg/cmd/ui
+    - pkg/yamlmeta
+    pkg/yamlfmt:
+    - pkg/yamlmeta
+    pkg/yttlibraryext:
+    - pkg/yttlibraryext/toml
+    pkg/yttlibraryext/toml:
+    - pkg/yttlibrary
+    - pkg/orderedmap
+    - pkg/template/core
+    - pkg/yamlmeta
+
+*/
+package pkg

--- a/pkg/experiments/doc.go
+++ b/pkg/experiments/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package experiments provides a global "Feature Flag" facility for
+circuit-breaking pre-GA code.
+
+The intent is to provide a means of selecting a flavor of executable at
+boot; not to toggle experiments on and off. Once settings are loaded from
+the environment variable experiments.Env, they are fixed.
+*/
+package experiments

--- a/pkg/experiments/flags.go
+++ b/pkg/experiments/flags.go
@@ -1,14 +1,14 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+package experiments
+
+import (
+	"os"
+	"strings"
+)
+
 /*
-Package experiments provides a global "Feature Flag" facility for
-circuit-breaking pre-GA code.
-
-The intent is to provide a means of selecting a flavor of executable at
-boot; not to toggle experiments on and off. Once settings are loaded from
-the environment variable experiments.Env, they are fixed.
-
 Registering a New Experiment
 
 1. implement a getter on this package `Is<experiment-name>Enabled()` and add the experiment to GetEnabled()
@@ -23,14 +23,7 @@ Registering a New Experiment
 
     experiments.ResetForTesting()
     os.Setenv(experiments.Env, "<experiment-name>,<other-experiment-name>,...")
-
 */
-package experiments
-
-import (
-	"os"
-	"strings"
-)
 
 // Env is the OS environment variable with comma-separated names of experiments to enable.
 const Env = "YTTEXPERIMENTS"

--- a/pkg/filepos/doc.go
+++ b/pkg/filepos/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package filepos provides the concept of Position: a source name (usually a file)
+and line number within that source.
+
+File positions are crucial when reporting errors to the user. It is often
+even more useful to share the actual source line as well. For this reason
+Position also contains a cached copy of the source line at the Position.
+
+Not all Position point within a file (e.g. code that is generated). The
+zero-value of Position (can be created using NewUnknownPosition()) represents
+this case.
+*/
+package filepos

--- a/pkg/files/doc.go
+++ b/pkg/files/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package files provides primitives for enumerating and loading data from various
+file or file-like Source's and for writing output to filesystem files and
+directories.
+
+This allows the rest of ytt code to process logically chunked streams of data
+without becoming entangled in the details of how to read or write data.
+
+ytt processes files differently depending on their Type. For example,
+File instances that are TypeYAML are parsed as YAML.
+*/
+package files

--- a/pkg/orderedmap/doc.go
+++ b/pkg/orderedmap/doc.go
@@ -1,0 +1,11 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package orderedmap provides a map implementation where the order of keys is
+maintained (unlike the native Go map).
+
+This flavor of map is crucial in keeping the output of ytt deterministic and
+stable.
+*/
+package orderedmap

--- a/pkg/schema/doc.go
+++ b/pkg/schema/doc.go
@@ -1,0 +1,31 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package schema enhances yamlmeta.Node structures with fine-grain data types.
+
+Type and Checking
+
+Within a schema document (which itself is a yamlmeta.Document), type metadata is
+attached to nodes via @schema/... annotations. Those annotations are parsed and
+digested into a composite tree of schema.Type.
+
+With such a schema.Type hierarchy in hand, other YAML documents can be
+"typed" (via Type.AssignTypeTo()). This process walks the target
+yamlmeta.Document and attaches the corresponding type as metadata on each
+corresponding yamlmeta.Node.
+
+"Typed" documents can then be "checked" (via schema.CheckNode()) to determine if
+their fine-grain types conform to the assigned schema.
+
+Documenting
+
+Other @schema/... annotations are used to describe the exact syntax and semantic
+of values.
+
+Other Schema Formats
+
+Like other Carvel tools, ytt aims to interoperate well with other tooling. In
+this vein, ytt can export schema defined within ytt as an OpenAPI v3 document.
+*/
+package schema

--- a/pkg/spell/doc.go
+++ b/pkg/spell/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package spell provides the ability to suggest an exact spelling of a word.
+
+In the context ytt, this is useful for errors that involve misspelled
+identifiers.
+*/
+package spell

--- a/pkg/spell/spell.go
+++ b/pkg/spell/spell.go
@@ -1,9 +1,8 @@
 // Copyright 2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package spell file defines a simple spelling checker for use in attribute errors
-// such as "no such field .foo; did you mean .food?".
 // (this source was copied from https://github.com/google/starlark-go/blob/b0039bd2cfe369fe8f2bdba0614bafd1f9402dbb/internal/spell/spell.go)
+
 package spell
 
 import (

--- a/pkg/template/core/doc.go
+++ b/pkg/template/core/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package core provides facilities for low-level integration with Starlark.
+*/
+package core

--- a/pkg/template/doc.go
+++ b/pkg/template/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package template provides the core templating engine for ytt.
+
+At its heart, a template is text (possibly of a specific format like YAML) that
+is parsed into a set of template.EvaluationNode's which is then compiled into a
+Starlark program whose objective is to build an output structure that reflects
+the evaluated expressions that were annotated in the original text.
+*/
+package template

--- a/pkg/texttemplate/doc.go
+++ b/pkg/texttemplate/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package texttemplate implements the text dialect of the ytt templating engine.
+*/
+package texttemplate

--- a/pkg/validations/doc.go
+++ b/pkg/validations/doc.go
@@ -1,0 +1,14 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package validations enriches YAML structures by attaching user-defined
+constraints (that is, validation rules) onto individual yamlmeta.Node's.
+
+Validations on Data Values
+
+While "@data/values" can technically be annotated with "@assert/validate"
+annotations, it is expected that authors will use "@schema/validation" in
+"@data/values-schema" documents instead.
+*/
+package validations

--- a/pkg/version/doc.go
+++ b/pkg/version/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package version is where the version of the ytt binary is set.
+*/
+package version

--- a/pkg/website/doc.go
+++ b/pkg/website/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package website provides the web-based Playground via an HTTP webserver.
+*/
+package website

--- a/pkg/workspace/datavalues/doc.go
+++ b/pkg/workspace/datavalues/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package datavalues integrates the schema and data values features into the
+workspace, providing a means of "addressing" to specific libraries.
+*/
+package datavalues

--- a/pkg/workspace/doc.go
+++ b/pkg/workspace/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package workspace is home to primitives for loading and processing ytt artifacts
+including the core four steps: pre-processing schema and data values, evaluating
+templates, and post-processing overlays.
+*/
+package workspace

--- a/pkg/workspace/ref/doc.go
+++ b/pkg/workspace/ref/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package ref provides the general-purpose ability to mark a document as targeted
+for specific library.
+*/
+package ref

--- a/pkg/yamlfmt/doc.go
+++ b/pkg/yamlfmt/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package yamlfmt implements the "fmt" command — formatting YAML (preserving
+comments) into a canonical form.
+*/
+package yamlfmt

--- a/pkg/yamlmeta/doc.go
+++ b/pkg/yamlmeta/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package yamlmeta parses YAML streams into a data structure (tree of
+yamlmeta.Node's) on which comments and metadata can be attached.
+*/
+package yamlmeta

--- a/pkg/yamltemplate/doc.go
+++ b/pkg/yamltemplate/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package yamltemplate implements the YAML dialect of the ytt templating engine.
+*/
+package yamltemplate

--- a/pkg/yttlibrary/doc.go
+++ b/pkg/yttlibrary/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package yttlibrary implements the "Standard Library" of modules that are
+built-in to the ytt templating engine.
+*/
+package yttlibrary

--- a/pkg/yttlibrary/overlay/doc.go
+++ b/pkg/yttlibrary/overlay/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package overlay implements YAML patching via ytt annotations.
+*/
+package overlay

--- a/pkg/yttlibraryext/doc.go
+++ b/pkg/yttlibraryext/doc.go
@@ -1,0 +1,11 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package yttlibraryext contains "Standard Library" modules that involve Go module
+dependencies and therefore are optional or extensions.
+
+This makes it possible to integrate with ytt as a Go module without having to
+accept all of its transitive dependencies for features you don't use.
+*/
+package yttlibraryext

--- a/pkg/yttlibraryext/toml/doc.go
+++ b/pkg/yttlibraryext/toml/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package toml extends the ytt "Standard Library" with the ability to encode
+and decode text in TOML format.
+*/
+package toml


### PR DESCRIPTION
Request for review:
- copy edits (spelling, grammar, etc)
- accuracy — this is technical documentation, it needs to be accurate
- summary in `./pkg` — what does the layering documented do for your sense of code organization?

Ultimate home will be: https://pkg.go.dev/github.com/vmware-tanzu/carvel-ytt/pkg or contributor/integrator running `godoc -http=localhost:6060`

Reviewer:
1. check out this branch
2. go get -v  golang.org/x/tools/cmd/godoc
3. go mod vendor
1. start up GoDoc server, locally
    ```
    godoc -http=localhost:6060
    ```
1. Navigate to the `./pkg` page
    ```
    http://localhost:6060/pkg/github.com/vmware-tanzu/carvel-ytt/pkg/
    ```
