### PR TITLE
Bump Golang to 1.24.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.24.2
+go 1.24.9
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
This PR Bump Golang to v1.24.9 to fix following CVEs : 
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy         │
│         │                │          │        │                   │                 │ validation in crypto/x509                                    │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-47907 │          │        │                   │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-58183 │          │        │                   │ 1.24.8, 1.25.2  │ golang: archive/tar: Unbounded allocation when parsing GNU   │
│         │                │          │        │                   │                 │ sparse map                                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-58183                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-58186 │          │        │                   │                 │ Despite HTTP headers having a default limit of 1MB, the      │
│         │                │          │        │                   │                 │ number of...                                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-58186                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-58187 │          │        │                   │ 1.24.9, 1.25.3  │ Due to the design of the name constraint checking algorithm, │
│         │                │          │        │                   │                 │ the proce...                                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-58187                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-58188 │          │        │                   │ 1.24.8, 1.25.2  │ Validating certificate chains which contain DSA public keys  │
│         │                │          │        │                   │                 │ can cause ......                                             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-58188                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-0913  │ MEDIUM   │        │                   │ 1.23.10, 1.24.4 │ Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows │
│         │                │          │        │                   │                 │ in os in syscall...                                          │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-0913                    │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-4673  │          │        │                   │                 │ net/http: Sensitive headers not cleared on cross-origin      │
│         │                │          │        │                   │                 │ redirect in net/http                                         │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-4673                    │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-47906 │          │        │                   │ 1.23.12, 1.24.6 │ os/exec: Unexpected paths returned from LookPath in os/exec  │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47906                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-47912 │          │        │                   │ 1.24.8, 1.25.2  │ net/url: Insufficient validation of bracketed IPv6 hostnames │
│         │                │          │        │                   │                 │ in net/url                                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47912                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-58185 │          │        │                   │                 │ encoding/asn1: Parsing DER payload can cause memory          │
│         │                │          │        │                   │                 │ exhaustion in encoding/asn1                                  │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-58185                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-58189 │          │        │                   │                 │ crypto/tls: go crypto/tls ALPN negotiation error contains    │
│         │                │          │        │                   │                 │ attacker controlled information                              │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-58189                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-61723 │          │        │                   │                 │ encoding/pem: Quadratic complexity when parsing some invalid │
│         │                │          │        │                   │                 │ inputs in encoding/pem                                       │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61723                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-61724 │          │        │                   │                 │ net/textproto: Excessive CPU consumption in                  │
│         │                │          │        │                   │                 │ Reader.ReadResponse in net/textproto                         │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61724                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-61725 │          │        │                   │                 │ net/mail: Excessive CPU consumption in ParseAddress in       │
│         │                │          │        │                   │                 │ net/mail                                                     │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61725                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```

