### PR TITLE
Bump go to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Fixes [CVE-2025-22871](https://github.com/advisories/GHSA-g9pc-8g42-g6vq) in stdlib