### PR TITLE
Allow template tests to have trailing empty lines

### DIFF
--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -1,6 +1,10 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/*
+Package filetests houses a test harness for evaluating templates and asserting
+the expected output.
+*/
 package filetests
 
 import (

--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -40,6 +40,17 @@ type EvaluateTemplate func(src string) (MarshalableResult, *TestErr)
 // - expected output starting with `ERR:` indicate that expected output is an error message
 // - expected output starting with `OUTPUT POSITION:` indicate that expected output is "pos" format
 // - otherwise expected output is the literal output from template
+//
+// For example:
+//
+//	#! my-test.tpltest
+//	---
+//	#@ msg = "hello"
+//	msg: #@ msg
+//	+++
+//
+//	msg: hello
+//
 type FileTests struct {
 	PathToTests      string
 	EvalFunc         EvaluateTemplate

--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -93,12 +93,12 @@ func (f FileTests) Run(t *testing.T) {
 				} else {
 					resultStr := testErr.UserErr().Error()
 					resultStr = regexp.MustCompile("__ytt_tpl\\d+_").ReplaceAllString(resultStr, "__ytt_tplXXX_")
-					resultStr = f.trimTrailingWhitespace(resultStr)
+					resultStr = TrimTrailingMultilineWhitespace(resultStr)
 
 					expectedStr = strings.TrimPrefix(expectedStr, "ERR:")
 					expectedStr = strings.TrimPrefix(expectedStr, " ")
 					expectedStr = strings.ReplaceAll(expectedStr, "__YTT_VERSION__", version.Version)
-					expectedStr = f.trimTrailingWhitespace(expectedStr)
+					expectedStr = TrimTrailingMultilineWhitespace(expectedStr)
 					err = f.expectEquals(resultStr, expectedStr)
 				}
 			case strings.HasPrefix(expectedStr, "OUTPUT POSITION:"):
@@ -132,14 +132,6 @@ func (f FileTests) Run(t *testing.T) {
 			}
 		})
 	}
-}
-
-func (f FileTests) trimTrailingWhitespace(multiLineString string) string {
-	var newLines []string
-	for _, line := range strings.Split(multiLineString, "\n") {
-		newLines = append(newLines, strings.TrimRight(line, "\t "))
-	}
-	return strings.Join(newLines, "\n")
 }
 
 func (f FileTests) asFilePositionsStr(result MarshalableResult) (string, error) {
@@ -249,4 +241,16 @@ func (l DefaultTemplateLoader) Load(thread *starlark.Thread, module string) (sta
 	api := yttlibrary.NewAPI(l.CompiledTemplate.TplReplaceNode,
 		yttlibrary.NewDataModule(&l.DataValues, nil), nil, nil)
 	return api.FindModule(strings.TrimPrefix(module, "@ytt:"))
+}
+
+// TrimTrailingMultilineWhitespace returns a string with trailing whitespace trimmed from every line as well
+// as trimmed trailing empty lines
+func TrimTrailingMultilineWhitespace(s string) string {
+	var trimmedLines []string
+	for _, line := range strings.Split(s, "\n") {
+		trimmedLine := strings.TrimRight(line, "\t ")
+		trimmedLines = append(trimmedLines, trimmedLine)
+	}
+	multiline := strings.Join(trimmedLines, "\n")
+	return strings.TrimRight(multiline, "\n")
 }

--- a/test/filetests/filetests_test.go
+++ b/test/filetests/filetests_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package filetests
 
 import (

--- a/test/filetests/filetests_test.go
+++ b/test/filetests/filetests_test.go
@@ -1,0 +1,56 @@
+package filetests
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTrimTrailingMultilineWhitespace(t *testing.T) {
+	for _, testcase := range []struct {
+		give, want string
+	}{
+		{
+			give: `we want yaml`,
+			want: `we want yaml`,
+		},
+		{
+			give: `we want yaml `,
+			want: `we want yaml`,
+		},
+		{
+			give: `we want yaml	`,
+			want: `we want yaml`,
+		},
+		{
+			give: `we want yaml
+`,
+			want: `we want yaml`,
+		},
+		{
+			give: `
+we 
+want	
+yaml  `,
+			want: `
+we
+want
+yaml`,
+		},
+		{
+			give: `
+we
+
+  want	
+	yaml
+
+`,
+			want: `
+we
+
+  want
+	yaml`,
+		},
+	} {
+		assert.Equal(t, testcase.want, TrimTrailingMultilineWhitespace(testcase.give))
+	}
+}


### PR DESCRIPTION
This makes it easier to author template tests, because editors tend to append a newline when saving files.

Previously, `ERR:` template test could not have trailing empty lines. I am using both _Vim_ and _IntelliJ_. Both make it hard to remove the last line break in the file. I spend a minute to figure it out, and in _Vim_ you can do `:set noendofline binary` for a buffer and it trims trailing whitespace. But that's a bother.

I think it is better testing UX this way. I held back from letting my IDE add a line break to existing `*.tpltest`.