### PR TITLE
Add "---" to separate functions on lib files

### DIFF
--- a/examples/playground/basics/alt-example-k8s-helm-ish2/helpers.lib.yml
+++ b/examples/playground/basics/alt-example-k8s-helm-ish2/helpers.lib.yml
@@ -6,11 +6,15 @@ name: #@ fullname(vars)
 labels: #@ labels(vars)
 #@ end
 
+---
+
 #@ def labels(vars):
 chart: #@ "{}-{}".format(vars.Chart.Name, vars.Chart.Version).replace("+", "_")
 heritage: #@ vars.Release.Service
 _: #@ template.replace(selector(vars))
 #@ end
+
+---
 
 #@ def selector(vars):
 app: #@ name(vars)

--- a/examples/playground/basics/example-k8s-ingress-multiple/app.lib.yml
+++ b/examples/playground/basics/example-k8s-ingress-multiple/app.lib.yml
@@ -9,9 +9,13 @@
 #@ def/end app_labels(app):
 app: #@ app.name
 
+---
+
 #@ def app_svc_name(app):
 #@   return app.name + "-svc"
 #@ end
+
+---
 
 #@ def app_config(app):
 ---

--- a/examples/playground/basics/example-load/funcs.lib.yml
+++ b/examples/playground/basics/example-load/funcs.lib.yml
@@ -7,6 +7,8 @@ cities:
 - LA
 #@ end
 
+---
+
 #@ def func2():
 name: joanna
 cities:

--- a/examples/playground/getting-started/example-collect-to-packages/config/common.lib.yml
+++ b/examples/playground/getting-started/example-collect-to-packages/config/common.lib.yml
@@ -5,9 +5,13 @@
 #@   return str(n)+"m"
 #@ end
 
+---
+
 #@ def memorys(n):
 #@   return "{}Mi".format(n)
 #@ end
+
+---
 
 #! request_50m_per_factor — generates a resources request
 #!   given a scaling factor such that the limits are twice

--- a/examples/playground/getting-started/example-extend-data-values/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-extend-data-values/config/lib/common.lib.yml
@@ -5,9 +5,13 @@
 #@   return str(n)+"m"
 #@ end
 
+---
+
 #@ def memorys(n):
 #@   return "{}Mi".format(n)
 #@ end
+
+---
 
 #! request_50m_per_factor — generates a resources request
 #!   given a scaling factor such that the limits are twice

--- a/examples/playground/getting-started/example-factor-to-modules/common.lib.yml
+++ b/examples/playground/getting-started/example-factor-to-modules/common.lib.yml
@@ -5,9 +5,13 @@
 #@   return str(n)+"m"
 #@ end
 
+---
+
 #@ def memorys(n):
 #@   return "{}Mi".format(n)
 #@ end
+
+---
 
 #! request_50m_per_factor — generates a resources request
 #!   given a scaling factor such that the limits are twice

--- a/examples/playground/getting-started/example-overlay-data-values/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-overlay-data-values/config/lib/common.lib.yml
@@ -5,9 +5,13 @@
 #@   return str(n)+"m"
 #@ end
 
+---
+
 #@ def memorys(n):
 #@   return "{}Mi".format(n)
 #@ end
+
+---
 
 #! request_50m_per_factor — generates a resources request
 #!   given a scaling factor such that the limits are twice

--- a/examples/playground/getting-started/example-overlay-map-items/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-overlay-map-items/config/lib/common.lib.yml
@@ -5,9 +5,13 @@
 #@   return str(n)+"m"
 #@ end
 
+---
+
 #@ def memorys(n):
 #@   return "{}Mi".format(n)
 #@ end
+
+---
 
 #! request_50m_per_factor — generates a resources request
 #!   given a scaling factor such that the limits are twice

--- a/examples/playground/getting-started/example-overlay-on-templates/config/lib/common.lib.yml
+++ b/examples/playground/getting-started/example-overlay-on-templates/config/lib/common.lib.yml
@@ -5,9 +5,13 @@
 #@   return str(n)+"m"
 #@ end
 
+---
+
 #@ def memorys(n):
 #@   return "{}Mi".format(n)
 #@ end
+
+---
 
 #! request_50m_per_factor — generates a resources request
 #!   given a scaling factor such that the limits are twice


### PR DESCRIPTION
# What was done?

A yaml separator was added between functions on the example .lib.yml files.

# Why was this done?

I found that the [playground's functions example](https://github.com/carvel-dev/ytt/blob/develop/examples/playground/basics/example-function/def.yml) explains how this can be done to isolate functions when the format conflicts with the rest of the file.

In the case of the .lib.yml files it's my understanding their only purpose is to centralize functions, it's true that a conflict won't always exist, yet I believe it would be a good practice to always isolate functions on this files, by doing this the format of .lib.yml files remains consistent (without sporadic separator here and there) making the file easier to read and in the case of actual conflicts developers who are used to follow this format should (in theory) not even encounter any issue.