### PR TITLE
Give validation rules priority and severity

### DIFF
--- a/pkg/validations/filetests/not_null=/when-value-is-null-short-circuits-other-rules.tpltest
+++ b/pkg/validations/filetests/not_null=/when-value-is-null-short-circuits-other-rules.tpltest
@@ -1,0 +1,7 @@
+#@assert/validate min=1, not_null=True
+value: null
+
++++
+
+ERR:
+- "value" (stdin:2) requires "not null"; fail: value is null (by stdin:1)


### PR DESCRIPTION
- the higher the priority, the earlier a rule runs
- if a rule is "fatal" it stops further rule checking on that
  validation.

Resolves #711 