### PR TITLE
Convert data module values once in TemplateLoader

### DIFF
--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -52,8 +52,11 @@ func NewTemplateLoader(values *datavalues.Envelope, libraryValuess []*datavalues
 	}
 
 	return &TemplateLoader{
-		ui:                 ui,
-		values:             core.NewGoValueWithOpts(values.Doc.AsInterface(), core.GoValueOpts{MapIsStruct: true}).AsStarlarkValue(),
+		ui: ui,
+		values: core.NewGoValueWithOpts(
+			values.Doc.AsInterface(),
+			core.GoValueOpts{MapIsStruct: true},
+		).AsStarlarkValue(),
 		libraryValuess:     libraryValuess,
 		librarySchemas:     librarySchemas,
 		opts:               opts,

--- a/pkg/workspace/template_loader.go
+++ b/pkg/workspace/template_loader.go
@@ -10,6 +10,7 @@ import (
 	"carvel.dev/ytt/pkg/cmd/ui"
 	"carvel.dev/ytt/pkg/files"
 	"carvel.dev/ytt/pkg/template"
+	"carvel.dev/ytt/pkg/template/core"
 	"carvel.dev/ytt/pkg/texttemplate"
 	"carvel.dev/ytt/pkg/workspace/datavalues"
 	"carvel.dev/ytt/pkg/yamlmeta"
@@ -20,7 +21,7 @@ import (
 
 type TemplateLoader struct {
 	ui                 ui.UI
-	values             *datavalues.Envelope
+	values             starlark.Value
 	libraryValuess     []*datavalues.Envelope
 	librarySchemas     []*datavalues.SchemaEnvelope
 	opts               TemplateLoaderOpts
@@ -52,7 +53,7 @@ func NewTemplateLoader(values *datavalues.Envelope, libraryValuess []*datavalues
 
 	return &TemplateLoader{
 		ui:                 ui,
-		values:             values,
+		values:             core.NewGoValueWithOpts(values.Doc.AsInterface(), core.GoValueOpts{MapIsStruct: true}).AsStarlarkValue(),
 		libraryValuess:     libraryValuess,
 		librarySchemas:     librarySchemas,
 		opts:               opts,
@@ -195,7 +196,7 @@ func (l *TemplateLoader) EvalYAML(libraryCtx LibraryExecutionContext, file *file
 	l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
 
 	yttLibrary := yttlibrary.NewAPI(compiledTemplate.TplReplaceNode,
-		yttlibrary.NewDataModule(l.values.Doc, DataLoader{libraryCtx}),
+		yttlibrary.NewDataModule(l.values, DataLoader{libraryCtx}),
 		NewLibraryModule(libraryCtx, l.libraryExecFactory, l.libraryValuess, l.librarySchemas).AsModule(), l.ui)
 
 	thread := l.newThread(libraryCtx, yttLibrary, file)
@@ -237,7 +238,7 @@ func (l *TemplateLoader) EvalText(libraryCtx LibraryExecutionContext, file *file
 	l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
 
 	yttLibrary := yttlibrary.NewAPI(compiledTemplate.TplReplaceNode,
-		yttlibrary.NewDataModule(l.values.Doc, DataLoader{libraryCtx}),
+		yttlibrary.NewDataModule(l.values, DataLoader{libraryCtx}),
 		NewLibraryModule(libraryCtx, l.libraryExecFactory, l.libraryValuess, l.librarySchemas).AsModule(), l.ui)
 
 	thread := l.newThread(libraryCtx, yttLibrary, file)
@@ -267,7 +268,7 @@ func (l *TemplateLoader) EvalStarlark(libraryCtx LibraryExecutionContext, file *
 	l.ui.Debugf("### template\n%s", compiledTemplate.DebugCodeAsString())
 
 	yttLibrary := yttlibrary.NewAPI(compiledTemplate.TplReplaceNode,
-		yttlibrary.NewDataModule(l.values.Doc, DataLoader{libraryCtx}),
+		yttlibrary.NewDataModule(l.values, DataLoader{libraryCtx}),
 		NewLibraryModule(libraryCtx, l.libraryExecFactory, l.libraryValuess, l.librarySchemas).AsModule(), l.ui)
 
 	thread := l.newThread(libraryCtx, yttLibrary, file)

--- a/pkg/yttlibrary/data.go
+++ b/pkg/yttlibrary/data.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"carvel.dev/ytt/pkg/template/core"
-	"carvel.dev/ytt/pkg/yamlmeta"
 	"github.com/k14s/starlark-go/starlark"
 	"github.com/k14s/starlark-go/starlarkstruct"
 )
@@ -22,9 +21,8 @@ type DataLoader interface {
 	FileData(string) ([]byte, error)
 }
 
-func NewDataModule(values *yamlmeta.Document, loader DataLoader) DataModule {
-	val := core.NewGoValueWithOpts(values.AsInterface(), core.GoValueOpts{MapIsStruct: true})
-	return DataModule{val.AsStarlarkValue(), loader}
+func NewDataModule(values starlark.Value, loader DataLoader) DataModule {
+	return DataModule{values, loader}
 }
 
 func (b DataModule) AsModule() starlark.StringDict {

--- a/pkg/yttlibrary/data.go
+++ b/pkg/yttlibrary/data.go
@@ -21,6 +21,8 @@ type DataLoader interface {
 	FileData(string) ([]byte, error)
 }
 
+// NewDataModule constructs a new instance of DataModule,
+// used to access data values and files
 func NewDataModule(values starlark.Value, loader DataLoader) DataModule {
 	return DataModule{values, loader}
 }

--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"carvel.dev/ytt/pkg/template"
+	"carvel.dev/ytt/pkg/template/core"
 	"carvel.dev/ytt/pkg/version"
 	"carvel.dev/ytt/pkg/yamlmeta"
 	"carvel.dev/ytt/pkg/yamltemplate"
@@ -252,7 +253,7 @@ func (l DefaultTemplateLoader) FindCompiledTemplate(_ string) *template.Compiled
 // DefaultTemplateLoader.DataValues)
 func (l DefaultTemplateLoader) Load(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 	api := yttlibrary.NewAPI(l.CompiledTemplate.TplReplaceNode,
-		yttlibrary.NewDataModule(&l.DataValues, nil), nil, nil)
+		yttlibrary.NewDataModule(core.NewGoValueWithOpts(l.DataValues.AsInterface(), core.GoValueOpts{MapIsStruct: true}).AsStarlarkValue(), nil), nil, nil)
 	return api.FindModule(strings.TrimPrefix(module, "@ytt:"))
 }
 

--- a/test/filetests/filetests.go
+++ b/test/filetests/filetests.go
@@ -253,7 +253,10 @@ func (l DefaultTemplateLoader) FindCompiledTemplate(_ string) *template.Compiled
 // DefaultTemplateLoader.DataValues)
 func (l DefaultTemplateLoader) Load(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 	api := yttlibrary.NewAPI(l.CompiledTemplate.TplReplaceNode,
-		yttlibrary.NewDataModule(core.NewGoValueWithOpts(l.DataValues.AsInterface(), core.GoValueOpts{MapIsStruct: true}).AsStarlarkValue(), nil), nil, nil)
+		yttlibrary.NewDataModule(
+			core.NewGoValueWithOpts(l.DataValues.AsInterface(),
+				core.GoValueOpts{MapIsStruct: true},
+			).AsStarlarkValue(), nil), nil, nil)
 	return api.FindModule(strings.TrimPrefix(module, "@ytt:"))
 }
 


### PR DESCRIPTION
Convert the document data values into a `starlark.Value` once in template loader instead of every time a file is evaluated. Resolves #953 

A rough benchmark of ytt called from the command line (that I'm unable to share, though see the issue for a public reproduction) yields a performance improvement as follows:
```
'develop' (mean ± σ): 5.561s ± 0.300s    [User: 5.437s, System: 0.071s]
this PR   (mean ± σ): 0.631s ± 0.078s    [User: 0.585s, System: 0.038s]
```