### PR TITLE
Bump golang to 1.20.5 in  v0.44.x line

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20.4"
+          go-version: "1.20.5"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20.3"
+          go-version: "1.20.4"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20.4"
+          go-version: "1.20.5"
 
       - name: generate website/generate.go
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20.3"
+          go-version: "1.20.4"
 
       - name: generate website/generate.go
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20.4"
+        go-version: "1.20.5"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20.3"
+        go-version: "1.20.4"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20.4"
+        go-version: "1.20.5"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Run Tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20.3"
+        go-version: "1.20.4"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Run Tests

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/ytt
       tool: ytt
-      goVersion: "1.20.4"
+      goVersion: "1.20.5"
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       repo: carvel-dev/ytt
       tool: ytt
-      goVersion: "1.20.3"
+      goVersion: "1.20.4"
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Bump golang to 1.20.5 in  v0.44.x line manually as cherry-pick bot is creating issue