### PR TITLE
Bump go version to 1.20.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.5"
+          go-version: "1.20.1"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,5 +22,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.2
           args: -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.5"
+          go-version: "1.20.1"
 
       - name: generate website/generate.go
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.5"
+        go-version: "1.20.1"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.5"
+        go-version: "1.20.1"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Run Tests

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/ytt
       tool: ytt
-      goVersion: "1.19.5"
+      goVersion: "1.20.1"
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-ytt
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Bump go version to 1.20.1
Bump golangci-lint to 1.51.2 as go 1.20 support was added from 1.51.0 onwards