### PR TITLE
Print full path rather than RelativePath only.

### DIFF
--- a/pkg/cmd/template/data_values_flags.go
+++ b/pkg/cmd/template/data_values_flags.go
@@ -168,7 +168,7 @@ func (s *DataValuesFlags) file(fullPath string, strict bool) ([]*datavalues.Enve
 		}
 		docSet, err := yamlmeta.NewDocumentSetFromBytes(contents, docSetOpts)
 		if err != nil {
-			return nil, fmt.Errorf("Unmarshaling YAML data values file '%s': %s", dvFile.RelativePath(), err)
+			return nil, fmt.Errorf("Unmarshaling YAML data values file '%s': %s", dvFile.Description(), err)
 		}
 
 		for _, doc := range docSet.Items {

--- a/pkg/files/sources.go
+++ b/pkg/files/sources.go
@@ -55,7 +55,7 @@ type LocalSource struct {
 
 func NewLocalSource(path, dir string) LocalSource { return LocalSource{path, dir} }
 
-func (s LocalSource) Description() string { return fmt.Sprintf("file '%s'", s.path) }
+func (s LocalSource) Description() string { return fmt.Sprintf("file %s", s.path) }
 
 func (s LocalSource) RelativePath() (string, error) {
 	if s.dir == "" {

--- a/pkg/files/sources.go
+++ b/pkg/files/sources.go
@@ -55,6 +55,7 @@ type LocalSource struct {
 
 func NewLocalSource(path, dir string) LocalSource { return LocalSource{path, dir} }
 
+// Description return LocalSource's (i.e. file's) path
 func (s LocalSource) Description() string { return fmt.Sprintf("file %s", s.path) }
 
 func (s LocalSource) RelativePath() (string, error) {

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -149,7 +149,7 @@ func (l *TemplateLoader) EvalPlainYAML(file *files.File) (*yamlmeta.DocumentSet,
 
 	docSet, err := yamlmeta.NewDocumentSetFromBytes(fileBs, docSetOpts)
 	if err != nil {
-		return nil, fmt.Errorf("Unmarshaling YAML template '%s': %s", file.RelativePath(), err)
+		return nil, fmt.Errorf("Unmarshaling YAML template '%s': %s", file.Description(), err)
 	}
 
 	return docSet, nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -292,6 +292,21 @@ new_thing: new
 	})
 }
 
+func TestProcessingFileWithError(t *testing.T) {
+	t.Run("invalidYamlFile", func(t *testing.T) {
+		tempInputDir, err := os.MkdirTemp(os.TempDir(), "ytt-check-dir")
+		require.NoError(t, err)
+		err = os.WriteFile(tempInputDir+"/config.yaml", []byte(`apiVersion: "v1"
+key value`), 0666)
+		require.NoError(t, err)
+		defer os.Remove(tempInputDir)
+
+		actualOutput := runYttExpectingError(t, testInputFiles{tempInputDir + "/config.yaml"}, nil, nil)
+		expectedOutput := "ytt: Error: Unmarshaling YAML template 'file " + tempInputDir + "/config.yaml': yaml: line 3: could not find expected ':'\n"
+		require.Equal(t, expectedOutput, actualOutput)
+	})
+}
+
 func TestCheckDirectoryOutput(t *testing.T) {
 	tempOutputDir, err := os.MkdirTemp(os.TempDir(), "ytt-check-dir")
 	require.NoError(t, err)


### PR DESCRIPTION
targets resolution of carvel-dev/ytt/issues/895

This PR just switches to print each file's `Description()` rather than `RelativePath()`. In order to keep quoting consistent, some single quotes were removed.