### PR TITLE
Fix `ytt fmt` for files with a single document separator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,9 @@ linters:
       rules:
         - name: dot-imports
           disabled: true
+        - name: add-constant
+          arguments:
+            - allowInts: "0,1"
   exclusions:
     generated: lax
     paths:

--- a/pkg/yamlfmt/filetests/two-documents.yml
+++ b/pkg/yamlfmt/filetests/two-documents.yml
@@ -1,0 +1,9 @@
+hello: world
+---
+hello: moon
+
++++
+
+hello: world
+---
+hello: moon

--- a/pkg/yamlfmt/printer.go
+++ b/pkg/yamlfmt/printer.go
@@ -42,10 +42,17 @@ func (p *Printer) PrintStr(val interface{}) string {
 func (p *Printer) print(val interface{}, ws whitespace, writer *writer) {
 	switch typedVal := val.(type) {
 	case *yamlmeta.DocumentSet:
+		// if the last document is empty, don't add a separator before it
+		nonEmptyDocCount := len(typedVal.Items)
+		lastDoc := typedVal.Items[len(typedVal.Items)-1]
+		if lastDoc.IsEmpty() {
+			nonEmptyDocCount--
+		}
+
 		for i, item := range typedVal.Items {
 			// TODO deal with first empty doc
 			meta := p.printMeta(item, ws, writer, i == 0)
-			if (i > 0 && i < len(typedVal.Items)-1) || len(meta.Suffix) > 0 {
+			if (i > 0 && i < nonEmptyDocCount) || len(meta.Suffix) > 0 {
 				writer.AddContent(writerChunk{
 					Indent:  ws.Indent,
 					Content: "---" + meta.Suffix,


### PR DESCRIPTION
After #911, there is a regression for files which have only a single document separator (ie my added test case passed before that PR, failed once it was merged, and is fixed by this change)

cc @cppforlife another one for you to review/merge/release when you return, thank you!