### PR TITLE
Bump golang version to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.24.6
+go 1.24.11
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Bump Golang in 0.52.x release branch to fix CVEs