### PR TITLE
Respect filemarks for Starlark files

### DIFF
--- a/pkg/files/file.go
+++ b/pkg/files/file.go
@@ -246,8 +246,8 @@ func (r *File) IsLibrary() bool {
 		return true
 	}
 
-	// make exception for starlark files as they are just pure code
-	return r.matchesExt(starlarkExts)
+	// Starlark files are always libraries
+	return r.Type() == TypeStarlark
 }
 
 func (r *File) matchesExt(exts []string) bool {


### PR DESCRIPTION
... and plumb UI's stderr to Starlark's Print() so that even output from Starlark runtime respects UI settings.

Fixes #786