### PR TITLE
Bump new from rev git sha

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58
+          version: v1.64
           args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters-settings:
         copyright-year: 20[0-9][0-9]
     template-path: code-header-template.txt
   revive:
-    enable-all: true
+    enable-all-rules: true
     rules:
     - name: dot-imports
       disabled: true
@@ -20,7 +20,6 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-use-default: false
-  new-from-rev: bd77aced0a1cd6d6f3ecd3ed04c1832e1c513ab0
-run:
   exclude-dirs:
     - pkg/yamlmeta/internal
+  new-from-rev: 07925eaf42bdbd6dc6d6ec802b9bc9aff1b67fd5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.23.6
+go 1.23.7
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
- Bump new-from-rev git sha to latest commit in develop to fix linter issues
- Bump golang version to 1.23.7