### PR TITLE
Bump golang to 1.20.3 and fix golint issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.50.1
+          version: v1.52.2
           args: -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.6"
+          go-version: "1.20.3"
 
       - name: generate website/generate.go
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.6"
+        go-version: "1.20.3"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.6"
+        go-version: "1.20.3"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Run Tests

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/ytt
       tool: ytt
-      goVersion: "1.19.6"
+      goVersion: "1.20.3"
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-ytt
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/pkg/schema/check.go
+++ b/pkg/schema/check.go
@@ -224,7 +224,7 @@ func (s *ScalarType) CheckType(node yamlmeta.Node) TypeCheck {
 // CheckType is a no-op because AnyType allows any value.
 //
 // Always returns an empty TypeCheck.
-func (a AnyType) CheckType(node yamlmeta.Node) TypeCheck {
+func (a AnyType) CheckType(_ yamlmeta.Node) TypeCheck {
 	return TypeCheck{}
 }
 

--- a/pkg/schema/type.go
+++ b/pkg/schema/type.go
@@ -199,7 +199,7 @@ func (t *DocumentType) SetDefaultValue(val interface{}) {
 }
 
 // SetDefaultValue is ignored as default values should be set on each MapItemType, individually.
-func (m *MapType) SetDefaultValue(val interface{}) {
+func (m *MapType) SetDefaultValue(_ interface{}) {
 	// TODO: determine if we should set the contents of a MapType by setting the given Map...?
 	return
 }
@@ -315,7 +315,7 @@ func (n *NullType) GetDescription() string {
 }
 
 // SetDescription sets the description of the type
-func (t *DocumentType) SetDescription(desc string) {}
+func (t *DocumentType) SetDescription(_ string) {}
 
 // SetDescription sets the description of the type
 func (m *MapType) SetDescription(desc string) {
@@ -323,7 +323,7 @@ func (m *MapType) SetDescription(desc string) {
 }
 
 // SetDescription sets the description of the type
-func (t *MapItemType) SetDescription(desc string) {}
+func (t *MapItemType) SetDescription(_ string) {}
 
 // SetDescription sets the description of the type
 func (a *ArrayType) SetDescription(desc string) {
@@ -331,7 +331,7 @@ func (a *ArrayType) SetDescription(desc string) {
 }
 
 // SetDescription sets the description of the type
-func (a *ArrayItemType) SetDescription(desc string) {}
+func (a *ArrayItemType) SetDescription(_ string) {}
 
 // SetDescription sets the description of the type
 func (s *ScalarType) SetDescription(desc string) {
@@ -389,7 +389,7 @@ func (n *NullType) GetTitle() string {
 }
 
 // SetTitle sets the title of the type
-func (t *DocumentType) SetTitle(title string) {}
+func (t *DocumentType) SetTitle(_ string) {}
 
 // SetTitle sets the title of the type
 func (m *MapType) SetTitle(title string) {
@@ -397,7 +397,7 @@ func (m *MapType) SetTitle(title string) {
 }
 
 // SetTitle sets the title of the type
-func (t *MapItemType) SetTitle(title string) {}
+func (t *MapItemType) SetTitle(_ string) {}
 
 // SetTitle sets the title of the type
 func (a *ArrayType) SetTitle(title string) {
@@ -405,7 +405,7 @@ func (a *ArrayType) SetTitle(title string) {
 }
 
 // SetTitle sets the title of the type
-func (a *ArrayItemType) SetTitle(title string) {}
+func (a *ArrayItemType) SetTitle(_ string) {}
 
 // SetTitle sets the title of the type
 func (s *ScalarType) SetTitle(title string) {
@@ -463,7 +463,7 @@ func (n *NullType) GetExamples() []Example {
 }
 
 // SetExamples sets the description and example of the type
-func (t *DocumentType) SetExamples(data []Example) {}
+func (t *DocumentType) SetExamples(_ []Example) {}
 
 // SetExamples sets the description and example of the type
 func (m *MapType) SetExamples(exs []Example) {
@@ -471,7 +471,7 @@ func (m *MapType) SetExamples(exs []Example) {
 }
 
 // SetExamples sets the description and example of the type
-func (t *MapItemType) SetExamples(exs []Example) {}
+func (t *MapItemType) SetExamples(_ []Example) {}
 
 // SetExamples sets the description and example of the type
 func (a *ArrayType) SetExamples(exs []Example) {
@@ -479,7 +479,7 @@ func (a *ArrayType) SetExamples(exs []Example) {
 }
 
 // SetExamples sets the description and example of the type
-func (a *ArrayItemType) SetExamples(exs []Example) {}
+func (a *ArrayItemType) SetExamples(_ []Example) {}
 
 // SetExamples sets the description and example of the type
 func (s *ScalarType) SetExamples(exs []Example) {
@@ -538,7 +538,7 @@ func (n *NullType) IsDeprecated() (bool, string) {
 }
 
 // SetDeprecated sets the deprecated field value
-func (t *DocumentType) SetDeprecated(deprecated bool, notice string) {}
+func (t *DocumentType) SetDeprecated(_ bool, _ string) {}
 
 // SetDeprecated sets the deprecated field value
 func (m *MapType) SetDeprecated(deprecated bool, notice string) {
@@ -547,7 +547,7 @@ func (m *MapType) SetDeprecated(deprecated bool, notice string) {
 }
 
 // SetDeprecated sets the deprecated field value
-func (t *MapItemType) SetDeprecated(deprecated bool, notice string) {}
+func (t *MapItemType) SetDeprecated(_ bool, _ string) {}
 
 // SetDeprecated sets the deprecated field value
 func (a *ArrayType) SetDeprecated(deprecated bool, notice string) {
@@ -556,7 +556,7 @@ func (a *ArrayType) SetDeprecated(deprecated bool, notice string) {
 }
 
 // SetDeprecated sets the deprecated field value
-func (a *ArrayItemType) SetDeprecated(deprecated bool, notice string) {}
+func (a *ArrayItemType) SetDeprecated(_ bool, _ string) {}
 
 // SetDeprecated sets the deprecated field value
 func (s *ScalarType) SetDeprecated(deprecated bool, notice string) {

--- a/pkg/yttlibrary/assert.go
+++ b/pkg/yttlibrary/assert.go
@@ -43,7 +43,7 @@ func (m AssertModule) AsModule() starlark.StringDict {
 }
 
 // Equals compares two values for equality
-func (m AssertModule) Equals(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) Equals(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 2 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 2)
 	}
@@ -89,7 +89,7 @@ func (m AssertModule) asString(value starlark.Value) (string, error) {
 }
 
 // Fail is a core.StarlarkFunc that forces a Starlark failure.
-func (m AssertModule) Fail(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) Fail(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -104,7 +104,7 @@ func (m AssertModule) Fail(thread *starlark.Thread, f *starlark.Builtin, args st
 
 // TryTo is a core.StarlarkFunc that attempts to invoke the passed in starlark.Callable, converting any error into
 // an error message.
-func (m AssertModule) TryTo(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) TryTo(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -185,7 +185,7 @@ func NewAssertMaxLen(maximum starlark.Int) *Assertion {
 }
 
 // MaxLen is a core.StarlarkFunc wrapping NewAssertMaxLen()
-func (m AssertModule) MaxLen(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) MaxLen(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -209,7 +209,7 @@ func NewAssertMinLen(minimum starlark.Int) *Assertion {
 }
 
 // MinLen is a core.StarlarkFunc wrapping NewAssertMinLen()
-func (m AssertModule) MinLen(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) MinLen(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -233,7 +233,7 @@ func NewAssertMin(min starlark.Value) *Assertion {
 }
 
 // Min is a core.StarlarkFunc wrapping NewAssertMin()
-func (m AssertModule) Min(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) Min(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -254,7 +254,7 @@ func NewAssertMax(max starlark.Value) *Assertion {
 }
 
 // Max is a core.StarlarkFunc wrapping NewAssertMax()
-func (m AssertModule) Max(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) Max(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -273,7 +273,7 @@ func NewAssertNotNull() *Assertion {
 }
 
 // NotNull is a core.StarlarkFunc wrapping NewAssertNotNull()
-func (m AssertModule) NotNull(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) NotNull(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() > 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want at most %d", args.Len(), 1)
 	}
@@ -293,7 +293,7 @@ func NewAssertOneNotNull(keys starlark.Sequence) *Assertion {
 }
 
 // OneNotNull is a core.StarlarkFunc wrapping NewAssertOneNotNull()
-func (m AssertModule) OneNotNull(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) OneNotNull(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() > 1 {
 		return starlark.None, fmt.Errorf("got %d arguments, want %d", args.Len(), 1)
 	}
@@ -391,7 +391,7 @@ func NewAssertOneOf(enum starlark.Sequence) *Assertion {
 }
 
 // OneOf is a core.StarlarkFunc wrapping NewAssertOneOf()
-func (m AssertModule) OneOf(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m AssertModule) OneOf(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() == 0 {
 		return starlark.None, fmt.Errorf("got %d arguments, want at least %d", args.Len(), 1)
 	}

--- a/pkg/yttlibrary/ip.go
+++ b/pkg/yttlibrary/ip.go
@@ -28,7 +28,7 @@ var (
 
 type ipModule struct{}
 
-func (m ipModule) ParseAddr(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m ipModule) ParseAddr(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}
@@ -72,7 +72,7 @@ func (av *IPAddrValue) ConversionHint() string {
 }
 
 // IsIPv4 is a core.StarlarkFunc that reveals whether this value is an IPv4 address.
-func (av *IPAddrValue) IsIPv4(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (av *IPAddrValue) IsIPv4(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 0 {
 		return starlark.None, fmt.Errorf("expected no argument")
 	}
@@ -81,7 +81,7 @@ func (av *IPAddrValue) IsIPv4(thread *starlark.Thread, f *starlark.Builtin, args
 }
 
 // IsIPv6 is a core.StarlarkFunc that reveals whether this value is an IPv6 address.
-func (av *IPAddrValue) IsIPv6(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (av *IPAddrValue) IsIPv6(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 0 {
 		return starlark.None, fmt.Errorf("expected no argument")
 	}
@@ -89,7 +89,7 @@ func (av *IPAddrValue) IsIPv6(thread *starlark.Thread, f *starlark.Builtin, args
 	return starlark.Bool(isV6), nil
 }
 
-func (av *IPAddrValue) string(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (av *IPAddrValue) string(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 0 {
 		return starlark.None, fmt.Errorf("expected no argument")
 	}
@@ -97,7 +97,7 @@ func (av *IPAddrValue) string(thread *starlark.Thread, f *starlark.Builtin, args
 }
 
 // ParseCIDR is a core.StarlarkFunc that extracts the IP address and IP network value from a CIDR expression
-func (m ipModule) ParseCIDR(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (m ipModule) ParseCIDR(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}
@@ -141,7 +141,7 @@ func (inv *IPNetValue) ConversionHint() string {
 }
 
 // Addr is a core.StarlarkFunc that returns the masked address portion of the network value
-func (inv *IPNetValue) Addr(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (inv *IPNetValue) Addr(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 0 {
 		return starlark.None, fmt.Errorf("expected no argument")
 	}
@@ -150,7 +150,7 @@ func (inv *IPNetValue) Addr(thread *starlark.Thread, f *starlark.Builtin, args s
 	return ip.AsStarlarkValue(), nil
 }
 
-func (inv *IPNetValue) string(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (inv *IPNetValue) string(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 0 {
 		return starlark.None, fmt.Errorf("expected no argument")
 	}

--- a/pkg/yttlibrary/yaml.go
+++ b/pkg/yttlibrary/yaml.go
@@ -28,7 +28,7 @@ var (
 type yamlModule struct{}
 
 // starlarkEncode adapts a call from Starlark to yamlModule.Encode()
-func (b yamlModule) starlarkEncode(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (b yamlModule) starlarkEncode(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}
@@ -69,7 +69,7 @@ func (b yamlModule) Encode(goValue interface{}) (string, error) {
 }
 
 // Decode is a core.StarlarkFunc that parses the provided input from YAML format into dicts, lists, and scalars
-func (b yamlModule) starlarkDecode(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (b yamlModule) starlarkDecode(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}

--- a/pkg/yttlibraryext/toml/toml.go
+++ b/pkg/yttlibraryext/toml/toml.go
@@ -37,7 +37,7 @@ func init() {
 type tomlModule struct{}
 
 // Encode is a core.StarlarkFunc that renders the provided input into a TOML formatted string
-func (b tomlModule) Encode(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (b tomlModule) Encode(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}
@@ -80,7 +80,7 @@ func (b tomlModule) Encode(thread *starlark.Thread, f *starlark.Builtin, args st
 }
 
 // Decode is a core.StarlarkFunc that parses the provided input from TOML format into dicts, lists, and scalars
-func (b tomlModule) Decode(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func (b tomlModule) Decode(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if args.Len() != 1 {
 		return starlark.None, fmt.Errorf("expected exactly one argument")
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -287,7 +287,7 @@ new_thing: new
 			{"--data-values-file": "-"},
 			{"-f": "-"},
 		}
-		actualOutput := runYttExpectingError(t, nil, "../../examples/data-values/values-file.yml", flags, nil)
+		actualOutput := runYttExpectingError(t, nil, flags, nil)
 		expectedOutput := "ytt: Error: Extracting data value from file:\n  Reading file 'stdin.yml':\n    Standard input has already been read, has the '-' argument been used in more than one flag?\n"
 		require.Equal(t, expectedOutput, actualOutput)
 	})
@@ -461,7 +461,7 @@ func runYtt(t *testing.T, files testInputFiles, stdinFileName string, flags yttF
 	return string(output)
 }
 
-func runYttExpectingError(t *testing.T, files testInputFiles, stdinFileName string, flags yttFlags, envs []string) string {
+func runYttExpectingError(t *testing.T, files testInputFiles, flags yttFlags, envs []string) string {
 	command, stdError := buildCommand(files, flags, envs)
 
 	_, err := command.Output()

--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -251,7 +251,7 @@ func (l DefaultTemplateLoader) FindCompiledTemplate(_ string) *template.Compiled
 
 // Load provides the ability to load any module from the ytt standard library (including `@ytt:data` populated with
 // DefaultTemplateLoader.DataValues)
-func (l DefaultTemplateLoader) Load(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+func (l DefaultTemplateLoader) Load(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 	api := yttlibrary.NewAPI(l.CompiledTemplate.TplReplaceNode,
 		yttlibrary.NewDataModule(&l.DataValues, nil), nil, nil)
 	return api.FindModule(strings.TrimPrefix(module, "@ytt:"))


### PR DESCRIPTION
- Bump golang to 1.20.3 to get rid of CVE's in go 1.19.6