### PR TITLE
Reformatting comments as per go fmt

### DIFF
--- a/pkg/schema/annotations.go
+++ b/pkg/schema/annotations.go
@@ -59,7 +59,7 @@ type TitleAnnotation struct {
 	pos   *filepos.Position
 }
 
-//DeprecatedAnnotation is a wrapper for a value provided via @schema/deprecated annotation
+// DeprecatedAnnotation is a wrapper for a value provided via @schema/deprecated annotation
 type DeprecatedAnnotation struct {
 	notice string
 	pos    *filepos.Position

--- a/pkg/yamlmeta/internal/yaml.v2/apic.go
+++ b/pkg/yamlmeta/internal/yaml.v2/apic.go
@@ -142,7 +142,7 @@ func yamlEmitterSetCanonical(emitter *yamlEmitterT, canonical bool) {
 	emitter.canonical = canonical
 }
 
-//// Set the indentation increment.
+// // Set the indentation increment.
 func yamlEmitterSetIndent(emitter *yamlEmitterT, indent int) {
 	if indent < 2 || indent > 9 {
 		indent = 2

--- a/pkg/yamlmeta/internal/yaml.v2/emitterc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/emitterc.go
@@ -133,10 +133,9 @@ func yamlEmitterEmit(emitter *yamlEmitterT, event *yamlEventT) bool {
 // Check if we need to accumulate more events before emitting.
 //
 // We accumulate extra
-//  - 1 event for DOCUMENT-START
-//  - 2 events for SEQUENCE-START
-//  - 3 events for MAPPING-START
-//
+//   - 1 event for DOCUMENT-START
+//   - 2 events for SEQUENCE-START
+//   - 3 events for MAPPING-START
 func yamlEmitterNeedMoreEvents(emitter *yamlEmitterT) bool {
 	if emitter.eventsHead == len(emitter.events) {
 		return true

--- a/pkg/yamlmeta/internal/yaml.v2/parserc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/parserc.go
@@ -173,7 +173,8 @@ func yamlParserStateMachine(parser *yamlParserT, event *yamlEventT) bool {
 
 // Parse the production:
 // stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
-//              ************
+//
+//	************
 func yamlParserParseStreamStart(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -195,9 +196,12 @@ func yamlParserParseStreamStart(parser *yamlParserT, event *yamlEventT) bool {
 
 // Parse the productions:
 // implicit_document    ::= block_node DOCUMENT-END*
-//                          *
+//
+//	*
+//
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-//                          *************************
+//
+//	*************************
 func yamlParserParseDocumentStart(parser *yamlParserT, event *yamlEventT, implicit bool) bool {
 
 	token := peekToken(parser)
@@ -280,8 +284,8 @@ func yamlParserParseDocumentStart(parser *yamlParserT, event *yamlEventT, implic
 
 // Parse the productions:
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-//                                                    ***********
 //
+//	***********
 func yamlParserParseDocumentContent(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -302,9 +306,10 @@ func yamlParserParseDocumentContent(parser *yamlParserT, event *yamlEventT) bool
 
 // Parse the productions:
 // implicit_document    ::= block_node DOCUMENT-END*
-//                                     *************
-// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //
+//	*************
+//
+// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 func yamlParserParseDocumentEnd(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -335,30 +340,41 @@ func yamlParserParseDocumentEnd(parser *yamlParserT, event *yamlEventT) bool {
 
 // Parse the productions:
 // block_node_or_indentless_sequence    ::=
-//                          ALIAS
-//                          *****
-//                          | properties (block_content | indentless_block_sequence)?
-//                            **********  *
-//                          | block_content | indentless_block_sequence
-//                            *
+//
+//	ALIAS
+//	*****
+//	| properties (block_content | indentless_block_sequence)?
+//	  **********  *
+//	| block_content | indentless_block_sequence
+//	  *
+//
 // block_node           ::= ALIAS
-//                          *****
-//                          | properties block_content?
-//                            ********** *
-//                          | block_content
-//                            *
+//
+//	*****
+//	| properties block_content?
+//	  ********** *
+//	| block_content
+//	  *
+//
 // flow_node            ::= ALIAS
-//                          *****
-//                          | properties flow_content?
-//                            ********** *
-//                          | flow_content
-//                            *
+//
+//	*****
+//	| properties flow_content?
+//	  ********** *
+//	| flow_content
+//	  *
+//
 // properties           ::= TAG ANCHOR? | ANCHOR TAG?
-//                          *************************
+//
+//	*************************
+//
 // block_content        ::= block_collection | flow_collection | SCALAR
-//                                                               ******
+//
+//	******
+//
 // flow_content         ::= flow_collection | SCALAR
-//                                            ******
+//
+//	******
 func yamlParserParseNode(parser *yamlParserT, event *yamlEventT, block, indentlessSequence bool) bool {
 	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
 
@@ -577,8 +593,8 @@ func yamlParserParseNode(parser *yamlParserT, event *yamlEventT, block, indentle
 
 // Parse the productions:
 // block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
-//                    ********************  *********** *             *********
 //
+//	********************  *********** *             *********
 func yamlParserParseBlockSequenceEntry(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
 		token := peekToken(parser)
@@ -633,7 +649,8 @@ func yamlParserParseBlockSequenceEntry(parser *yamlParserT, event *yamlEventT, f
 
 // Parse the productions:
 // indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
-//                           *********** *
+//
+//	*********** *
 func yamlParserParseIndentlessSequenceEntry(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -674,14 +691,14 @@ func yamlParserParseIndentlessSequenceEntry(parser *yamlParserT, event *yamlEven
 
 // Parse the productions:
 // block_mapping        ::= BLOCK-MAPPING_START
-//                          *******************
-//                          ((KEY block_node_or_indentless_sequence?)?
-//                            *** *
-//                          (VALUE block_node_or_indentless_sequence?)?)*
 //
-//                          BLOCK-END
-//                          *********
+//	*******************
+//	((KEY block_node_or_indentless_sequence?)?
+//	  *** *
+//	(VALUE block_node_or_indentless_sequence?)?)*
 //
+//	BLOCK-END
+//	*********
 func yamlParserParseBlockMappingKey(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
 		token := peekToken(parser)
@@ -732,13 +749,11 @@ func yamlParserParseBlockMappingKey(parser *yamlParserT, event *yamlEventT, firs
 // Parse the productions:
 // block_mapping        ::= BLOCK-MAPPING_START
 //
-//                          ((KEY block_node_or_indentless_sequence?)?
+//	((KEY block_node_or_indentless_sequence?)?
 //
-//                          (VALUE block_node_or_indentless_sequence?)?)*
-//                           ***** *
-//                          BLOCK-END
-//
-//
+//	(VALUE block_node_or_indentless_sequence?)?)*
+//	 ***** *
+//	BLOCK-END
 func yamlParserParseBlockMappingValue(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -766,16 +781,18 @@ func yamlParserParseBlockMappingValue(parser *yamlParserT, event *yamlEventT) bo
 
 // Parse the productions:
 // flow_sequence        ::= FLOW-SEQUENCE-START
-//                          *******************
-//                          (flow_sequence_entry FLOW-ENTRY)*
-//                           *                   **********
-//                          flow_sequence_entry?
-//                          *
-//                          FLOW-SEQUENCE-END
-//                          *****************
-// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                          *
 //
+//	*******************
+//	(flow_sequence_entry FLOW-ENTRY)*
+//	 *                   **********
+//	flow_sequence_entry?
+//	*
+//	FLOW-SEQUENCE-END
+//	*****************
+//
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//
+//	*
 func yamlParserParseFlowSequenceEntry(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
 		token := peekToken(parser)
@@ -842,11 +859,10 @@ func yamlParserParseFlowSequenceEntry(parser *yamlParserT, event *yamlEventT, fi
 	return true
 }
 
-//
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                      *** *
 //
+//	*** *
 func yamlParserParseFlowSequenceEntryMappingKey(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -866,8 +882,8 @@ func yamlParserParseFlowSequenceEntryMappingKey(parser *yamlParserT, event *yaml
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                                      ***** *
 //
+//	***** *
 func yamlParserParseFlowSequenceEntryMappingValue(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -890,8 +906,8 @@ func yamlParserParseFlowSequenceEntryMappingValue(parser *yamlParserT, event *ya
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                                                      *
 //
+//	*
 func yamlParserParseFlowSequenceEntryMappingEnd(parser *yamlParserT, event *yamlEventT) bool {
 	token := peekToken(parser)
 	if token == nil {
@@ -908,16 +924,17 @@ func yamlParserParseFlowSequenceEntryMappingEnd(parser *yamlParserT, event *yaml
 
 // Parse the productions:
 // flow_mapping         ::= FLOW-MAPPING-START
-//                          ******************
-//                          (flow_mapping_entry FLOW-ENTRY)*
-//                           *                  **********
-//                          flow_mapping_entry?
-//                          ******************
-//                          FLOW-MAPPING-END
-//                          ****************
-// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                          *           *** *
 //
+//	******************
+//	(flow_mapping_entry FLOW-ENTRY)*
+//	 *                  **********
+//	flow_mapping_entry?
+//	******************
+//	FLOW-MAPPING-END
+//	****************
+//
+// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//   - *** *
 func yamlParserParseFlowMappingKey(parser *yamlParserT, event *yamlEventT, first bool) bool {
 	if first {
 		token := peekToken(parser)
@@ -981,8 +998,7 @@ func yamlParserParseFlowMappingKey(parser *yamlParserT, event *yamlEventT, first
 
 // Parse the productions:
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                   *                  ***** *
-//
+//   - ***** *
 func yamlParserParseFlowMappingValue(parser *yamlParserT, event *yamlEventT, empty bool) bool {
 	token := peekToken(parser)
 	if token == nil {

--- a/pkg/yamlmeta/internal/yaml.v2/scannerc.go
+++ b/pkg/yamlmeta/internal/yaml.v2/scannerc.go
@@ -1506,11 +1506,11 @@ func yamlParserScanToNextToken(parser *yamlParserT) bool {
 // Scan a YAML-DIRECTIVE or TAG-DIRECTIVE token.
 //
 // Scope:
-//      %YAML    1.1    # a comment \n
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//      %TAG    !yaml!  tag:yaml.org,2002:  \n
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //
+//	%YAML    1.1    # a comment \n
+//	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//	%TAG    !yaml!  tag:yaml.org,2002:  \n
+//	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 func yamlParserScanDirective(parser *yamlParserT, token *yamlTokenT) bool {
 	// Eat '%'.
 	startMark := parser.mark
@@ -1607,11 +1607,11 @@ func yamlParserScanDirective(parser *yamlParserT, token *yamlTokenT) bool {
 // Scan the directive name.
 //
 // Scope:
-//      %YAML   1.1     # a comment \n
-//       ^^^^
-//      %TAG    !yaml!  tag:yaml.org,2002:  \n
-//       ^^^
 //
+//	%YAML   1.1     # a comment \n
+//	 ^^^^
+//	%TAG    !yaml!  tag:yaml.org,2002:  \n
+//	 ^^^
 func yamlParserScanDirectiveName(parser *yamlParserT, startMark yamlMarkT, name *[]byte) bool {
 	// Consume the directive name.
 	if parser.unread < 1 && !yamlParserUpdateBuffer(parser, 1) {
@@ -1646,8 +1646,9 @@ func yamlParserScanDirectiveName(parser *yamlParserT, startMark yamlMarkT, name 
 // Scan the value of VERSION-DIRECTIVE.
 //
 // Scope:
-//      %YAML   1.1     # a comment \n
-//           ^^^^^^
+//
+//	%YAML   1.1     # a comment \n
+//	     ^^^^^^
 func yamlParserScanVersionDirectiveValue(parser *yamlParserT, startMark yamlMarkT, major, minor *int8) bool {
 	// Eat whitespaces.
 	if parser.unread < 1 && !yamlParserUpdateBuffer(parser, 1) {
@@ -1685,10 +1686,11 @@ const maxNumberLength = 2
 // Scan the version number of VERSION-DIRECTIVE.
 //
 // Scope:
-//      %YAML   1.1     # a comment \n
-//              ^
-//      %YAML   1.1     # a comment \n
-//                ^
+//
+//	%YAML   1.1     # a comment \n
+//	        ^
+//	%YAML   1.1     # a comment \n
+//	          ^
 func yamlParserScanVersionDirectiveNumber(parser *yamlParserT, startMark yamlMarkT, number *int8) bool {
 
 	// Repeat while the next character is digit.
@@ -1722,9 +1724,9 @@ func yamlParserScanVersionDirectiveNumber(parser *yamlParserT, startMark yamlMar
 // Scan the value of a TAG-DIRECTIVE token.
 //
 // Scope:
-//      %TAG    !yaml!  tag:yaml.org,2002:  \n
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //
+//	%TAG    !yaml!  tag:yaml.org,2002:  \n
+//	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 func yamlParserScanTagDirectiveValue(parser *yamlParserT, startMark yamlMarkT, handle, prefix *[]byte) bool {
 	var handleValue, prefixValue []byte
 

--- a/pkg/yamlmeta/internal/yaml.v2/yaml.go
+++ b/pkg/yamlmeta/internal/yaml.v2/yaml.go
@@ -5,8 +5,7 @@
 //
 // Source code and other details for the project are available at GitHub:
 //
-//   https://github.com/go-yaml/yaml
-//
+//	https://github.com/go-yaml/yaml
 package yaml
 
 import (
@@ -76,16 +75,15 @@ type Marshaler interface {
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     var t T
-//     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	var t T
+//	yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-//
 func Unmarshal(in []byte, out interface{}) (err error) {
 	_, err = unmarshal(in, out, false)
 	return err
@@ -225,36 +223,35 @@ func unmarshal(in []byte, out interface{}, strict bool) (comments []Comment, err
 //
 // The field tag format accepted is:
 //
-//     `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
+//	`(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
 //
 // The following flags are currently supported:
 //
-//     omitempty    Only include the field if it's not set to the zero
-//                  value for the type or to empty slices or maps.
-//                  Zero valued structs will be omitted if all their public
-//                  fields are zero, unless they implement an IsZero
-//                  method (see the IsZeroer interface type), in which
-//                  case the field will be included if that method returns true.
+//	omitempty    Only include the field if it's not set to the zero
+//	             value for the type or to empty slices or maps.
+//	             Zero valued structs will be omitted if all their public
+//	             fields are zero, unless they implement an IsZero
+//	             method (see the IsZeroer interface type), in which
+//	             case the field will be included if that method returns true.
 //
-//     flow         Marshal using a flow style (useful for structs,
-//                  sequences and maps).
+//	flow         Marshal using a flow style (useful for structs,
+//	             sequences and maps).
 //
-//     inline       Inline the field, which must be a struct or a map,
-//                  causing all of its fields or keys to be processed as if
-//                  they were part of the outer struct. For maps, keys must
-//                  not conflict with the yaml keys of other struct fields.
+//	inline       Inline the field, which must be a struct or a map,
+//	             causing all of its fields or keys to be processed as if
+//	             they were part of the outer struct. For maps, keys must
+//	             not conflict with the yaml keys of other struct fields.
 //
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
-//     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
-//
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
+//	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()

--- a/pkg/yamlmeta/internal/yaml.v2/yamlh.go
+++ b/pkg/yamlmeta/internal/yaml.v2/yamlh.go
@@ -418,7 +418,9 @@ type yamlDocumentT struct {
 // The number of written bytes should be set to the size_read variable.
 //
 // [in,out]   data        A pointer to an application data specified by
-//                        yaml_parser_set_input().
+//
+//	yaml_parser_set_input().
+//
 // [out]      buffer      The buffer to write the data from the source.
 // [in]       size        The size of the buffer.
 // [out]      size_read   The actual number of bytes read from the source.
@@ -616,13 +618,14 @@ type yamlParserT struct {
 // @a buffer to the output.
 //
 // @param[in,out]   data        A pointer to an application data specified by
-//                              yaml_emitter_set_output().
+//
+//	yaml_emitter_set_output().
+//
 // @param[in]       buffer      The buffer with bytes to be written.
 // @param[in]       size        The size of the buffer.
 //
 // @returns On success, the handler should return @c 1.  If the handler failed,
 // the returned value should be @c 0.
-//
 type yamlWriteHandlerT func(emitter *yamlEmitterT, buffer []byte) error
 
 type yamlEmitterStateT int

--- a/pkg/yamlmeta/parser.go
+++ b/pkg/yamlmeta/parser.go
@@ -124,11 +124,12 @@ func (p *Parser) parseBytes(data []byte, lineCorrection int) (*DocumentSet, erro
 }
 
 // setPositionOfCollections assigns the Position of Maps and Arrays to their parent
-//   these kinds of nodes are not visible and therefore technically don't have a position.
-//   However, it is useful when communicating certain error cases to be able to reference
-//   a collection by line number.
-//   The position of the parent matches well with what the user sees. E.g. the MapItem that
-//   holds an Array is a great place to point at when referring to the entire array.
+//
+//	these kinds of nodes are not visible and therefore technically don't have a position.
+//	However, it is useful when communicating certain error cases to be able to reference
+//	a collection by line number.
+//	The position of the parent matches well with what the user sees. E.g. the MapItem that
+//	holds an Array is a great place to point at when referring to the entire array.
 func setPositionOfCollections(node Node, parent Node) {
 	if !node.GetPosition().IsKnown() {
 		if parent != nil {


### PR DESCRIPTION
Reformatting comments as per go fmt. 

It seems like with go `1.19.3`, go fmt has bit of tweak w.r.t. some of the comments.

This is the PR for comments to be on the similar lines as output of go fmt.