### PR TITLE
Bump go version to 1.22.3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.22.2"
-      - uses: actions/checkout@v2
+          go-version: "1.22"
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.52.2
+          version: v1.58
           args: -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.22.2"
+          go-version: '1.22'
       
       - name: Set up Cosign
         uses: sigstore/cosign-installer@v3    

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: "1.22.2"
+        go-version: '1.22'
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: src/github.com/${{ github.repository }}
         fetch-depth: 0

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: "1.22.2"
+        go-version: '1.22'
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Run Tests
       shell: powershell
       run: |

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,6 +1,7 @@
 name: Trivy CVE Dependency Scanner
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
@@ -10,7 +11,7 @@ jobs:
     with:
       repo: carvel-dev/ytt
       tool: ytt
-      goVersion: "1.22.2"
+      goVersion: '1.22'
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       slackWebhookURL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   enable:
     - goheader
     - revive
-    - deadcode
     - unused
   disable-all: true
 # all available settings of specific linters
@@ -12,11 +11,16 @@ linters-settings:
       regexp:
         copyright-year: 20[0-9][0-9]
     template-path: code-header-template.txt
+  revive:
+    enable-all: true
+    rules:
+    - name: dot-imports
+      disabled: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
   new-from-rev: bd77aced0a1cd6d6f3ecd3ed04c1832e1c513ab0
 run:
-  skip-dirs:
+  exclude-dirs:
     - pkg/yamlmeta/internal

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -19,7 +19,7 @@ func NewCmd(o *template.Options) *cobra.Command {
 		Use:     "template",
 		Aliases: []string{"t", "tpl"},
 		Short:   "Process YAML templates (deprecated; use top-level command -- e.g. `ytt -f-` instead of `ytt template -f-`)",
-		RunE:    func(c *cobra.Command, args []string) error { return o.Run() },
+		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
 	}
 	o.BindFlags(cmd.Flags())
 	return cmd

--- a/pkg/yttlibrary/assert.go
+++ b/pkg/yttlibrary/assert.go
@@ -316,7 +316,7 @@ func (m AssertModule) OneNotNull(_ *starlark.Thread, _ *starlark.Builtin, args s
 }
 
 func (m AssertModule) oneNotNullCheck(keys starlark.Sequence) core.StarlarkFunc {
-	return func(thread *starlark.Thread, f *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 		if args.Len() != 1 {
 			return starlark.None, fmt.Errorf("check: got %d arguments, want %d", args.Len(), 1)
 		}

--- a/pkg/yttlibrary/math.go
+++ b/pkg/yttlibrary/math.go
@@ -156,7 +156,7 @@ func (m MathModule) AsModule() starlark.StringDict {
 // newUnaryBuiltin wraps a unary floating-point Go function
 // as a Starlark built-in that accepts int or float arguments.
 func (m MathModule) newUnaryBuiltin(name string, fn func(float64) float64) *starlark.Builtin {
-	return starlark.NewBuiltin(name, m.warnOnCall(core.ErrWrapper(func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.NewBuiltin(name, m.warnOnCall(core.ErrWrapper(func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 		if args.Len() != 1 {
 			return starlark.None, fmt.Errorf("expected exactly one argument")
 		}
@@ -173,7 +173,7 @@ func (m MathModule) newUnaryBuiltin(name string, fn func(float64) float64) *star
 // newBinaryBuiltin wraps a binary floating-point Go function
 // as a Starlark built-in that accepts int or float arguments.
 func (m MathModule) newBinaryBuiltin(name string, fn func(float64, float64) float64) *starlark.Builtin {
-	return starlark.NewBuiltin(name, m.warnOnCall(core.ErrWrapper(func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.NewBuiltin(name, m.warnOnCall(core.ErrWrapper(func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 		if args.Len() != 2 {
 			return starlark.None, fmt.Errorf("expected exactly two arguments")
 		}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -317,7 +317,7 @@ func TestJsonOutput(t *testing.T) {
 
 func TestPlaygroundExamplesExecuteWithoutError(t *testing.T) {
 	t.Run("Basics", func(t *testing.T) {
-		filepath.WalkDir("../../examples/playground/basics", func(path string, d fs.DirEntry, err error) error {
+		filepath.WalkDir("../../examples/playground/basics", func(path string, d fs.DirEntry, _ error) error {
 			if !d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -336,7 +336,7 @@ func TestPlaygroundExamplesExecuteWithoutError(t *testing.T) {
 		})
 	})
 	t.Run("Overlays", func(t *testing.T) {
-		filepath.WalkDir("../../examples/playground/overlays", func(path string, d fs.DirEntry, err error) error {
+		filepath.WalkDir("../../examples/playground/overlays", func(path string, d fs.DirEntry, _ error) error {
 			if !d.IsDir() {
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
* Bump go version to v1.22.3
  * Use go line in go.mod to define minimum patch version
* Bump linter to 1.58
* Fix linter issues
  * Remove deadcode linter as it's deprecated
  * Allow dot-imports as it's useful in unit tests
  * Use `_` as name of unused parameters
* Add workflow_dispatcher as an event in trivy scan workflow (to allow manually triggering a trivy scan)