### PR TITLE
Bump golang version to 1.25.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1
+          version: v2.4
           args: -v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.24.9
+go 1.25.6
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Bumping golang to 1.25.5 to fix the following CVEs:
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-61729 │ HIGH     │ fixed  │ v1.25.4           │ 1.24.11, 1.25.5 │ crypto/x509: Excessive resource consumption when printing   │
│         │                │          │        │                   │                 │ error string for host certificate validation...             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61729                  │
│         ├────────────────┼──────────┤        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2025-61727 │ MEDIUM   │        │                   │                 │ golang: crypto/x509: excluded subdomain constraint does not │
│         │                │          │        │                   │                 │ restrict wildcard SANs                                      │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61727                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```