### PR TITLE
Support loading Data Values files in the same ways "ordinary" files are loaded

### DIFF
--- a/examples/data-values-directory/README.md
+++ b/examples/data-values-directory/README.md
@@ -1,0 +1,23 @@
+This example demonstrates how ytt handles specifying a directory for Data Values
+inputs. (originally https://kubernetes.slack.com/archives/CH8KCCKA5/p1651167583289939)
+
+With this:
+```
+├── config
+│   ├── config.yml
+│   └── values-schema.yml
+└── values                   <-- any YAML under here is assumed to be plain Data Values
+    ├── appdev-overrides     <-- sorted by full pathname, alphabetically
+    │   └── values.yaml
+    └── operator-overrides
+        ├── 50-operations-overrides.yml
+        ├── 99-opssec-overrides.yml
+        └── approvals.toml   <-- non YAML files are ignored.
+```
+
+Executing this:
+
+```console
+$ ytt -f examples/data-values-directory/config.yml \
+      --data-values-file examples/data-values-directory/values/
+```

--- a/examples/data-values-directory/config/config.yml
+++ b/examples/data-values-directory/config/config.yml
@@ -1,0 +1,8 @@
+#! In the real-world, this configuration would be the manifests that describe
+#! this application's deployment. For this example, we simply render the
+#! net values; this is the point of this example.
+
+#@ load("@ytt:data", "data")
+
+---
+values: #@ data.values

--- a/examples/data-values-directory/config/values-schema.yml
+++ b/examples/data-values-directory/config/values-schema.yml
@@ -1,0 +1,10 @@
+#@data/values-schema
+---
+name: suggestion-service
+instances: 0
+accept_insecure_conns: true
+#@schema/nullable
+cache:
+  driver: ""
+  #@schema/type any=True
+  config: {}

--- a/examples/data-values-directory/expected.txt
+++ b/examples/data-values-directory/expected.txt
@@ -1,0 +1,12 @@
+values:
+  name: suggestion-service
+  instances: 4
+  accept_insecure_conns: false
+  cache:
+    driver: redis
+    config:
+      maxEntries: 1024
+      strategy: MRU
+      host: localhost:6379
+      tls-client-cert-file: client.crt
+      tls-client-key-file: client.key

--- a/examples/data-values-directory/run.sh
+++ b/examples/data-values-directory/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+./ytt -f examples/data-values-directory/config/ \
+      --data-values-file examples/data-values-directory/values/

--- a/examples/data-values-directory/values/appdev-overrides/values.yaml
+++ b/examples/data-values-directory/values/appdev-overrides/values.yaml
@@ -1,0 +1,8 @@
+---
+instances: 1
+accept_insecure_conns: true
+cache:
+  driver: in-memory
+  config:
+    maxEntries: 1024
+    strategy: MRU

--- a/examples/data-values-directory/values/operator-overrides/50-operations-overrides.yml
+++ b/examples/data-values-directory/values/operator-overrides/50-operations-overrides.yml
@@ -1,0 +1,10 @@
+---
+# 2022-05-13: avg + rms over last 3 months
+instances: 4
+
+cache:
+  driver: redis
+  config:
+    host: localhost:6379
+    tls-client-cert-file: client.crt
+    tls-client-key-file: client.key

--- a/examples/data-values-directory/values/operator-overrides/99-opssec-overrides.yml
+++ b/examples/data-values-directory/values/operator-overrides/99-opssec-overrides.yml
@@ -1,0 +1,3 @@
+---
+# Policy 1.31a: all north-south connections must be encrypted.
+accept_insecure_conns: false

--- a/examples/data-values-directory/values/operator-overrides/approvals.toml
+++ b/examples/data-values-directory/values/operator-overrides/approvals.toml
@@ -1,0 +1,7 @@
+[[approvals]]
+    dept = "operations"
+    user = "grumpy-grey-beard@example.com"
+
+[[approvals]]
+    dept = "Operations Security"
+    user = "pedantic-protector@example.com"

--- a/examples/overlay-files/expected.txt
+++ b/examples/overlay-files/expected.txt
@@ -1,0 +1,251 @@
+name: bosh
+releases:
+- name: bosh
+  version: 268.6.0
+  url: https://s3.amazonaws.com/...
+  sha1: 480b15380f446bcd6fb86511e1ad39b4f1019e37
+- name: bpm
+  version: 0.12.3
+  url: https://s3.amazonaws.com/...
+  sha1: 54fbf8e2ecf14c69ee761ddde0624edd228ac478
+- name: os-conf
+  version: 18
+  url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=18
+  sha1: 78d79f08ff5001cc2a24f572837c7a9c59a0e796
+resource_pools:
+- name: vms
+  network: default
+  env:
+    bosh:
+      password: '*'
+      mbus:
+        cert: ((mbus_bootstrap_ssl))
+disk_pools:
+- name: disks
+  disk_size: 65536
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((internal_cidr))
+    gateway: ((internal_gw))
+    static:
+    - ((internal_ip))
+    dns:
+    - 8.8.8.8
+instance_groups:
+- name: bosh
+  instances: 1
+  jobs:
+  - name: bpm
+    release: bpm
+  - name: nats
+    release: bosh
+  - name: postgres-10
+    release: bosh
+  - name: blobstore
+    release: bosh
+  - name: director
+    release: bosh
+  - name: health_monitor
+    release: bosh
+  - name: user_add
+    release: os-conf
+    properties:
+      users:
+      - name: jumpbox
+        public_key: ((jumpbox_ssh.public_key))
+  resource_pool: vms
+  persistent_disk_pool: disks
+  networks:
+  - name: default
+    static_ips:
+    - ((internal_ip))
+  properties:
+    agent:
+      mbus: nats://nats:((nats_password))@((internal_ip)):4222
+      env:
+        bosh:
+          blobstores:
+          - provider: dav
+            options:
+              endpoint: https://((internal_ip)):25250
+              user: agent
+              password: ((blobstore_agent_password))
+              tls:
+                cert:
+                  ca: ((blobstore_ca.certificate))
+    nats:
+      address: ((internal_ip))
+      user: nats
+      password: ((nats_password))
+      tls:
+        ca: ((nats_server_tls.ca))
+        client_ca:
+          certificate: ((nats_ca.certificate))
+          private_key: ((nats_ca.private_key))
+        server:
+          certificate: ((nats_server_tls.certificate))
+          private_key: ((nats_server_tls.private_key))
+        director:
+          certificate: ((nats_clients_director_tls.certificate))
+          private_key: ((nats_clients_director_tls.private_key))
+        health_monitor:
+          certificate: ((nats_clients_health_monitor_tls.certificate))
+          private_key: ((nats_clients_health_monitor_tls.private_key))
+    postgres:
+      listen_address: 127.0.0.1
+      host: 127.0.0.1
+      user: postgres
+      password: ((postgres_password))
+      database: bosh
+      adapter: postgres
+    blobstore:
+      address: ((internal_ip))
+      port: 25250
+      provider: dav
+      director:
+        user: director
+        password: ((blobstore_director_password))
+      agent:
+        user: agent
+        password: ((blobstore_agent_password))
+      tls:
+        cert:
+          ca: ((blobstore_ca.certificate))
+          certificate: ((blobstore_server_tls.certificate))
+          private_key: ((blobstore_server_tls.private_key))
+    director:
+      address: 127.0.0.1
+      name: ((director_name))
+      db:
+        listen_address: 127.0.0.1
+        host: 127.0.0.1
+        user: postgres
+        password: ((postgres_password))
+        database: bosh
+        adapter: postgres
+      flush_arp: true
+      enable_post_deploy: true
+      generate_vm_passwords: true
+      enable_dedicated_status_worker: true
+      enable_nats_delivered_templates: true
+      workers: 4
+      local_dns:
+        enabled: true
+      events:
+        record_events: true
+      ssl:
+        key: ((director_ssl.private_key))
+        cert: ((director_ssl.certificate))
+      user_management:
+        provider: local
+        local:
+          users:
+          - name: admin
+            password: ((admin_password))
+          - name: hm
+            password: ((hm_password))
+      default_ssh_options:
+        gateway_user: jumpbox
+    hm:
+      director_account:
+        user: hm
+        password: ((hm_password))
+        ca_cert: ((director_ssl.ca))
+      resurrector_enabled: true
+    ntp:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+cloud_provider:
+  mbus: https://mbus:((mbus_bootstrap_password))@((internal_ip)):6868
+  cert: ((mbus_bootstrap_ssl))
+  properties:
+    agent:
+      mbus: https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868
+    blobstore:
+      provider: local
+      path: /var/vcap/micro_bosh/data/cache
+    ntp:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+variables:
+- name: admin_password
+  type: password
+- name: blobstore_director_password
+  type: password
+- name: blobstore_agent_password
+  type: password
+- name: hm_password
+  type: password
+- name: mbus_bootstrap_password
+  type: password
+- name: nats_password
+  type: password
+- name: postgres_password
+  type: password
+- name: default_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: ca
+- name: mbus_bootstrap_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: director_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: nats_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: default.nats-ca.bosh-internal
+- name: nats_server_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.nats.bosh-internal
+    alternative_names:
+    - ((internal_ip))
+    extended_key_usage:
+    - server_auth
+- name: nats_clients_director_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.director.bosh-internal
+    extended_key_usage:
+    - client_auth
+- name: nats_clients_health_monitor_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.hm.bosh-internal
+    extended_key_usage:
+    - client_auth
+- name: blobstore_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: default.blobstore-ca.bosh-internal
+- name: blobstore_server_tls
+  type: certificate
+  options:
+    ca: blobstore_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: jumpbox_ssh
+  type: ssh

--- a/examples/overlay-regular-files/expected.txt
+++ b/examples/overlay-regular-files/expected.txt
@@ -1,0 +1,251 @@
+name: bosh
+releases:
+- name: bosh
+  version: 268.6.0
+  url: https://s3.amazonaws.com/...
+  sha1: 480b15380f446bcd6fb86511e1ad39b4f1019e37
+- name: bpm
+  version: 0.12.3
+  url: https://s3.amazonaws.com/...
+  sha1: 54fbf8e2ecf14c69ee761ddde0624edd228ac478
+- name: os-conf
+  version: 18
+  url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=18
+  sha1: 78d79f08ff5001cc2a24f572837c7a9c59a0e796
+resource_pools:
+- name: vms
+  network: default
+  env:
+    bosh:
+      password: '*'
+      mbus:
+        cert: ((mbus_bootstrap_ssl))
+disk_pools:
+- name: disks
+  disk_size: 65536
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((internal_cidr))
+    gateway: ((internal_gw))
+    static:
+    - ((internal_ip))
+    dns:
+    - 8.8.8.8
+instance_groups:
+- name: bosh
+  instances: 1
+  jobs:
+  - name: bpm
+    release: bpm
+  - name: nats
+    release: bosh
+  - name: postgres-10
+    release: bosh
+  - name: blobstore
+    release: bosh
+  - name: director
+    release: bosh
+  - name: health_monitor
+    release: bosh
+  - name: user_add
+    release: os-conf
+    properties:
+      users:
+      - name: jumpbox
+        public_key: ((jumpbox_ssh.public_key))
+  resource_pool: vms
+  persistent_disk_pool: disks
+  networks:
+  - name: default
+    static_ips:
+    - ((internal_ip))
+  properties:
+    agent:
+      mbus: nats://nats:((nats_password))@((internal_ip)):4222
+      env:
+        bosh:
+          blobstores:
+          - provider: dav
+            options:
+              endpoint: https://((internal_ip)):25250
+              user: agent
+              password: ((blobstore_agent_password))
+              tls:
+                cert:
+                  ca: ((blobstore_ca.certificate))
+    nats:
+      address: ((internal_ip))
+      user: nats
+      password: ((nats_password))
+      tls:
+        ca: ((nats_server_tls.ca))
+        client_ca:
+          certificate: ((nats_ca.certificate))
+          private_key: ((nats_ca.private_key))
+        server:
+          certificate: ((nats_server_tls.certificate))
+          private_key: ((nats_server_tls.private_key))
+        director:
+          certificate: ((nats_clients_director_tls.certificate))
+          private_key: ((nats_clients_director_tls.private_key))
+        health_monitor:
+          certificate: ((nats_clients_health_monitor_tls.certificate))
+          private_key: ((nats_clients_health_monitor_tls.private_key))
+    postgres:
+      listen_address: 127.0.0.1
+      host: 127.0.0.1
+      user: postgres
+      password: ((postgres_password))
+      database: bosh
+      adapter: postgres
+    blobstore:
+      address: ((internal_ip))
+      port: 25250
+      provider: dav
+      director:
+        user: director
+        password: ((blobstore_director_password))
+      agent:
+        user: agent
+        password: ((blobstore_agent_password))
+      tls:
+        cert:
+          ca: ((blobstore_ca.certificate))
+          certificate: ((blobstore_server_tls.certificate))
+          private_key: ((blobstore_server_tls.private_key))
+    director:
+      address: 127.0.0.1
+      name: ((director_name))
+      db:
+        listen_address: 127.0.0.1
+        host: 127.0.0.1
+        user: postgres
+        password: ((postgres_password))
+        database: bosh
+        adapter: postgres
+      flush_arp: true
+      enable_post_deploy: true
+      generate_vm_passwords: true
+      enable_dedicated_status_worker: true
+      enable_nats_delivered_templates: true
+      workers: 4
+      local_dns:
+        enabled: true
+      events:
+        record_events: true
+      ssl:
+        key: ((director_ssl.private_key))
+        cert: ((director_ssl.certificate))
+      user_management:
+        provider: local
+        local:
+          users:
+          - name: admin
+            password: ((admin_password))
+          - name: hm
+            password: ((hm_password))
+      default_ssh_options:
+        gateway_user: jumpbox
+    hm:
+      director_account:
+        user: hm
+        password: ((hm_password))
+        ca_cert: ((director_ssl.ca))
+      resurrector_enabled: true
+    ntp:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+cloud_provider:
+  mbus: https://mbus:((mbus_bootstrap_password))@((internal_ip)):6868
+  cert: ((mbus_bootstrap_ssl))
+  properties:
+    agent:
+      mbus: https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868
+    blobstore:
+      provider: local
+      path: /var/vcap/micro_bosh/data/cache
+    ntp:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+variables:
+- name: admin_password
+  type: password
+- name: blobstore_director_password
+  type: password
+- name: blobstore_agent_password
+  type: password
+- name: hm_password
+  type: password
+- name: mbus_bootstrap_password
+  type: password
+- name: nats_password
+  type: password
+- name: postgres_password
+  type: password
+- name: default_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: ca
+- name: mbus_bootstrap_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: director_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: nats_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: default.nats-ca.bosh-internal
+- name: nats_server_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.nats.bosh-internal
+    alternative_names:
+    - ((internal_ip))
+    extended_key_usage:
+    - server_auth
+- name: nats_clients_director_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.director.bosh-internal
+    extended_key_usage:
+    - client_auth
+- name: nats_clients_health_monitor_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.hm.bosh-internal
+    extended_key_usage:
+    - client_auth
+- name: blobstore_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: default.blobstore-ca.bosh-internal
+- name: blobstore_server_tls
+  type: certificate
+  options:
+    ca: blobstore_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: jumpbox_ssh
+  type: ssh

--- a/examples/overlay/expected.txt
+++ b/examples/overlay/expected.txt
@@ -1,0 +1,251 @@
+name: bosh
+releases:
+- name: bosh
+  version: 268.6.0
+  url: https://s3.amazonaws.com/...
+  sha1: 480b15380f446bcd6fb86511e1ad39b4f1019e37
+- name: bpm
+  version: 0.12.3
+  url: https://s3.amazonaws.com/...
+  sha1: 54fbf8e2ecf14c69ee761ddde0624edd228ac478
+- name: os-conf
+  version: 18
+  url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=18
+  sha1: 78d79f08ff5001cc2a24f572837c7a9c59a0e796
+resource_pools:
+- name: vms
+  network: default
+  env:
+    bosh:
+      password: '*'
+      mbus:
+        cert: ((mbus_bootstrap_ssl))
+disk_pools:
+- name: disks
+  disk_size: 65536
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((internal_cidr))
+    gateway: ((internal_gw))
+    static:
+    - ((internal_ip))
+    dns:
+    - 8.8.8.8
+instance_groups:
+- name: bosh
+  instances: 1
+  jobs:
+  - name: bpm
+    release: bpm
+  - name: nats
+    release: bosh
+  - name: postgres-10
+    release: bosh
+  - name: blobstore
+    release: bosh
+  - name: director
+    release: bosh
+  - name: health_monitor
+    release: bosh
+  - name: user_add
+    release: os-conf
+    properties:
+      users:
+      - name: jumpbox
+        public_key: ((jumpbox_ssh.public_key))
+  resource_pool: vms
+  persistent_disk_pool: disks
+  networks:
+  - name: default
+    static_ips:
+    - ((internal_ip))
+  properties:
+    agent:
+      mbus: nats://nats:((nats_password))@((internal_ip)):4222
+      env:
+        bosh:
+          blobstores:
+          - provider: dav
+            options:
+              endpoint: https://((internal_ip)):25250
+              user: agent
+              password: ((blobstore_agent_password))
+              tls:
+                cert:
+                  ca: ((blobstore_ca.certificate))
+    nats:
+      address: ((internal_ip))
+      user: nats
+      password: ((nats_password))
+      tls:
+        ca: ((nats_server_tls.ca))
+        client_ca:
+          certificate: ((nats_ca.certificate))
+          private_key: ((nats_ca.private_key))
+        server:
+          certificate: ((nats_server_tls.certificate))
+          private_key: ((nats_server_tls.private_key))
+        director:
+          certificate: ((nats_clients_director_tls.certificate))
+          private_key: ((nats_clients_director_tls.private_key))
+        health_monitor:
+          certificate: ((nats_clients_health_monitor_tls.certificate))
+          private_key: ((nats_clients_health_monitor_tls.private_key))
+    postgres:
+      listen_address: 127.0.0.1
+      host: 127.0.0.1
+      user: postgres
+      password: ((postgres_password))
+      database: bosh
+      adapter: postgres
+    blobstore:
+      address: ((internal_ip))
+      port: 25250
+      provider: dav
+      director:
+        user: director
+        password: ((blobstore_director_password))
+      agent:
+        user: agent
+        password: ((blobstore_agent_password))
+      tls:
+        cert:
+          ca: ((blobstore_ca.certificate))
+          certificate: ((blobstore_server_tls.certificate))
+          private_key: ((blobstore_server_tls.private_key))
+    director:
+      address: 127.0.0.1
+      name: ((director_name))
+      db:
+        listen_address: 127.0.0.1
+        host: 127.0.0.1
+        user: postgres
+        password: ((postgres_password))
+        database: bosh
+        adapter: postgres
+      flush_arp: true
+      enable_post_deploy: true
+      generate_vm_passwords: true
+      enable_dedicated_status_worker: true
+      enable_nats_delivered_templates: true
+      workers: 4
+      local_dns:
+        enabled: true
+      events:
+        record_events: true
+      ssl:
+        key: ((director_ssl.private_key))
+        cert: ((director_ssl.certificate))
+      user_management:
+        provider: local
+        local:
+          users:
+          - name: admin
+            password: ((admin_password))
+          - name: hm
+            password: ((hm_password))
+      default_ssh_options:
+        gateway_user: jumpbox
+    hm:
+      director_account:
+        user: hm
+        password: ((hm_password))
+        ca_cert: ((director_ssl.ca))
+      resurrector_enabled: true
+    ntp:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+cloud_provider:
+  mbus: https://mbus:((mbus_bootstrap_password))@((internal_ip)):6868
+  cert: ((mbus_bootstrap_ssl))
+  properties:
+    agent:
+      mbus: https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868
+    blobstore:
+      provider: local
+      path: /var/vcap/micro_bosh/data/cache
+    ntp:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+variables:
+- name: admin_password
+  type: password
+- name: blobstore_director_password
+  type: password
+- name: blobstore_agent_password
+  type: password
+- name: hm_password
+  type: password
+- name: mbus_bootstrap_password
+  type: password
+- name: nats_password
+  type: password
+- name: postgres_password
+  type: password
+- name: default_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: ca
+- name: mbus_bootstrap_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: director_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: nats_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: default.nats-ca.bosh-internal
+- name: nats_server_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.nats.bosh-internal
+    alternative_names:
+    - ((internal_ip))
+    extended_key_usage:
+    - server_auth
+- name: nats_clients_director_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.director.bosh-internal
+    extended_key_usage:
+    - client_auth
+- name: nats_clients_health_monitor_tls
+  type: certificate
+  options:
+    ca: nats_ca
+    common_name: default.hm.bosh-internal
+    extended_key_usage:
+    - client_auth
+- name: blobstore_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: default.blobstore-ca.bosh-internal
+- name: blobstore_server_tls
+  type: certificate
+  options:
+    ca: blobstore_ca
+    common_name: ((internal_ip))
+    alternative_names:
+    - ((internal_ip))
+- name: jumpbox_ssh
+  type: ssh

--- a/pkg/cmd/template/cmd.go
+++ b/pkg/cmd/template/cmd.go
@@ -54,8 +54,13 @@ type FileSource interface {
 
 var _ []FileSource = []FileSource{&BulkFilesSource{}, &RegularFilesSource{}}
 
+// NewOptions initializes a new instance of template.Options.
 func NewOptions() *Options {
-	return &Options{}
+	var opts files.SymlinkAllowOpts
+	return &Options{
+		RegularFilesSourceOpts: RegularFilesSourceOpts{SymlinkAllowOpts: &opts},
+		DataValuesFlags:        DataValuesFlags{SymlinkAllowOpts: &opts},
+	}
 }
 
 // BindFlags registers template flags for template command.
@@ -66,7 +71,7 @@ func (o *Options) BindFlags(cmdFlags CmdFlags) {
 		"Configure whether implicit map keys overrides are allowed")
 	cmdFlags.BoolVarP(&o.StrictYAML, "strict", "s", false, "Configure to use _strict_ YAML subset")
 	cmdFlags.BoolVar(&o.Debug, "debug", false, "Enable debug output")
-	cmdFlags.BoolVar(&o.InspectFiles, "files-inspect", false, "Inspect files")
+	cmdFlags.BoolVar(&o.InspectFiles, "files-inspect", false, "Determine the set of files that would be processed and display that result")
 
 	o.BulkFilesSourceOpts.Set(cmdFlags)
 	o.RegularFilesSourceOpts.Set(cmdFlags)

--- a/pkg/cmd/template/cmd_data_values_file_test.go
+++ b/pkg/cmd/template/cmd_data_values_file_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vmware-tanzu/carvel-ytt/pkg/files"
 )
 
-func TestDataValuesWithDataValuesFileFlags(t *testing.T) {
+func TestDataValuesFilesFlag_acceptsPlainYAML(t *testing.T) {
 	yamlTplData := []byte(`
 #@ load("@ytt:data", "data")
 values: #@ data.values`)
@@ -94,14 +94,14 @@ array:
 
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
 		FromFiles: []string{"dvs1.yml", "dvs2.yml", "dvs3.yml"},
-		ReadFileFunc: func(path string) ([]byte, error) {
+		ReadFilesFunc: func(path string) ([]*files.File, error) {
 			switch path {
 			case "dvs1.yml":
-				return dvs1, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs1.yml", dvs1))}, nil
 			case "dvs2.yml":
-				return dvs2, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs2.yml", dvs2))}, nil
 			case "dvs3.yml":
-				return dvs3, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs3.yml", dvs3))}, nil
 			default:
 				return nil, fmt.Errorf("Unknown file '%s'", path)
 			}
@@ -118,7 +118,7 @@ array:
 	assert.Equal(t, expectedYAMLTplData, string(file.Bytes()))
 }
 
-func TestDataValuesWithDataValuesFileFlagsForbiddenComment(t *testing.T) {
+func TestDataValuesFilesFlag_rejectsTemplatedYAML(t *testing.T) {
 	yamlTplData := []byte(`
 #@ load("@ytt:data", "data")
 values: #@ data.values`)
@@ -136,10 +136,10 @@ int: 123`)
 
 	opts.DataValuesFlags = cmdtpl.DataValuesFlags{
 		FromFiles: []string{"dvs1.yml"},
-		ReadFileFunc: func(path string) ([]byte, error) {
+		ReadFilesFunc: func(path string) ([]*files.File, error) {
 			switch path {
 			case "dvs1.yml":
-				return dvs1, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs1.yml", dvs1))}, nil
 			default:
 				return nil, fmt.Errorf("Unknown file '%s'", path)
 			}
@@ -148,4 +148,87 @@ int: 123`)
 
 	out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
 	require.EqualError(t, out.Err, "Extracting data value from file: Checking data values file 'dvs1.yml': Expected to be plain YAML, having no annotations (hint: remove comments starting with `#@`)")
+}
+
+func TestDataValuesFilesFlag_WithNonYAMLFiles(t *testing.T) {
+	t.Run("errors when file is explicitly specified", func(t *testing.T) {
+		yamlTplData := []byte(`
+#@ load("@ytt:data", "data")
+values: #@ data.values`)
+
+		toml1 := `
+[foo]
+  bar = 123
+`
+
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+		})
+
+		ui := ui.NewTTY(false)
+		opts := cmdtpl.NewOptions()
+
+		opts.DataValuesFlags = cmdtpl.DataValuesFlags{
+			FromFiles: []string{"toml1.toml"},
+			ReadFilesFunc: func(path string) ([]*files.File, error) {
+				switch path {
+				case "toml1.toml":
+					return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("toml1.toml", []byte(toml1)))}, nil
+				default:
+					return nil, fmt.Errorf("Unknown file '%s'", path)
+				}
+			},
+		}
+
+		out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+		require.EqualError(t, out.Err, "Extracting data value from file: Unmarshaling YAML data values file 'toml1.toml': yaml: line 2: did not find expected <document start>")
+	})
+	t.Run("skips when path given is a directory", func(t *testing.T) {
+		yamlTplData := []byte(`
+#@ load("@ytt:data", "data")
+values: #@ data.values`)
+
+		dvs1 := `---
+int: 123
+`
+		toml1 := `
+[foo]
+  bar = 456
+`
+
+		expectedYAMLTplData := `values:
+  int: 123
+`
+
+		filesToProcess := files.NewSortedFiles([]*files.File{
+			files.MustNewFileFromSource(files.NewBytesSource("tpl.yml", yamlTplData)),
+		})
+
+		ui := ui.NewTTY(false)
+		opts := cmdtpl.NewOptions()
+
+		opts.DataValuesFlags = cmdtpl.DataValuesFlags{
+			FromFiles: []string{"values"},
+			ReadFilesFunc: func(path string) ([]*files.File, error) {
+				switch path {
+				case "values":
+					return []*files.File{
+						files.MustNewFileFromSource(files.NewBytesSource("values/dvs1.yml", []byte(dvs1))),
+						files.MustNewFileFromSource(files.NewBytesSource("values/toml1.toml", []byte(toml1))),
+					}, nil
+				default:
+					return nil, fmt.Errorf("Unknown file '%s'", path)
+				}
+			},
+		}
+
+		out := opts.RunWithFiles(cmdtpl.Input{Files: filesToProcess}, ui)
+		require.NoError(t, out.Err)
+		require.Len(t, out.Files, 1, "unexpected number of output files")
+
+		file := out.Files[0]
+
+		assert.Equal(t, "tpl.yml", file.RelativePath())
+		assert.Equal(t, expectedYAMLTplData, string(file.Bytes()))
+	})
 }

--- a/pkg/cmd/template/cmd_data_values_test.go
+++ b/pkg/cmd/template/cmd_data_values_test.go
@@ -181,48 +181,48 @@ another:
 }
 
 func TestDataValuesWithLibraryAttachedFlags(t *testing.T) {
-	tplBytes := []byte(`
+	tplBytes := `
 #@ load("@ytt:library", "library")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:data", "data")
 
 root: #@ data.values
---- #@ template.replace(library.get("lib", alias="inst1").eval())`)
+--- #@ template.replace(library.get("lib", alias="inst1").eval())`
 
-	libTplBytes := []byte(`
+	libTplBytes := `
 #@ load("@ytt:library", "library")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:data", "data")
 
 from_library: #@ data.values
 --- #@ template.replace(library.get("nested-lib").eval())
-`)
+`
 
-	libValuesBytes := []byte(`
+	libValuesBytes := `
 #@data/values
 ---
 val0: override-me
-`)
+`
 
-	nestedLibTplBytes := []byte(`
+	nestedLibTplBytes := `
 #@ load("@ytt:data", "data")
 
 from_nested_lib: #@ data.values
-`)
+`
 
-	nestedLibValuesBytes := []byte(`
+	nestedLibValuesBytes := `
 #@data/values
 ---
 val1: override-me
-`)
+`
 
-	dvs2 := []byte(`val2: 2`)
+	dvs2 := `val2: 2`
 
-	dvs3 := []byte(`val3: 3`)
+	dvs3 := `val3: 3`
 
-	dvs4 := []byte(`val4: 4`)
+	dvs4 := `val4: 4`
 
-	dvs6 := []byte(`6`)
+	dvs6 := `6`
 
 	expectedYAMLTplData := `root:
   val2: 2
@@ -239,11 +239,11 @@ from_nested_lib:
 `
 
 	filesToProcess := files.NewSortedFiles([]*files.File{
-		files.MustNewFileFromSource(files.NewBytesSource("config.yml", tplBytes)),
-		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/values.yml", libValuesBytes)),
-		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/config.yml", libTplBytes)),
-		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/_ytt_lib/nested-lib/values.yml", nestedLibValuesBytes)),
-		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/_ytt_lib/nested-lib/config.yml", nestedLibTplBytes)),
+		files.MustNewFileFromSource(files.NewBytesSource("config.yml", []byte(tplBytes))),
+		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/values.yml", []byte(libValuesBytes))),
+		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/config.yml", []byte(libTplBytes))),
+		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/_ytt_lib/nested-lib/values.yml", []byte(nestedLibValuesBytes))),
+		files.MustNewFileFromSource(files.NewBytesSource("_ytt_lib/lib/_ytt_lib/nested-lib/config.yml", []byte(nestedLibTplBytes))),
 	})
 
 	ui := ui.NewTTY(false)
@@ -255,16 +255,16 @@ from_nested_lib:
 		EnvFromStrings: []string{"@lib:DVS"},
 		EnvironFunc:    func() []string { return []string{"DVS_val5=5"} },
 		KVsFromFiles:   []string{"@lib:val6=c:\\User\\user\\dvs6.yml"},
-		ReadFileFunc: func(path string) ([]byte, error) {
+		ReadFilesFunc: func(path string) ([]*files.File, error) {
 			switch path {
 			case "c:\\User\\user\\dvs2.yml":
-				return dvs2, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs2.yml", []byte(dvs2)))}, nil
 			case "dvs3.yml":
-				return dvs3, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs3.yml", []byte(dvs3)))}, nil
 			case "D:\\User\\user\\dvs4.yml":
-				return dvs4, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs4.yml", []byte(dvs4)))}, nil
 			case "c:\\User\\user\\dvs6.yml":
-				return dvs6, nil
+				return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs6.yml", []byte(dvs6)))}, nil
 			default:
 				return nil, fmt.Errorf("Unknown file '%s'", path)
 			}

--- a/pkg/cmd/template/regular_input.go
+++ b/pkg/cmd/template/regular_input.go
@@ -22,7 +22,7 @@ type RegularFilesSourceOpts struct {
 	OutputFiles string
 	OutputType  OutputType
 
-	files.SymlinkAllowOpts
+	*files.SymlinkAllowOpts
 }
 
 // OutputType holds the user's desire for two (2) categories of output:
@@ -35,7 +35,7 @@ type OutputType struct {
 // Set registers flags related to sourcing ordinary files/directories and wires-up those flags up to this
 // RegularFilesSourceOpts to be set when the corresponding cobra.Command is executed.
 func (s *RegularFilesSourceOpts) Set(cmdFlags CmdFlags) {
-	cmdFlags.StringArrayVarP(&s.files, "file", "f", nil, "File (ie local path, HTTP URL, -) (can be specified multiple times)")
+	cmdFlags.StringArrayVarP(&s.files, "file", "f", nil, "File(s) to process {filepath, HTTP URL, or '-' (i.e. stdin)} (can be specified multiple times)")
 
 	cmdFlags.StringVar(&s.outputDir, "dangerous-emptied-output-directory", "",
 		"Delete given directory, and then create it with output files")
@@ -65,7 +65,7 @@ func (s *RegularFilesSource) HasInput() bool  { return len(s.opts.files) > 0 }
 func (s *RegularFilesSource) HasOutput() bool { return true }
 
 func (s *RegularFilesSource) Input() (Input, error) {
-	filesToProcess, err := files.NewSortedFilesFromPaths(s.opts.files, s.opts.SymlinkAllowOpts)
+	filesToProcess, err := files.NewSortedFilesFromPaths(s.opts.files, *s.opts.SymlinkAllowOpts)
 	if err != nil {
 		return Input{}, err
 	}

--- a/pkg/cmd/template/schema_consumer_test.go
+++ b/pkg/cmd/template/schema_consumer_test.go
@@ -255,10 +255,10 @@ foo:
 
 		opts.DataValuesFlags = cmdtpl.DataValuesFlags{
 			FromFiles: []string{"dvs1.yml"},
-			ReadFileFunc: func(path string) ([]byte, error) {
+			ReadFilesFunc: func(path string) ([]*files.File, error) {
 				switch path {
 				case "dvs1.yml":
-					return []byte(dvs1), nil
+					return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs1.yml", []byte(dvs1)))}, nil
 				default:
 					return nil, fmt.Errorf("Unknown file '%s'", path)
 				}
@@ -707,10 +707,10 @@ rendered: #@ data.values.foo
 `
 		cmdOpts.DataValuesFlags = cmdtpl.DataValuesFlags{
 			KVsFromFiles: []string{"foo=dvs1.yml"},
-			ReadFileFunc: func(path string) ([]byte, error) {
+			ReadFilesFunc: func(path string) ([]*files.File, error) {
 				switch path {
 				case "dvs1.yml":
-					return []byte(dvs1), nil
+					return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs1.yml", []byte(dvs1)))}, nil
 				default:
 					return nil, fmt.Errorf("Unknown file '%s'", path)
 				}
@@ -752,10 +752,10 @@ rendered: #@ data.values.foo
 `
 		cmdOpts.DataValuesFlags = cmdtpl.DataValuesFlags{
 			FromFiles: []string{"dvs1.yml"},
-			ReadFileFunc: func(path string) ([]byte, error) {
+			ReadFilesFunc: func(path string) ([]*files.File, error) {
 				switch path {
 				case "dvs1.yml":
-					return []byte(dvs1), nil
+					return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs1.yml", []byte(dvs1)))}, nil
 				default:
 					return nil, fmt.Errorf("Unknown file '%s'", path)
 				}
@@ -787,11 +787,11 @@ dvs1.yml:
 ---
 hostname: ""
 `
-		dvs1Data := `---
+		dvs1 := `---
 not_in_schema: this should be the only violation reported
 `
 
-		dvs2Data := `---
+		dvs2 := `---
 hostname: 14   # wrong type; but will never be caught
 `
 		templateYAML := `---
@@ -803,12 +803,12 @@ rendered: true`
 		})
 		opts.DataValuesFlags = cmdtpl.DataValuesFlags{
 			FromFiles: []string{"dvs1.yml", "dvs2.yml"},
-			ReadFileFunc: func(path string) ([]byte, error) {
+			ReadFilesFunc: func(path string) ([]*files.File, error) {
 				switch path {
 				case "dvs1.yml":
-					return []byte(dvs1Data), nil
+					return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs1.yml", []byte(dvs1)))}, nil
 				case "dvs2.yml":
-					return []byte(dvs2Data), nil
+					return []*files.File{files.MustNewFileFromSource(files.NewBytesSource("dvs2.yml", []byte(dvs2)))}, nil
 				default:
 					return nil, fmt.Errorf("Unknown file '%s'", path)
 				}

--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -233,6 +233,12 @@ func (r *File) isTemplate() bool {
 	return !r.IsLibrary() && (t == TypeYAML || t == TypeText)
 }
 
+// IsImplied reports whether this file was implicitly included (found within an explicitly named directory) or not
+// (named explicitly as input).
+func (r *File) IsImplied() bool {
+	return strings.ContainsRune(r.OriginalRelativePath(), os.PathSeparator)
+}
+
 func (r *File) IsLibrary() bool {
 	exts := strings.Split(filepath.Base(r.RelativePath()), ".")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,7 +49,7 @@ func TestCheckStdInReadingOnlyOnce(t *testing.T) {
 		{"-f": "-"},
 	}
 	actualOutput := runYttExpectingError(t, nil, "../../examples/data-values/values-file.yml", flags, nil)
-	expectedOutput := "ytt: Error: Extracting data value from file:\n  Reading file '-':\n    Standard input has already been read, has the '-' argument been used in more than one flag?\n"
+	expectedOutput := "ytt: Error: Extracting data value from file:\n  Reading file 'stdin.yml':\n    Standard input has already been read, has the '-' argument been used in more than one flag?\n"
 	require.Equal(t, expectedOutput, actualOutput)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -104,6 +104,18 @@ float: 123.123
 
 			require.Equal(t, expectedOutput, actualOutput)
 		})
+		t.Run("--data-values-file enumerates YAML files from given directory", func(t *testing.T) {
+			testDir := "../../examples/data-values-directory"
+			flags := yttFlags{
+				{"--data-values-file": testDir + "/values"},
+			}
+			actualOutput := runYtt(t, testInputFiles{testDir + "/config"}, "", flags, nil)
+
+			expectedOutput, err := ioutil.ReadFile(filepath.Join(testDir, "expected.txt"))
+			require.NoError(t, err)
+
+			require.Equal(t, string(expectedOutput), actualOutput)
+		})
 	})
 	t.Run("can be 'required'", func(t *testing.T) {
 		expectedFileOutput, err := ioutil.ReadFile("../../examples/data-values-required/expected.txt")


### PR DESCRIPTION
Reusing the strategy by which a filepath from `--file` is used to resolve to the contents of the file(s) for loading Data Values.

All types of inputs are now supported (and handled identically) across `--file`, `--data-value-file`, and `--data-values-file`: 🎉 
- ordinary file
- filesystem directories
- named pipes
- HTTP/HTTPS URLs
- standard input