### PR TITLE
Bump golang to 1.23.7

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58
+          version: v1.64
           args: -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v1.58
           args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
-  new-from-rev: bd77aced0a1cd6d6f3ecd3ed04c1832e1c513ab0
-run:
   exclude-dirs:
     - pkg/yamlmeta/internal
+  new-from-rev: bd77aced0a1cd6d6f3ecd3ed04c1832e1c513ab0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,10 +15,23 @@ linters-settings:
     rules:
     - name: dot-imports
       disabled: true
+    - name: line-length-limit
+      disabled: true
+    - name: add-constant
+      disabled: false
+      arguments:
+          - maxLitCount: "3"
+            allowStrs: '""'
+            allowInts: "0,1,2"
+            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+    - name: cognitive-complexity
+      disabled: false
+      exclude: ["TEST"]
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
   exclude-dirs:
     - pkg/yamlmeta/internal
+    - pkg/spell
   new-from-rev: bd77aced0a1cd6d6f3ecd3ed04c1832e1c513ab0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters-settings:
         copyright-year: 20[0-9][0-9]
     template-path: code-header-template.txt
   revive:
-    enable-all-rules: true
     rules:
     - name: dot-imports
       disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters-settings:
         copyright-year: 20[0-9][0-9]
     template-path: code-header-template.txt
   revive:
-    enable-all: true
+    enable-all-rules: true
     rules:
     - name: dot-imports
       disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,15 +18,9 @@ linters-settings:
     - name: line-length-limit
       disabled: true
     - name: add-constant
-      disabled: false
-      arguments:
-          - maxLitCount: "3"
-            allowStrs: '""'
-            allowInts: "0,1,2"
-            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+      disabled: true
     - name: cognitive-complexity
-      disabled: false
-      exclude: ["TEST"]
+      disabled: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.23.3
+go 1.23.7
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Bumping golang version fixes below CVEs present in stdlib and golang
- CVE-2024-45336
- CVE-2024-45341
- CVE-2025-22866