### PR TITLE
don't modify input when converting to orderedmap

### DIFF
--- a/pkg/orderedmap/convert.go
+++ b/pkg/orderedmap/convert.go
@@ -70,20 +70,21 @@ func (c Conversion) fromUnorderedMaps(object interface{}) interface{} {
 		panic("Expected map[interface{}]interface{} instead of *unordered.Map in fromUnorderedMaps")
 
 	case []interface{}:
+		result := make([]interface{}, len(typedObj))
 		for i, item := range typedObj {
-			typedObj[i] = c.fromUnorderedMaps(item)
+			result[i] = c.fromUnorderedMaps(item)
 		}
-		return typedObj
+		return result
 
 	// some sources (e.g. toml library) yield specific type of slices.
 	// slices in Go are not covariant, so each flavor of slice must have its own case, here.
 	// process these exactly the same way we do for generic slices (prior case)
 	case []map[string]interface{}:
-		resultArray := make([]interface{}, len(typedObj))
+		result := make([]interface{}, len(typedObj))
 		for i, item := range typedObj {
-			resultArray[i] = c.fromUnorderedMaps(item)
+			result[i] = c.fromUnorderedMaps(item)
 		}
-		return resultArray
+		return result
 	default:
 		return typedObj
 	}

--- a/pkg/orderedmap/convert_test.go
+++ b/pkg/orderedmap/convert_test.go
@@ -1,3 +1,5 @@
+// Copyright 2020 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
 package orderedmap_test
 
 import (

--- a/pkg/orderedmap/convert_test.go
+++ b/pkg/orderedmap/convert_test.go
@@ -1,0 +1,23 @@
+package orderedmap_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vmware-tanzu/carvel-ytt/pkg/orderedmap"
+)
+
+func TestFromUnorderedMaps(t *testing.T) {
+	inputA := map[string]interface{}{
+		"key": []interface{}{map[string]interface{}{"nestedKey": "nestedValue"}},
+	}
+	inputB := map[string]interface{}{
+		"key": []interface{}{map[string]interface{}{"nestedKey": "nestedValue"}},
+	}
+
+	orderedmap.Conversion{Object: inputA}.FromUnorderedMaps()
+
+	if !reflect.DeepEqual(inputA, inputB) {
+		t.Errorf("Nested object was modified. Got: %v, Expected: %v", inputA, inputB)
+	}
+}

--- a/pkg/orderedmap/convert_test.go
+++ b/pkg/orderedmap/convert_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/vmware-tanzu/carvel-ytt/pkg/orderedmap"
+	"carvel.dev/ytt/pkg/orderedmap"
 )
 
 func TestFromUnorderedMaps(t *testing.T) {


### PR DESCRIPTION
I'm integrating with ytt as a library and noticed that when I convert an object to an `orderedmap.Map` the input object gets modified. I'm not sure if that's intended but right now it requires me to deepcopy the input before converting which is a little unfortunate.