### PR TITLE
[v0.53.x] Bump Golang 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/ytt
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Bump golang to 1.25.7

(cherry picked from commit 452382821dd9dae7cc36995960656bb94dc47212)