### PR TITLE
Bump golang to 1.24.6 to fix CVEs

### DIFF
--- a/examples/integrating-with-ytt/internal-templating/go.mod
+++ b/examples/integrating-with-ytt/internal-templating/go.mod
@@ -1,6 +1,6 @@
 module example_internal_templating
 
-go 1.24.2
+go 1.24.6
 
 // ensure example works with this copy of ytt; remove before use
 replace carvel.dev/ytt => ../../../

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
CVEs fixed

[CVE-2025-22874](https://avd.aquasec.com/nvd/cve-2025-22874) - crypto/x509: Usage of ExtKeyUsageAny disables policy validation in crypto/x509
[CVE-2025-47907](https://avd.aquasec.com/nvd/cve-2025-47907) - database/sql: Postgres Scan Race Condition

[CVE-2025-0913](https://avd.aquasec.com/nvd/cve-2025-0) - Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall
[CVE-2025-4673](https://avd.aquasec.com/nvd/cve-2025-4673) - net/http: Sensitive headers not cleared on cross-origin redirect in net/http