### PR TITLE
Optimize OrderedMap string key comparison

### DIFF
--- a/pkg/orderedmap/map.go
+++ b/pkg/orderedmap/map.go
@@ -56,6 +56,19 @@ func (m *Map) Delete(key interface{}) bool {
 }
 
 func (m *Map) isKeyEq(key1, key2 interface{}) bool {
+	/*
+		Optimize the common case of string keys, using a direct equality check.
+		Check key2 first, it remains constant over repeated calls within the
+		loops of the above Set, Get, and Delete functions
+	*/
+	if key2Str, ok := key2.(string); ok {
+		if key1Str, ok := key1.(string); ok {
+			return key1Str == key2Str
+		}
+		return false
+	}
+
+	// For non-string keys, use deep equality check.
 	return reflect.DeepEqual(key1, key2)
 }
 


### PR DESCRIPTION
The current `OrderedMap` implementation is `O(n)` which hurts performance for large maps, made worse by the call to `reflect.DeepEqual` for equality checks. Reducing the time complexity while maintaining compatibility is possible, but out of scope for me at the moment. 

Optimizing the common case of a map with string keys reduces the runtime for many common uses of `OrderedMap`, without compromising the ability of the map to store other keys of complex types.

Testing [an artificial benchmark](https://gist.github.com/emh-jump/575d7fceb13611704c09227bdec41633) with `GOGC=off`:
```
develop: 3.66user 0.03system 0:03.71elapsed 99%CPU (0avgtext+0avgdata 270288maxresident)k
this PR: 1.38user 0.03system 0:01.42elapsed 99%CPU (0avgtext+0avgdata 266232maxresident)k
```

In internal workloads, we similarly show up to a 34% improvement compared to `v0.52.0`