### PR TITLE
feat: add flag to allow skipping unmatched wildcard file marks

### DIFF
--- a/pkg/cmd/template/file_marks.go
+++ b/pkg/cmd/template/file_marks.go
@@ -13,12 +13,19 @@ import (
 
 type FileMarksOpts struct {
 	FileMarks []string
+	Relaxed   bool
 }
 
 // Set registers file mark flags and wires-up those flags up to this
 // FileMarksOpts to be set when the corresponding cobra.Command is executed.
 func (s *FileMarksOpts) Set(cmdFlags CmdFlags) {
 	cmdFlags.StringArrayVar(&s.FileMarks, "file-mark", nil, "File mark (ie change file path, mark as non-template) (format: file:key=value) (can be specified multiple times)")
+	cmdFlags.BoolVar(
+		&s.Relaxed,
+		"file-mark-relaxed",
+		false,
+		"Do not error if a file path pattern containing '*' matches no files",
+	)
 }
 
 func (s *FileMarksOpts) Apply(filesToProcess []*files.File) ([]*files.File, error) {
@@ -101,7 +108,7 @@ func (s *FileMarksOpts) Apply(filesToProcess []*files.File) ([]*files.File, erro
 			}
 		}
 
-		if !matched {
+		if !matched && (!s.Relaxed || !strings.Contains(path, "*")) {
 			return nil, fmt.Errorf("Expected file mark '%s' to match at least one file by path, but did not", mark)
 		}
 

--- a/pkg/cmd/template/file_marks_test.go
+++ b/pkg/cmd/template/file_marks_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"testing"
+
+	"carvel.dev/ytt/pkg/files"
+	"github.com/stretchr/testify/require"
+)
+
+func newFile(path string) *files.File {
+	return files.MustNewFileFromSource(files.NewBytesSource(path, []byte{}))
+}
+
+func TestFileMarksOpts_Apply_RelaxedBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		files   []*files.File
+		marks   []string
+		relaxed bool
+		wantErr bool
+	}{
+		"strict no-glob": {
+			files: []*files.File{
+				newFile("bar.txt"),
+			},
+			marks:   []string{"foo.txt:type=text-plain"},
+			wantErr: true,
+		},
+		"strict glob": {
+			files: []*files.File{
+				newFile("bar.yaml"),
+			},
+			marks:   []string{"*.txt:type=text-plain"},
+			wantErr: true,
+		},
+		"relaxed no-glob": {
+			files: []*files.File{
+				newFile("baz.yaml"),
+			},
+			marks:   []string{"foo.txt:type=text-plain"},
+			relaxed: true,
+			wantErr: true,
+		},
+		"relaxed glob": {
+			files: []*files.File{
+				newFile("baz.yaml"),
+			},
+			marks:   []string{"*.txt:type=text-plain"},
+			relaxed: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := &FileMarksOpts{
+				FileMarks: tt.marks,
+				Relaxed:   tt.relaxed,
+			}
+
+			_, err := opts.Apply(tt.files)
+			if tt.wantErr {
+				require.ErrorContains(
+					t,
+					err,
+					"to match at least one file by path",
+				)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/carvel-dev/ytt/issues/624

This change is backward-compatible, as the new behavior is opt-in and controlled via a separate flag.