### PR TITLE
Return error on non-200 responses

### DIFF
--- a/pkg/files/sources.go
+++ b/pkg/files/sources.go
@@ -88,6 +88,7 @@ type HTTPSource struct {
 	Client *http.Client
 }
 
+// NewHTTPSource returns a new source of type HTTP
 func NewHTTPSource(path string) HTTPSource { return HTTPSource{path, &http.Client{}} }
 
 func (s HTTPSource) Description() string {

--- a/pkg/files/sources_test.go
+++ b/pkg/files/sources_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package files
+package files_test
 
 import (
 	"bytes"
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/carvel-ytt/pkg/files"
 )
 
 func TestHTTPFileSources(t *testing.T) {
@@ -28,7 +29,7 @@ func TestHTTPFileSources(t *testing.T) {
 		}
 	})
 
-	fileSource := NewHTTPSource(url)
+	fileSource := files.NewHTTPSource(url)
 	fileSource.Client = client
 	body, err := fileSource.Bytes()
 	require.NoError(t, err)
@@ -45,7 +46,7 @@ func TestHTTPFileSources(t *testing.T) {
 		}
 	})
 
-	fileSource = NewHTTPSource(url)
+	fileSource = files.NewHTTPSource(url)
 	fileSource.Client = client
 	body, err = fileSource.Bytes()
 	require.NoError(t, err)
@@ -63,7 +64,7 @@ func TestHTTPFileSources(t *testing.T) {
 		}
 	})
 
-	fileSource = NewHTTPSource(url)
+	fileSource = files.NewHTTPSource(url)
 	fileSource.Client = client
 	_, err = fileSource.Bytes()
 	require.EqualError(t, err, fmt.Sprintf("Requesting URL '%s': %s", url, status))

--- a/pkg/files/sources_test.go
+++ b/pkg/files/sources_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package files
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPFileSources(t *testing.T) {
+	url := "http://example.com/some/path"
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, req.URL.String(), url)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	fileSource := NewHTTPSource(url)
+	fileSource.Client = client
+	body, err := fileSource.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("OK"), body)
+
+	// 2xx Status Codes
+	client = NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, req.URL.String(), url)
+		return &http.Response{
+			StatusCode: http.StatusIMUsed,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}
+	})
+
+	fileSource = NewHTTPSource(url)
+	fileSource.Client = client
+	body, err = fileSource.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("OK"), body)
+
+	// Non-OK HTTP Status Code
+	status := "404 Not Found"
+	client = NewTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, req.URL.String(), url)
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     status,
+			Header:     make(http.Header),
+		}
+	})
+
+	fileSource = NewHTTPSource(url)
+	fileSource.Client = client
+	_, err = fileSource.Bytes()
+	require.EqualError(t, err, fmt.Sprintf("Requesting URL '%s': %s", url, status))
+}
+
+// NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}


### PR DESCRIPTION
Handle http errors as specified in #682. The resolution is the same as in https://github.com/vmware-tanzu/carvel-kapp/pull/523